### PR TITLE
fix(a11y): localise footer logo alt text for all languages

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,7 +1,7 @@
 ---
 import type { Lang } from '../content/nav'
 
-import { footerAriaLabel, footerLinks } from '../content/footer'
+import { footerAriaLabel, footerLinks, footerLogoAlt } from '../content/footer'
 import { colors, CONTENT_PADDING, CONTENT_SIZE, gridAreas, sizes } from '../lib/styles'
 import InstagramLink from './footer/InstagramLink.astro'
 import Link from './footer/Link.astro'
@@ -73,7 +73,7 @@ const getAriaLabel = footerAriaLabel[lang]
     <div class="container">
         <div>
             <img
-                alt="Vihreiden logo ja teksti"
+                alt={footerLogoAlt[lang]}
                 height="45"
                 loading="lazy"
                 src="/images/greensLogo3Languages.min.svg"

--- a/src/content/footer.ts
+++ b/src/content/footer.ts
@@ -21,3 +21,9 @@ export const footerAriaLabel: Record<Lang, (title: string) => string> = {
     fi: (title) => `Lauri Lavanti palvelussa ${title} (linkki aukeaa uudessa välilehdessä)`,
     sv: (title) => `Lauri Lavanti på ${title} (öppnas i ny flik)`,
 }
+
+export const footerLogoAlt: Record<Lang, string> = {
+    en: 'The Greens logo and text',
+    fi: 'Vihreiden logo ja teksti',
+    sv: 'De Gröna logotyp och text',
+}


### PR DESCRIPTION
## Summary
- Footer logo alt text was hardcoded in Finnish (`"Vihreiden logo ja teksti"`) regardless of page language
- Added `footerLogoAlt` record to `src/content/footer.ts` with translations for `fi`, `en`, and `sv`
- Updated `Footer.astro` to use `footerLogoAlt[lang]` following the existing `footerAriaLabel` pattern

Closes #1099

## Test plan
- [ ] `npm run lint && npm run check` — no errors
- [ ] `npm run test:e2e -- --update-snapshots` — snapshots updated
- [ ] Full suite: `npm run lint && npm run check && npm run test && npm run build && npm run test:e2e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)