### PR TITLE
fix(seo): add x-default hreflang pointing to Finnish version

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -58,6 +58,8 @@ const hreflangLinks =
           }))
         : []
 
+const xDefaultHref = hreflangLinks.find((l) => l.hreflang === 'fi')?.href ?? null
+
 const canonical = !noindex && (slug === 'index' ? Astro.site : slug ? new URL(`${slug}/`, siteUrl) : null)
 
 const ogImageUrl = ogImage ?? null
@@ -194,6 +196,7 @@ const keywords = [
     )
 }
 {hreflangLinks.map(({ hreflang, href }) => <link href={href} hreflang={hreflang} rel="alternate" />)}
+{xDefaultHref && <link href={xDefaultHref} hreflang="x-default" rel="alternate" />}
 {
     ogImageUrl ? (
         <>


### PR DESCRIPTION
## Summary

- Adds `<link rel="alternate" hreflang="x-default">` pointing to the Finnish version of each page
- Finnish is the site default (`prefixDefaultLocale: true`, `defaultLocale: 'fi'`)
- This gives Google/Bing a fallback signal for users whose language doesn't match fi/sv/en

## Other audit points from #1119

- Root `/` redirect page has `noindex` + `canonical` → `/fi/` ✅
- Sitemap does not include `https://laurilavanti.fi/` — only locale-prefixed URLs ✅
- `/fi/` home page canonical is correctly `https://laurilavanti.fi/fi/` ✅

Closes #1119