### PR TITLE
feat(blog): add post 55 — Kirkkonummi sanoo: sinä kuulut tänne

### DIFF
--- a/src/pages/en/blog/55/kirkkonummi-tells-everyone-you-belong-here/index.mdx
+++ b/src/pages/en/blog/55/kirkkonummi-tells-everyone-you-belong-here/index.mdx
@@ -1,0 +1,64 @@
+---
+layout: '../../../../../layouts/PostLayout.astro'
+id: 55
+slug: 'kirkkonummi-tells-everyone-you-belong-here'
+lang: 'en'
+title: 'Kirkkonummi tells everyone: you belong here'
+description: "Bullying of rainbow youth is increasing. Kirkkonummi voted 30–14 for flag-flying — a small gesture with measurable effects on young people's wellbeing."
+publishDate: '2026-04-09'
+tags:
+  - equality-and-non-discrimination
+  - kirkkonummi
+heroImage: Kirsikkapuisto
+alt: 'Kirkkonummi Kirsikkapuisto park on a sunny summer day. Mostly lawn in view, apartment buildings in the background and some playground equipment in the foreground'
+---
+
+import BlockQuote from '../../../../../components/body/BlockQuote.astro'
+import SmartLink from '../../../../../components/SmartLink.astro'
+import H2 from '../../../../../components/H2.astro'
+import H3 from '../../../../../components/H3.astro'
+import Paragraph from '../../../../../components/Paragraph.astro'
+
+export const components = { blockquote: BlockQuote, a: SmartLink, h2: H2, h3: H3, p: Paragraph }
+
+The figures from the Finnish Institute for Health and Welfare (THL) school health survey in Kirkkonummi are not merely statistics. They are young people sitting in classrooms, attending hobbies, and moving through our municipality every day — often carrying a burden that no one else sees. On 10 March 2026, Kirkkonummi municipal council voted 30–14 in favour of rainbow flag-flying. The decision is a small one. Its significance for the young people it was made for is not.
+
+## What does the THL school health survey tell us about rainbow young people?
+
+A [summary published by Seta](https://seta.fi/2026/02/02/uusin-kouluterveyskysely-sateenkaarinuorten-hyvinvointi-ei-parantunut/) — Finland's national LGBTQ+ rights organisation — in February 2026, drawing on THL data, shows that one in five lower secondary school pupils belonging to a gender minority has experienced repeated bullying — at least once a week. Among sexual minorities, the figure is one in seven. Compared to other young people, the rate of bullying is two to three times higher.
+
+These figures are troubling on their own terms. They are most alarming because they concern young people who have had the courage to respond to the survey disclosing their own identity. A large proportion of rainbow young people do not share their identity at all — not at home, not at school, not among friends. The actual extent of bullying experience is likely wider than the data reveals.
+
+Since 2023, the situation has not improved. It has worsened. This does not happen in a vacuum: the social climate in many countries, including Finland, has hardened in terms of public discourse directed at LGBTQ+ people. When intolerance is normalised in public debate, it is reflected directly in young people's everyday lives. These are young people in Kirkkonummi.
+
+## Why is flag-flying more than symbolism?
+
+Symbolism is concrete when its recipient is a vulnerable young person. Research consistently shows that the wellbeing of rainbow young people is supported above all by two things: the experience of being accepted and visibility — the knowledge that one is not alone. These are not merely emotional responses. They are measurable variables with a demonstrated connection to young people's mental health and school satisfaction.
+
+> When a young person sees that their municipality acknowledges their existence, it is not an empty gesture. It is a message: you belong here.
+
+Community acceptance is research-evidenced as associated with a lower risk of depression, reduced loneliness, and better school attendance. When a municipality visibly demonstrates that it values all its residents, it is conducting preventive mental health work — without a separate programme or a dedicated budget line.
+
+A flag is not an internal report or a strategy document — it is a visible, physical message that every passerby can observe. That is precisely why its significance is greater than its physical size would suggest.
+
+## How did the flag-flying decision come about in Kirkkonummi?
+
+{/* @SEOReviewer: FAQ schema recommended */}
+
+The decision did not emerge from nothing. I submitted a [council initiative on annual rainbow flag-flying](/fi/blog/39/valtuustoaloite-vuosittainen-pride-liputus-kirkkonummelle/) at an earlier stage, and the matter proceeded through preparation to a full council vote. At the 10 March session I delivered a [council speech](/fi/blog/52/kirkkonummi-on-tanaan-tasa-arvoisempi-kuin-eilen/) in which I put forward the same argument I am repeating here: the cost of a small gesture is minimal, but its effect on the young people it concerns may be immeasurable.
+
+The voting result of 30–14 shows that genuine political deliberation took place. Some councillors voted against — that is their right and part of democracy. The majority concluded, however, that the municipality's role is to promote the wellbeing of all its residents. The *kuntalaki* (Local Government Act) requires municipalities to promote the wellbeing of their residents, and the municipality's own strategy commits to equality and non-discrimination. The flag-flying decision translates these commitments into practice.
+
+## What does a small gesture cost compared to the costs of social exclusion?
+
+A flag costs a few dozen euros. The societal costs of a marginalised young person — lost working years, social services, healthcare — run to tens of thousands of euros per person; in some calculations considerably more.
+
+> Prevention is always cheaper. This holds as true for youth work as it does for healthcare.
+
+I am not claiming that flag-flying alone resolves the wellbeing challenges faced by rainbow young people. It does not. What is needed is concrete anti-bullying work in schools, sufficient access to school counsellors and psychologist services, and a community culture in which difference is accepted — not merely permitted. The flag is a starting point. It signals that the municipality has the will. And will is the prerequisite for everything that follows. It communicates the direction in which the municipality intends to develop — and it creates an obligation to continue in that direction.
+
+Somewhere in Kirkkonummi today there is a young person who has not yet told anyone who they are. They may not know about the vote. Perhaps they will see the flag next summer. Perhaps not. But the decision has been made — and it was made for them. Kirkkonummi has said aloud: you belong here.
+
+Kirkkonummi is more equal today than it was yesterday. That is not an endpoint — it is a starting gun. How many more small gestures are still waiting to be made?
+
+{/* [SCHEMA: BlogPosting required] */}

--- a/src/pages/fi/blog/55/kirkkonummi-sanoo-sina-kuulut-tanne/index.mdx
+++ b/src/pages/fi/blog/55/kirkkonummi-sanoo-sina-kuulut-tanne/index.mdx
@@ -1,0 +1,64 @@
+---
+layout: '../../../../../layouts/PostLayout.astro'
+id: 55
+slug: 'kirkkonummi-sanoo-sina-kuulut-tanne'
+lang: 'fi'
+title: 'Kirkkonummi sanoo: sinä kuulut tänne'
+description: 'Sateenkaarinuorten kiusaaminen kasvaa. Kirkkonummi äänesti 30–14 liputuksen puolesta — pieni ele, jolla on mitattavia vaikutuksia nuorten hyvinvointiin.'
+publishDate: '2026-04-09'
+tags:
+  - equality-and-non-discrimination
+  - kirkkonummi
+heroImage: Kirsikkapuisto
+alt: 'Kirkkonummen Kirsikkapuisto aurinkoisena kesäpäivänä. Näköpiirissä pääasiassa nurmialuetta, taustalla kerrostaloja ja edustalla hieman leikkipuistoja'
+---
+
+import BlockQuote from '../../../../../components/body/BlockQuote.astro'
+import SmartLink from '../../../../../components/SmartLink.astro'
+import H2 from '../../../../../components/H2.astro'
+import H3 from '../../../../../components/H3.astro'
+import Paragraph from '../../../../../components/Paragraph.astro'
+
+export const components = { blockquote: BlockQuote, a: SmartLink, h2: H2, h3: H3, p: Paragraph }
+
+Kirkkonummen THL:n kouluterveyskyselyn luvut eivät ole pelkkiä tilastoja. Ne ovat nuoria, jotka istuvat luokissa, käyvät harrastuksissa ja kulkevat kunnassamme päivittäin — usein kantaen mukanaan kuormaa, josta muut eivät tiedä. Maaliskuun 10. päivänä 2026 Kirkkonummen valtuusto äänesti 30–14 sateenkaariliputuksen puolesta. Päätös on pieni. Sen merkitys niille nuorille, joita varten se tehtiin, ei ole.
+
+## Mitä THL:n kouluterveyskysely kertoo sateenkaarinuorista?
+
+[Setan helmikuussa 2026 julkaisema kooste](https://seta.fi/2026/02/02/uusin-kouluterveyskysely-sateenkaarinuorten-hyvinvointi-ei-parantunut/) THL:n aineistosta osoittaa, että sukupuolivähemmistöihin kuuluvista yläkoululaisista joka viides on kokenut toistuvaa koulukiusaamista — vähintään kerran viikossa. Seksuaalivähemmistöihin kuuluvista joka seitsemäs. Verrattuna muihin nuoriin kiusaaminen on kaksin- tai kolminkertaista.
+
+Nämä luvut ovat huolestuttavia jo sinänsä. Kaikkein vakavimpia ne ovat siksi, että kyse on nuorista, jotka ovat uskaltaneet vastata kyselyyn omalla identiteetillään. Suuri osa sateenkaarinuorista ei kerro identiteetistään lainkaan — ei kotona, ei koulussa, ei kavereiden kesken. Tosiasiallinen kiusaamisen kokemus on todennäköisesti laajempaa kuin data paljastaa.
+
+Vuoden 2023 jälkeen tilanne ei ole parantunut. Se on pahentunut. Tämä ei tapahdu tyhjiössä: yhteiskunnallinen ilmapiiri on monessa maassa ja myös Suomessa koventunut sateenkaareviin ihmisiin kohdistuvassa puheessa. Kun suvaitsemattomuus normalisoidaan julkisessa keskustelussa, se heijastuu suoraan nuorten arkeen. Nämä ovat kirkkonummelaisia nuoria.
+
+## Miksi liputus ei ole pelkkää symboliikkaa?
+
+Symboliikka on konkreettista, kun sen kohde on haavoittuva nuori. Tutkimus osoittaa johdonmukaisesti, että sateenkaarinuorten hyvinvointia tukee ennen kaikkea kaksi asiaa: hyväksytyksi tulemisen kokemus ja näkyvyys — tieto siitä, ettei ole yksin. Nämä eivät ole ainoastaan tunnereaktioita. Ne ovat mitattavia muuttujia, joilla on yhteys nuorten mielenterveyteen ja kouluviihtyvyyteen.
+
+> Kun nuori näkee, että hänen kuntansa tunnustaa hänen olemassaolonsa, se ei ole tyhjä ele. Se on viesti: sinä kuulut tänne.
+
+Yhteisöllinen hyväksyntä on tutkitusti yhteydessä alentuneeseen masennusriskiin, vähentyneeseen yksinäisyyteen ja parempaan koulunkäyntiin. Kun kunta näkyvästi osoittaa arvostavansa kaikkia asukkaitaan, se tekee ennaltaehkäisevää mielenterveystyötä — ilman erillistä ohjelmaa tai budjettiriviä.
+
+Lippu ei ole sisäinen raportti tai strategiakirjaus — se on näkyvä, fyysinen viesti, jonka jokainen ohikulkija voi havaita. Juuri siksi sen merkitys on suurempi kuin sen koko antaa ymmärtää.
+
+{/* @SEOReviewer: FAQ schema recommended */}
+
+## Miten liputuspäätös syntyi Kirkkonummella?
+
+Päätös ei syntynyt tyhjästä. Tein [valtuustoaloitteen vuosittaisesta sateenkaariluputuksesta](/fi/blog/39/valtuustoaloite-vuosittainen-pride-liputus-kirkkonummelle/) jo aiemmin, ja asia eteni valmistelun kautta valtuuston käsittelyyn. Maaliskuun 10. istunnossa pidin asiasta [valtuustopuheenvuoron](/fi/blog/52/kirkkonummi-on-tanaan-tasa-arvoisempi-kuin-eilen/), jossa esitin saman argumentin, jonka toistan tässäkin: pienen eleen kustannus on minimaalinen, mutta sen vaikutus niille nuorille, joita se koskee, voi olla mittaamaton.
+
+Äänestystulos 30–14 kertoo, että asiasta käytiin aitoa poliittista harkintaa. Osa valtuutetuista äänesti vastaan — se on heidän oikeutensa ja osa demokratiaa. Enemmistö katsoi kuitenkin, että kunnan tehtävä on edistää kaikkien asukkaidensa hyvinvointia. Kuntalaki edellyttää asukkaiden hyvinvoinnin edistämistä, ja kunnan strategia lupaa tasa-arvoa ja yhdenvertaisuutta. Liputuspäätös vie nämä lupaukset käytäntöön.
+
+## Mitä pieni ele maksaa verrattuna syrjäytymisen kustannuksiin?
+
+Lippu maksaa muutaman kymmenen euroa. Syrjäytyneen nuoren yhteiskunnalliset kustannukset — menetetyt työvuodet, sosiaalipalvelut, terveydenhuolto — ovat kymmenien tuhansien euron luokkaa per henkilö, joissain laskelmissa huomattavasti enemmän.
+
+> Ennaltaehkäisy on aina halvempaa. Tämä pätee niin terveydenhuollossa kuin nuorisotyössäkin.
+
+En väitä, että liputus yksin ratkaisee sateenkaarinuorten hyvinvointihaasteen. Se ei tee sitä. Tarvitaan kouluihin kohdistuvaa konkreettista kiusaamisen vastaista työtä, riittävästi kuraattori- ja psykologipalveluja sekä yhteisöllinen kulttuuri, jossa erilaisuus on hyväksyttyä — ei vain sallittua. Lippu on alkupiste. Se on signaali siitä, että kunnassa on tahtoa. Ja tahto on edellytys kaikelle muulle, mitä seuraa perässä. Se viestii, millaiseen suuntaan kunta haluaa kehittyä — ja se velvoittaa jatkamaan samaan suuntaan.
+
+Jossain päin Kirkkonummea on tänään nuori, joka ei ole vielä kertonut kenellekään, kuka hän on. Hän ei ehkä tiedä äänestystuloksesta. Ehkä hän näkee lipun ensi kesänä. Ehkä ei. Mutta päätös on tehty — ja se on tehty häntä varten. Kirkkonummi on sanonut ääneen: sinä kuulut tänne.
+
+Kirkkonummi on tänään tasa-arvoisempi kuin eilen. Se ei ole loppupiste — se on lähtölaukaus. Montako muuta pientä elettä odottaa vielä tekemistään?
+
+{/* [SCHEMA: BlogPosting required] */}

--- a/src/pages/sv/blog/55/kyrkslatt-till-alla-du-hor-hemma-har/index.mdx
+++ b/src/pages/sv/blog/55/kyrkslatt-till-alla-du-hor-hemma-har/index.mdx
@@ -1,0 +1,64 @@
+---
+layout: '../../../../../layouts/PostLayout.astro'
+id: 55
+slug: 'kyrkslatt-till-alla-du-hor-hemma-har'
+lang: 'sv'
+title: 'Kyrkslätt till alla: du hör hemma här'
+description: 'Mobbning av regnbågsungdomar ökar. Kyrkslätt röstade 30–14 för flaggning — en liten gest med mätbara effekter på ungas välmående.'
+publishDate: '2026-04-09'
+tags:
+  - equality-and-non-discrimination
+  - kirkkonummi
+heroImage: Kirsikkapuisto
+alt: 'Kyrkslätt Kirsikkapuisto en solig sommardag. Nästan bara gräsmatta i blickfånget, i bakgrunden flervåningshus och i förgrunden lite lekplatsutrustning'
+---
+
+import BlockQuote from '../../../../../components/body/BlockQuote.astro'
+import SmartLink from '../../../../../components/SmartLink.astro'
+import H2 from '../../../../../components/H2.astro'
+import H3 from '../../../../../components/H3.astro'
+import Paragraph from '../../../../../components/Paragraph.astro'
+
+export const components = { blockquote: BlockQuote, a: SmartLink, h2: H2, h3: H3, p: Paragraph }
+
+Siffrorna från THL:s enkät om skolhälsa i Kyrkslätt är inte bara statistik. De är unga människor som sitter i klassrum, deltar i hobbyer och rör sig i vår kommun varje dag — och som ofta bär på en börda som ingen annan ser. Den 10 mars 2026 röstade Kyrkslätts fullmäktige 30–14 för regnbågsflaggning. Beslutet är litet. Dess betydelse för de unga det gjordes för är det inte.
+
+## Vad berättar THL:s enkät om skolhälsa om regnbågsungdomar?
+
+[Setas sammanfattning från februari 2026](https://seta.fi/2026/02/02/uusin-kouluterveyskysely-sateenkaarinuorten-hyvinvointi-ei-parantunut/) av THL:s material visar att var femte högstadieelev som tillhör en könsminoritet har upplevt upprepad mobbning — minst en gång i veckan. Bland sexuella minoriteter gäller det var sjunde. Jämfört med andra unga är mobbningen dubbelt eller tre gånger så vanlig.
+
+Dessa siffror är oroväckande i sig. Det allvarligaste är att de gäller unga som vågat svara på enkäten och uppge sin identitet. Många regnbågsungdomar berättar inte om sin identitet alls — inte hemma, inte i skolan, inte bland vänner. Den faktiska erfarenheten av mobbning är sannolikt mer utbredd än vad data visar.
+
+Efter 2023 har situationen inte förbättrats. Den har försämrats. Det sker inte i ett vakuum: det samhälleliga klimatet har i många länder, och också i Finland, hårdnat i fråga om hur man talar om och till regnbågsidentifierade personer. När intolerans normaliseras i det offentliga samtalet reflekteras det direkt i ungdomarnas vardag. Det handlar om unga i Kyrkslätt.
+
+## Varför är flaggningen mer än symbolik?
+
+Symbolik är konkret när mottagaren är en utsatt ung människa. Forskning visar konsekvent att regnbågsungdomars välmående framför allt stöds av två saker: upplevelsen av att bli accepterad och synlighet — vetskapen om att man inte är ensam. Det är inte bara känslomässiga reaktioner. Det är mätbara variabler med koppling till ungdomars psykiska hälsa och trivsel i skolan.
+
+> När en ung person ser att deras kommun erkänner deras existens är det ingen tom gest. Det är ett budskap: du hör hemma här.
+
+Gemenskapens acceptans är forskningsbelagt kopplad till lägre risk för depression, minskad ensamhet och bättre skolnärvaro. När kommunen synligt visar att den värdesätter alla sina invånare bedriver den förebyggande psykisk hälsovård — utan ett separat program eller en budgetrad.
+
+Flaggan är inte en intern rapport eller en strategiskrivning — den är ett synligt, fysiskt budskap som alla förbipasserande kan se. Just därför är dess betydelse större än vad dess storlek antyder.
+
+## Hur uppstod flaggningsbeslutet i Kyrkslätt?
+
+{/* @SEOReviewer: FAQ schema recommended */}
+
+Beslutet kom inte ur tomma luften. Jag lämnade ett [fullmäktigeinitiativ om en årlig regnbågsflaggning](/fi/blog/39/valtuustoaloite-vuosittainen-pride-liputus-kirkkonummelle/) redan tidigare, och frågan gick via beredning till fullmäktige. Vid mötet den 10 mars höll jag ett [fullmäktigeanförande](/fi/blog/52/kirkkonummi-on-tanaan-tasa-arvoisempi-kuin-eilen/) där jag framförde samma argument som jag upprepar även här: kostnaden för en liten gest är minimal, men dess effekt för de unga den berör kan vara omätbar.
+
+Röstningsresultatet 30–14 visar att det fördes en äkta politisk diskussion. En del fullmäktigeledamöter röstade emot — det är deras rätt och en del av demokratin. Majoriteten ansåg ändå att kommunens uppgift är att främja alla invånares välbefinnande. Kommunallagen kräver att kommunen verkar för invånarnas välbefinnande, och kommunens strategi utlovar jämställdhet och likabehandling. Flaggningsbeslutet för dessa löften till praktiken.
+
+## Vad kostar en liten gest jämfört med kostnaderna för utanförskap?
+
+En flagga kostar några tiotal euro. De samhälleliga kostnaderna för en marginaliserad ung människa — förlorade arbetsår, socialtjänst, hälsovård — är i storleksordningen tiotusentals euro per person, i vissa beräkningar avsevärt mer.
+
+> Förebyggande åtgärder är alltid billigare. Det gäller såväl hälsovård som ungdomsarbete.
+
+Jag påstår inte att flaggning ensam löser de utmaningar regnbågsungdomar möter i sitt välmående. Det gör den inte. Det behövs konkret mobbningsförebyggande arbete i skolorna, tillräckligt med kuratorer och psykologtjänster, och en gemensamhetskultur där olikhet är accepterad — inte bara tolererad. Flaggan är en startpunkt. Den är ett signal om att kommunen har vilja. Och viljan är en förutsättning för allt annat som följer. Den kommunicerar i vilken riktning kommunen vill utvecklas — och den förpliktar till att fortsätta i samma riktning.
+
+Någonstans i Kyrkslätt finns det i dag en ung person som ännu inte berättat för någon vem hen är. Hen kanske inte känner till röstningsresultatet. Kanske ser hen flaggan nästa sommar. Kanske inte. Men beslutet är fattat — och det är fattat för hens skull. Kyrkslätt har sagt högt: du hör hemma här.
+
+Kyrkslätt är i dag mer jämlikt än i går. Det är inte en slutpunkt — det är ett startskott. Och det är inte symbolpolitik — det är förvaltning som fungerar. Hur många fler sådana små gester väntar på att göras?
+
+{/* [SCHEMA: BlogPosting required] */}

--- a/tests/e2e/blogPostPage.spec.ts-snapshots/Blog-Post-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/blogPostPage.spec.ts-snapshots/Blog-Post-Page-should-match-aria-snapshot-1.aria.yml
@@ -153,21 +153,18 @@
                   - /url: /fi/category/health-and-social-reform/
           - paragraph: Asetan itseni ehdolle aluevaaleihin. Tärkeintä on lähipalvelujen säilyminen, terveydenhuollon pitäminen julkisena ja hoitohenkilökunnan hyvinvointi.
       - listitem:
-        - article "Länsirata paljasti Kirkkonummen ongelmat":
-          - link "Lauri Lavanti nojaamassa korkeaan pöytään. Päällään hänellä on musta bleiseri ja sinivalkoinen kukkakuvioinen kauluspaita. Bleiserin taskussa on monivärinen taskuliina. Taustalla ikkunoita. Länsirata paljasti Kirkkonummen ongelmat":
-            - /url: /fi/blog/50/lansirata-paatos-nosti-esiin-ongelmia-kirkkonummen-pitkajanteisessa-strategisessa-kehittamisessa/
-            - img "Lauri Lavanti nojaamassa korkeaan pöytään. Päällään hänellä on musta bleiseri ja sinivalkoinen kukkakuvioinen kauluspaita. Bleiserin taskussa on monivärinen taskuliina. Taustalla ikkunoita."
-            - heading "Länsirata paljasti Kirkkonummen ongelmat" [level=2]
-          - complementary "Kirjoituksen \"Länsirata paljasti Kirkkonummen ongelmat\" meta-tiedot":
+        - 'article "Kirkkonummi sanoo: sinä kuulut tänne"':
+          - 'link "Kirkkonummen Kirsikkapuisto aurinkoisena kesäpäivänä. Näköpiirissä pääasiassa nurmialuetta, taustalla kerrostaloja ja edustalla hieman leikkipuistoja Kirkkonummi sanoo: sinä kuulut tänne"':
+            - /url: /fi/blog/55/kirkkonummi-sanoo-sina-kuulut-tanne/
+            - img "Kirkkonummen Kirsikkapuisto aurinkoisena kesäpäivänä. Näköpiirissä pääasiassa nurmialuetta, taustalla kerrostaloja ja edustalla hieman leikkipuistoja"
+            - 'heading "Kirkkonummi sanoo: sinä kuulut tänne" [level=2]'
+          - 'complementary "Kirjoituksen \"Kirkkonummi sanoo: sinä kuulut tänne\" meta-tiedot"':
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infra":
-                  - /url: /fi/category/infrastructure/
+                - link "#Tasa-arvo ja yhdenvertaisuus":
+                  - /url: /fi/category/equality-and-non-discrimination/
               - listitem:
                 - link "#Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
-              - listitem:
-                - link "#Länsirata":
-                  - /url: /fi/category/west-railway/
-          - paragraph: Länsirata-päätöstä tehdessä mitattiin päättäjien kykyä tehdä koko kunnalle strategisesti tärkeitä, tulevaisuuteen katsovia ratkaisuja.
+          - paragraph: /Sateenkaarinuorten kiusaaminen kasvaa\. Kirkkonummi äänesti \d+–\d+ liputuksen puolesta — pieni ele, jolla on mitattavia vaikutuksia nuorten hyvinvointiin\./

--- a/tests/e2e/homeEnPage.spec.ts-snapshots/Home-Page-in-English-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/homeEnPage.spec.ts-snapshots/Home-Page-in-English-should-match-aria-snapshot-1.aria.yml
@@ -14,6 +14,22 @@
         - /url: /en/privacy-policy/
     - list:
       - listitem:
+        - 'article "Kirkkonummi tells everyone: you belong here"':
+          - 'link "Kirkkonummi Kirsikkapuisto park on a sunny summer day. Mostly lawn in view, apartment buildings in the background and some playground equipment in the foreground Kirkkonummi tells everyone: you belong here"':
+            - /url: /en/blog/55/kirkkonummi-tells-everyone-you-belong-here/
+            - img "Kirkkonummi Kirsikkapuisto park on a sunny summer day. Mostly lawn in view, apartment buildings in the background and some playground equipment in the foreground"
+            - 'heading "Kirkkonummi tells everyone: you belong here" [level=2]'
+          - 'complementary "Meta information for post \"Kirkkonummi tells everyone: you belong here\""':
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "#Equality & equity":
+                  - /url: /en/category/equality-and-non-discrimination/
+              - listitem:
+                - link "#Kirkkonummi":
+                  - /url: /en/category/kirkkonummi/
+          - paragraph: /Bullying of rainbow youth is increasing\. Kirkkonummi voted \d+–\d+ for flag-flying — a small gesture with measurable effects on young people's wellbeing\./
+      - listitem:
         - 'article "Chat control: parliament was right"':
           - 'link "A Japanese-style screen behind which a room is visible in soft focus. Chat control: parliament was right"':
             - /url: /en/blog/54/chat-control-parliament-was-right/
@@ -128,22 +144,6 @@
                 - link "#Privacy":
                   - /url: /en/category/privacy/
           - paragraph: When fingerprints were added to passports, Finland created a national biometric register. Now the government wants to open it to police use.
-      - listitem:
-        - article /\d+ is the year of AI — not as you think/:
-          - link /Lauri Lavanti standing in front of a mirror with a phone in his hand, taking a selfie\. Wearing a black jacket, white shirt and green tie\. In the background, the light corridor of the main building of the University of Helsinki\. \d+ is the year of AI — not as you think/:
-            - /url: /en/blog/47/2026-is-the-year-of-ai/
-            - img "Lauri Lavanti standing in front of a mirror with a phone in his hand, taking a selfie. Wearing a black jacket, white shirt and green tie. In the background, the light corridor of the main building of the University of Helsinki."
-            - heading /\d+ is the year of AI — not as you think/ [level=2]
-          - complementary /Meta information for post "\d+ is the year of AI — not as you think"/:
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "#Digitalisation":
-                  - /url: /en/category/digitalisation/
-              - listitem:
-                - link "#Artificial intelligence":
-                  - /url: /en/category/artificial-intelligence/
-          - paragraph: AI is changing society — but perhaps not as you imagine. The biggest changes will be in private life and in the everyday lives of children.
     - region "Frequently Asked Questions":
       - heading "Frequently Asked Questions" [level=2]
       - term: Which party does Lauri Lavanti belong to?

--- a/tests/e2e/homePage.spec.ts-snapshots/Home-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/homePage.spec.ts-snapshots/Home-Page-should-match-aria-snapshot-1.aria.yml
@@ -14,6 +14,22 @@
         - /url: /en/privacy-policy/
     - list:
       - listitem:
+        - 'article "Kirkkonummi tells everyone: you belong here"':
+          - 'link "Kirkkonummi Kirsikkapuisto park on a sunny summer day. Mostly lawn in view, apartment buildings in the background and some playground equipment in the foreground Kirkkonummi tells everyone: you belong here"':
+            - /url: /en/blog/55/kirkkonummi-tells-everyone-you-belong-here/
+            - img "Kirkkonummi Kirsikkapuisto park on a sunny summer day. Mostly lawn in view, apartment buildings in the background and some playground equipment in the foreground"
+            - 'heading "Kirkkonummi tells everyone: you belong here" [level=2]'
+          - 'complementary "Meta information for post \"Kirkkonummi tells everyone: you belong here\""':
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "#Equality & equity":
+                  - /url: /en/category/equality-and-non-discrimination/
+              - listitem:
+                - link "#Kirkkonummi":
+                  - /url: /en/category/kirkkonummi/
+          - paragraph: /Bullying of rainbow youth is increasing\. Kirkkonummi voted \d+–\d+ for flag-flying — a small gesture with measurable effects on young people's wellbeing\./
+      - listitem:
         - 'article "Chat control: parliament was right"':
           - 'link "A Japanese-style screen behind which a room is visible in soft focus. Chat control: parliament was right"':
             - /url: /en/blog/54/chat-control-parliament-was-right/
@@ -128,22 +144,6 @@
                 - link "#Privacy":
                   - /url: /en/category/privacy/
           - paragraph: When fingerprints were added to passports, Finland created a national biometric register. Now the government wants to open it to police use.
-      - listitem:
-        - article /\d+ is the year of AI — not as you think/:
-          - link /Lauri Lavanti standing in front of a mirror with a phone in his hand, taking a selfie\. Wearing a black jacket, white shirt and green tie\. In the background, the light corridor of the main building of the University of Helsinki\. \d+ is the year of AI — not as you think/:
-            - /url: /en/blog/47/2026-is-the-year-of-ai/
-            - img "Lauri Lavanti standing in front of a mirror with a phone in his hand, taking a selfie. Wearing a black jacket, white shirt and green tie. In the background, the light corridor of the main building of the University of Helsinki."
-            - heading /\d+ is the year of AI — not as you think/ [level=2]
-          - complementary /Meta information for post "\d+ is the year of AI — not as you think"/:
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "#Digitalisation":
-                  - /url: /en/category/digitalisation/
-              - listitem:
-                - link "#Artificial intelligence":
-                  - /url: /en/category/artificial-intelligence/
-          - paragraph: AI is changing society — but perhaps not as you imagine. The biggest changes will be in private life and in the everyday lives of children.
     - region "Frequently Asked Questions":
       - heading "Frequently Asked Questions" [level=2]
       - term: Which party does Lauri Lavanti belong to?

--- a/tests/e2e/homeSwePage.spec.ts-snapshots/Home-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/homeSwePage.spec.ts-snapshots/Home-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
@@ -15,6 +15,22 @@
       - text: .
     - list:
       - listitem:
+        - 'article "Kyrkslätt till alla: du hör hemma här"':
+          - 'link "Kyrkslätt Kirsikkapuisto en solig sommardag. Nästan bara gräsmatta i blickfånget, i bakgrunden flervåningshus och i förgrunden lite lekplatsutrustning Kyrkslätt till alla: du hör hemma här"':
+            - /url: /sv/blog/55/kyrkslatt-till-alla-du-hor-hemma-har/
+            - img "Kyrkslätt Kirsikkapuisto en solig sommardag. Nästan bara gräsmatta i blickfånget, i bakgrunden flervåningshus och i förgrunden lite lekplatsutrustning"
+            - 'heading "Kyrkslätt till alla: du hör hemma här" [level=2]'
+          - 'complementary "Metainformation för inlägget \"Kyrkslätt till alla: du hör hemma här\""':
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "#Jämlikhet":
+                  - /url: /sv/category/equality-and-non-discrimination/
+              - listitem:
+                - link "#Kyrkslätt":
+                  - /url: /sv/category/kirkkonummi/
+          - paragraph: /Mobbning av regnbågsungdomar ökar\. Kyrkslätt röstade \d+–\d+ för flaggning — en liten gest med mätbara effekter på ungas välmående\./
+      - listitem:
         - 'article "Chat control: parlamentet handlade rätt"':
           - 'link "Bild på en japansk skärm bakom vilken ett rum skymtar suddigt. Chat control: parlamentet handlade rätt"':
             - /url: /sv/blog/54/chat-control-parlamentet-handlade-ratt/
@@ -129,22 +145,6 @@
                 - link "#Integritetsskydd":
                   - /url: /sv/category/privacy/
           - paragraph: När fingeravtryck infördes i pass skapades ett nationellt biometriskt register i Finland. Nu vill regeringen öppna det för polisens bruk.
-      - listitem:
-        - article /År \d+ är AI-året — en överraskande sanning/:
-          - link /Lauri Lavanti stående framför en spegel med en telefon i handen och tar en selfie\. Klädd i svart jacka, vit skjorta och grön slips\. I bakgrunden den ljusa korridoren i Helsingfors universitets huvudbyggnad\. År \d+ är AI-året — en överraskande sanning/:
-            - /url: /sv/blog/47/ar-2026-ar-ai-aret/
-            - img "Lauri Lavanti stående framför en spegel med en telefon i handen och tar en selfie. Klädd i svart jacka, vit skjorta och grön slips. I bakgrunden den ljusa korridoren i Helsingfors universitets huvudbyggnad."
-            - heading /År \d+ är AI-året — en överraskande sanning/ [level=2]
-          - complementary /Metainformation för inlägget "År \d+ är AI-året — en överraskande sanning"/:
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "#Digitalisering":
-                  - /url: /sv/category/digitalisation/
-              - listitem:
-                - link "#Artificiell intelligens":
-                  - /url: /sv/category/artificial-intelligence/
-          - paragraph: AI förändrar samhället — men kanske inte som du tror. De största förändringarna ser vi i privatlivet och i barnens och ungdomarnas vardag.
     - region "Vanliga frågor":
       - heading "Vanliga frågor" [level=2]
       - term: Vilket parti tillhör Lauri Lavanti?

--- a/tests/e2e/notFoundPage.spec.ts-snapshots/404-Not-Found-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/notFoundPage.spec.ts-snapshots/404-Not-Found-Page-should-match-aria-snapshot-1.aria.yml
@@ -3,6 +3,22 @@
   - article:
     - list:
       - listitem:
+        - 'article "Kirkkonummi sanoo: sinä kuulut tänne"':
+          - 'link "Kirkkonummen Kirsikkapuisto aurinkoisena kesäpäivänä. Näköpiirissä pääasiassa nurmialuetta, taustalla kerrostaloja ja edustalla hieman leikkipuistoja Kirkkonummi sanoo: sinä kuulut tänne"':
+            - /url: /fi/blog/55/kirkkonummi-sanoo-sina-kuulut-tanne/
+            - img "Kirkkonummen Kirsikkapuisto aurinkoisena kesäpäivänä. Näköpiirissä pääasiassa nurmialuetta, taustalla kerrostaloja ja edustalla hieman leikkipuistoja"
+            - 'heading "Kirkkonummi sanoo: sinä kuulut tänne" [level=2]'
+          - 'complementary "Kirjoituksen \"Kirkkonummi sanoo: sinä kuulut tänne\" meta-tiedot"':
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "#Tasa-arvo ja yhdenvertaisuus":
+                  - /url: /fi/category/equality-and-non-discrimination/
+              - listitem:
+                - link "#Kirkkonummi":
+                  - /url: /fi/category/kirkkonummi/
+          - paragraph: /Sateenkaarinuorten kiusaaminen kasvaa\. Kirkkonummi äänesti \d+–\d+ liputuksen puolesta — pieni ele, jolla on mitattavia vaikutuksia nuorten hyvinvointiin\./
+      - listitem:
         - 'article "Chat control: parlamentti toimi oikein"':
           - 'link "Kuva japanilaistyylisestä sermistä, jonka takana näkyy sumeasti huone. Chat control: parlamentti toimi oikein"':
             - /url: /fi/blog/54/chat-control-parlamentti-toimi-oikein/
@@ -117,19 +133,3 @@
                 - link "#Yksityisyydensuoja":
                   - /url: /fi/category/privacy/
           - paragraph: Kun sormenjäljet tuotiin passeihin, Suomeen perustettiin kansallinen biometrinen rekisteri. Nyt hallitus haluaa avata sen poliisin käyttöön.
-      - listitem:
-        - article /Vuosi \d+ on tekoälyn – yllättävä totuus/:
-          - link /Lauri Lavanti seisomassa peilin edessä puhelin kädessä, ottamassa itsestään kuvaa\. Päällä musta takki, valkoinen kauluspaita ja kaulassa vihreä kravatti\. Taustalla Helsingin Yliopiston päärakennuksen vaalea käytävä\. Vuosi \d+ on tekoälyn – yllättävä totuus/:
-            - /url: /fi/blog/47/vuosi-2026-on-tekoalyn/
-            - img "Lauri Lavanti seisomassa peilin edessä puhelin kädessä, ottamassa itsestään kuvaa. Päällä musta takki, valkoinen kauluspaita ja kaulassa vihreä kravatti. Taustalla Helsingin Yliopiston päärakennuksen vaalea käytävä."
-            - heading /Vuosi \d+ on tekoälyn – yllättävä totuus/ [level=2]
-          - complementary /Kirjoituksen "Vuosi \d+ on tekoälyn – yllättävä totuus" meta-tiedot/:
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "#Digitalisaatio":
-                  - /url: /fi/category/digitalisation/
-              - listitem:
-                - link "#Tekoäly":
-                  - /url: /fi/category/artificial-intelligence/
-          - paragraph: Tekoäly muuttaa yhteiskuntaamme – mutta ei ehkä siten kuin kuvittelet. Suurimmat muutokset näemme yksityiselämässä ja lasten arjessa.


### PR DESCRIPTION
## Summary
- Publishes op-ed `docs/drafts/opinion-pieces/pride-liputus-kirkkonummi.md` as blog post #55 in fi, sv, en
- Op-ed published in Kirkkonummen Sanomat (25.3.2026) and Länsiväylä (8.4.2026)

## Source
- Finnish + Swedish: `pride-liputus-kirkkonummi.md` (bilingual op-ed file)
- English: translated from Finnish

## Posts created
- `/fi/blog/55/kirkkonummi-sanoo-sina-kuulut-tanne/`
- `/sv/blog/55/kyrkslatt-till-alla-du-hor-hemma-har/`
- `/en/blog/55/kirkkonummi-tells-everyone-you-belong-here/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)