### PR TITLE
fix(seo): shorten fi about page meta description to 126 chars

### DIFF
--- a/src/pages/fi/about/index.mdx
+++ b/src/pages/fi/about/index.mdx
@@ -2,7 +2,7 @@
 layout: '../../../layouts/PageLayout.astro'
 lang: fi
 title: 'Teknologian ja yhteis­kunnan raja­pinnassa'
-description: 'Olen johtava ohjelmistokehittäjä, diplomi-insinööri ja poliitikko. Työskentelen siellä, missä teknologia muuttaa yhteiskuntaa – ja missä päätöksenteon pitäisi pysyä mukana'
+description: 'Olen johtava ohjelmistokehittäjä, diplomi-insinööri ja poliitikko. Työskentelen siellä, missä teknologia muuttaa yhteiskuntaa.'
 slug: 'fi/about'
 type: 'Person'
 heroImage: Lauri-Lavanti-sitting-in-front-of-a-window


### PR DESCRIPTION
## Summary

- Trimmed the Finnish about page `description` frontmatter from 171 chars to 126 chars
- Exceeding the 165-char threshold causes Google to truncate the description in SERPs

Fixes #1013

## Test plan

- [x] Description length verified: 126 chars (within 120–160 ideal range)
- [x] `npm run lint` passes
- [ ] SEO check passes (run `/seo-check src/pages/fi/about/index.mdx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)