### PR TITLE
fix(seo): change blog index type from 'Blog' to 'WebPage'

### DIFF
--- a/src/pages/en/blog/index.mdx
+++ b/src/pages/en/blog/index.mdx
@@ -4,7 +4,7 @@ lang: en
 title: 'Blog – Technology, Economics and Local Politics'
 description: 'I write about technology, economics, and local politics in Kirkkonummi. Read my thoughts on everyday decisions and municipal governance.'
 slug: 'en/blog'
-type: 'Blog'
+type: 'WebPage'
 heroImage: 'Lauri-Lavanti-next-to-a-table'
 alt: 'Lauri Lavanti sitting on a stool leaning against a tall table. He is wearing a black blazer and a blue-and-white floral shirt. In the blazer pocket is a multicoloured pocket square. A staircase in the background.'
 ---

--- a/src/pages/fi/blog/index.mdx
+++ b/src/pages/fi/blog/index.mdx
@@ -4,7 +4,7 @@ lang: fi
 title: 'Kirjoitukset – IT, talous ja kunnallispolitiikka'
 description: 'Lauri Lavanti kirjoittaa IT:stä, taloudesta ja kunnallispolitiikasta. Lue ajatuksia arjen päätöksistä ja kunnanvaltuutetun näkökulmasta.'
 slug: 'fi/blog'
-type: 'Blog'
+type: 'WebPage'
 heroImage: Lauri-Lavanti-next-to-a-table
 alt: 'Lauri Lavanti istumassa jakkaralla ja nojaa korkeaan pöytään. Päällään hänellä on musta bleiseri ja sinivalkoinen kukkakuvioinen kauluspaita. Bleiserin taskussa on monivärinen taskuliina. Taustalla portaikko.'
 ---

--- a/src/pages/sv/blog/index.mdx
+++ b/src/pages/sv/blog/index.mdx
@@ -4,7 +4,7 @@ lang: sv
 title: 'Blogginlägg – IT, ekonomi och kommunalpolitik'
 description: 'Lauri Lavanti skriver om IT, ekonomi och kommunalpolitik. Läs tankar om vardagsbeslut och kommunalpolitik från Kyrkslätt.'
 slug: 'sv/blog'
-type: 'Blog'
+type: 'WebPage'
 heroImage: 'Lauri-Lavanti-next-to-a-table'
 alt: 'Lauri Lavanti sitter på en pall och lutar sig mot ett högt bord. Han har på sig en svart kavaj och en blåvit blommig skjorta. I kavajfickan finns en flerfärgad bröstduk. En trappa i bakgrunden.'
 ---


### PR DESCRIPTION
## Summary
- All three blog index pages had `type: 'Blog'` in frontmatter
- `'Blog'` is not a valid value in `JSON_LD_TYPES`, causing `Head.astro` to silently fall back to `WebSite` schema
- Changed to `type: 'WebPage'` in `fi/blog/index.mdx`, `en/blog/index.mdx`, and `sv/blog/index.mdx`

Closes #1097

## Test plan
- [ ] `npm run lint && npm run check` — passes clean
- [ ] `npm run build` — builds without errors
- [ ] `npm run test:e2e` — no snapshot changes expected (frontmatter-only change)