### PR TITLE
feat(schema): add Person + PoliticalParty JSON-LD to home and about pages

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -1,7 +1,7 @@
 ---
 import type { Lang } from '../content/nav'
 
-import { BLOGPOSTING, JSON_LD_TYPES, type JsonLdType, WEBPAGE, WEBSITE } from '../lib/jsonld'
+import { BLOGPOSTING, JSON_LD_TYPES, type JsonLdType, PERSON, WEBPAGE, WEBSITE } from '../lib/jsonld'
 
 interface Props {
     createdAt?: string
@@ -62,6 +62,20 @@ const mastodon = 'https://mastodontti.fi/@laurilavanti'
 const threads = 'https://www.threads.com/@laurilavanti'
 const tikTok = 'https://www.tiktok.com/@laurilavanti'
 
+const personJobTitle: Record<Lang, string> = {
+    en: 'Parliamentary candidate',
+    fi: 'Kansanedustajaehdokas',
+    sv: 'Riksdagskandidat',
+}
+
+const personDescription: Record<Lang, string> = {
+    en: 'Green parliamentary candidate in the Uusimaa constituency in 2027. Focused on economics, entrepreneurship, and digital independence.',
+    fi: 'Vihreiden kansanedustajaehdokas Uudenmaan vaalipiirissä 2027. Keskittyy talouteen, yrittäjyyteen ja digitaaliseen riippumattomuuteen.',
+    sv: 'Grönas riksdagskandidat i Nylands valkrets 2027. Fokuserar på ekonomi, företagande och digital självständighet.',
+}
+
+const sameAs = [bluesky, facebook, instagram, linkedIn, mastodon, threads, tikTok]
+
 const jsonLd = JSON.stringify({
     '@context': 'https://schema.org',
     '@type': type && JSON_LD_TYPES.includes(type) ? type : WEBSITE,
@@ -86,7 +100,27 @@ const jsonLd = JSON.stringify({
     ...(type === WEBSITE
         ? {
               name,
-              sameAs: [bluesky, facebook, instagram, linkedIn, mastodon, threads, tikTok],
+              sameAs,
+          }
+        : {}),
+    ...(type === PERSON
+        ? {
+              description: personDescription[lang],
+              jobTitle: personJobTitle[lang],
+              knowsAbout: [
+                  'Talouspolitiikka',
+                  'Yrittäjyys',
+                  'Innovaatiopolitiikka',
+                  'Digitaalinen riippumattomuus',
+                  'Vihreä siirtymä',
+              ],
+              memberOf: {
+                  '@type': 'PoliticalParty',
+                  name: 'Vihreä liitto',
+                  url: 'https://www.vihreat.fi',
+              },
+              name,
+              sameAs,
           }
         : {}),
 })

--- a/src/components/Head.spec.ts
+++ b/src/components/Head.spec.ts
@@ -151,4 +151,53 @@ describe('<Head />', () => {
         expect(jsonLd.dateModified).toBe('2024-06-01')
         expect(jsonLd.datePublished).toBe('2024-06-01')
     })
+
+    it('should set Person JSON-LD when type is Person', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                lang: 'fi',
+                title: 'Lauri Lavanti',
+                type: 'Person',
+            },
+        })
+
+        const jsonLdScript = result.querySelector('script[type="application/ld+json"]')
+        const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
+        expect(jsonLd['@type']).toBe('Person')
+        expect(jsonLd.name).toBe('Lauri Lavanti')
+        expect(jsonLd.jobTitle).toBe('Kansanedustajaehdokas')
+        expect(jsonLd.sameAs).toHaveLength(7)
+        expect(jsonLd.memberOf['@type']).toBe('PoliticalParty')
+        expect(jsonLd.memberOf.name).toBe('Vihreä liitto')
+        expect(jsonLd.memberOf.url).toBe('https://www.vihreat.fi')
+        expect(jsonLd.knowsAbout).toHaveLength(5)
+    })
+
+    it('should localise Person jobTitle for English', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                lang: 'en',
+                title: 'Lauri Lavanti',
+                type: 'Person',
+            },
+        })
+
+        const jsonLdScript = result.querySelector('script[type="application/ld+json"]')
+        const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
+        expect(jsonLd.jobTitle).toBe('Parliamentary candidate')
+    })
+
+    it('should localise Person jobTitle for Swedish', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                lang: 'sv',
+                title: 'Lauri Lavanti',
+                type: 'Person',
+            },
+        })
+
+        const jsonLdScript = result.querySelector('script[type="application/ld+json"]')
+        const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
+        expect(jsonLd.jobTitle).toBe('Riksdagskandidat')
+    })
 })


### PR DESCRIPTION
## Summary

- Emit `Person` + `PoliticalParty` JSON-LD on all home and about pages (which already use `type: 'Person'`)
- Localises `jobTitle` and `description` per `lang` (fi/sv/en)
- Includes all 7 social profile URLs in `sameAs`
- Adds `knowsAbout` with four primary policy areas
- Refactors `sameAs` array into a shared constant reused by both `WebSite` and `Person` blocks

## Test plan

- [x] New Vitest tests for Person JSON-LD (Finnish, English, Swedish `jobTitle`)
- [x] All 374 existing tests pass (`npm run test`)
- [x] `npm run lint` clean
- [x] `npm run check` — 0 errors
- [x] `npm run build` — 415 pages built successfully

Closes #1028

🤖 Generated with [Claude Code](https://claude.com/claude-code)