### PR TITLE
fix(blog): edit post 55 — reduce dashes, tighten prose, fix typo

### DIFF
--- a/src/pages/en/blog/55/kirkkonummi-tells-everyone-you-belong-here/index.mdx
+++ b/src/pages/en/blog/55/kirkkonummi-tells-everyone-you-belong-here/index.mdx
@@ -21,43 +21,41 @@ import Paragraph from '../../../../../components/Paragraph.astro'
 
 export const components = { blockquote: BlockQuote, a: SmartLink, h2: H2, h3: H3, p: Paragraph }
 
-The figures from the Finnish Institute for Health and Welfare (THL) school health survey in Kirkkonummi are not merely statistics. They are young people sitting in classrooms, attending hobbies, and moving through our municipality every day — often carrying a burden that no one else sees. On 10 March 2026, Kirkkonummi municipal council voted 30–14 in favour of rainbow flag-flying. The decision is a small one. Its significance for the young people it was made for is not.
+The figures from the Finnish Institute for Health and Welfare (THL) school health survey in Kirkkonummi are not merely statistics. They are young people sitting in classrooms, attending hobbies, and moving through our municipality every day. On 10 March 2026, Kirkkonummi municipal council voted 30–14 in favour of rainbow flag-flying. The decision is a small one. Its significance for the young people it was made for is not.
 
 ## What does the THL school health survey tell us about rainbow young people?
 
-A [summary published by Seta](https://seta.fi/2026/02/02/uusin-kouluterveyskysely-sateenkaarinuorten-hyvinvointi-ei-parantunut/) — Finland's national LGBTQ+ rights organisation — in February 2026, drawing on THL data, shows that one in five lower secondary school pupils belonging to a gender minority has experienced repeated bullying — at least once a week. Among sexual minorities, the figure is one in seven. Compared to other young people, the rate of bullying is two to three times higher.
+A [summary published by Seta](https://seta.fi/2026/02/02/uusin-kouluterveyskysely-sateenkaarinuorten-hyvinvointi-ei-parantunut/) — Finland's national LGBTQ+ rights organisation — in February 2026, drawing on THL data, shows that one in five lower secondary school pupils belonging to a gender minority has experienced repeated bullying, at least once a week. Among sexual minorities, the figure is one in seven. Compared to other young people, the rate of bullying is two to three times higher.
 
-These figures are troubling on their own terms. They are most alarming because they concern young people who have had the courage to respond to the survey disclosing their own identity. A large proportion of rainbow young people do not share their identity at all — not at home, not at school, not among friends. The actual extent of bullying experience is likely wider than the data reveals.
+These figures are troubling on their own terms. It is also important to note that they concern young people who have had the courage to respond to the survey disclosing their own identity. Not everyone does.
 
-Since 2023, the situation has not improved. It has worsened. This does not happen in a vacuum: the social climate in many countries, including Finland, has hardened in terms of public discourse directed at LGBTQ+ people. When intolerance is normalised in public debate, it is reflected directly in young people's everyday lives. These are young people in Kirkkonummi.
+Since 2023, the situation has not improved. It has worsened. This does not happen in a vacuum: the social climate in many countries, including Finland, has hardened in terms of public discourse directed at LGBTQ+ people. When intolerance is normalised in public debate, it is reflected directly also in the everyday lives of young people in Kirkkonummi.
 
 ## Why is flag-flying more than symbolism?
 
-Symbolism is concrete when its recipient is a vulnerable young person. Research consistently shows that the wellbeing of rainbow young people is supported above all by two things: the experience of being accepted and visibility — the knowledge that one is not alone. These are not merely emotional responses. They are measurable variables with a demonstrated connection to young people's mental health and school satisfaction.
+Research consistently shows that the wellbeing of rainbow young people is supported above all by two things: the experience of being accepted and visibility — the knowledge that one is not alone.
 
 > When a young person sees that their municipality acknowledges their existence, it is not an empty gesture. It is a message: you belong here.
 
-Community acceptance is research-evidenced as associated with a lower risk of depression, reduced loneliness, and better school attendance. When a municipality visibly demonstrates that it values all its residents, it is conducting preventive mental health work — without a separate programme or a dedicated budget line.
+Community acceptance is research-evidenced as associated with a lower risk of depression, reduced loneliness, and better school attendance. When a municipality visibly demonstrates that it values all its residents, it is conducting preventive mental health work without a separate programme or a dedicated budget line.
 
-A flag is not an internal report or a strategy document — it is a visible, physical message that every passerby can observe. That is precisely why its significance is greater than its physical size would suggest.
+A flag is not an internal report or a strategy document. It is a visible, physical message that every passerby can observe. That is precisely why its significance is greater than its physical size would suggest.
 
 ## How did the flag-flying decision come about in Kirkkonummi?
 
 {/* @SEOReviewer: FAQ schema recommended */}
 
-The decision did not emerge from nothing. I submitted a [council initiative on annual rainbow flag-flying](/fi/blog/39/valtuustoaloite-vuosittainen-pride-liputus-kirkkonummelle/) at an earlier stage, and the matter proceeded through preparation to a full council vote. At the 10 March session I delivered a [council speech](/fi/blog/52/kirkkonummi-on-tanaan-tasa-arvoisempi-kuin-eilen/) in which I put forward the same argument I am repeating here: the cost of a small gesture is minimal, but its effect on the young people it concerns may be immeasurable.
+The flag-flying decision arose from [my council initiative on annual rainbow flag-flying](/fi/blog/39/valtuustoaloite-vuosittainen-pride-liputus-kirkkonummelle/), which the council approved in March. At the 10 March session I delivered a [council speech](/fi/blog/52/kirkkonummi-on-tanaan-tasa-arvoisempi-kuin-eilen/) and put forward the same argument I am repeating here: the cost of a small gesture is minimal, but its effect on the young people it concerns may be immeasurable.
 
-The voting result of 30–14 shows that genuine political deliberation took place. Some councillors voted against — that is their right and part of democracy. The majority concluded, however, that the municipality's role is to promote the wellbeing of all its residents. The *kuntalaki* (Local Government Act) requires municipalities to promote the wellbeing of their residents, and the municipality's own strategy commits to equality and non-discrimination. The flag-flying decision translates these commitments into practice.
+The voting result of 30–14 shows that the majority of councillors understood the figures and made their decision on that basis. The municipality's own strategy commits to equality and non-discrimination; the *kuntalaki* (Local Government Act) requires promoting the wellbeing of residents. The flag-flying decision translates these commitments into practice.
 
 ## What does a small gesture cost compared to the costs of social exclusion?
 
-A flag costs a few dozen euros. The societal costs of a marginalised young person — lost working years, social services, healthcare — run to tens of thousands of euros per person; in some calculations considerably more.
+A flag costs a few dozen euros. The societal costs of a marginalised young person (lost working years, social services, healthcare) run to tens of thousands of euros per person; in some calculations considerably more.
 
 > Prevention is always cheaper. This holds as true for youth work as it does for healthcare.
 
-I am not claiming that flag-flying alone resolves the wellbeing challenges faced by rainbow young people. It does not. What is needed is concrete anti-bullying work in schools, sufficient access to school counsellors and psychologist services, and a community culture in which difference is accepted — not merely permitted. The flag is a starting point. It signals that the municipality has the will. And will is the prerequisite for everything that follows. It communicates the direction in which the municipality intends to develop — and it creates an obligation to continue in that direction.
-
-Somewhere in Kirkkonummi today there is a young person who has not yet told anyone who they are. They may not know about the vote. Perhaps they will see the flag next summer. Perhaps not. But the decision has been made — and it was made for them. Kirkkonummi has said aloud: you belong here.
+I am not claiming that flag-flying alone resolves the wellbeing challenges faced by rainbow young people. It does not. What is needed is concrete anti-bullying work in schools, sufficient access to school counsellors and psychologist services, and a community culture in which difference is accepted, not merely permitted. The flag is a starting point. It communicates the direction in which the municipality intends to develop and creates an obligation to continue in that direction.
 
 Kirkkonummi is more equal today than it was yesterday. That is not an endpoint — it is a starting gun. How many more small gestures are still waiting to be made?
 

--- a/src/pages/en/blog/55/kirkkonummi-tells-everyone-you-belong-here/index.mdx
+++ b/src/pages/en/blog/55/kirkkonummi-tells-everyone-you-belong-here/index.mdx
@@ -11,6 +11,15 @@ tags:
   - kirkkonummi
 heroImage: Kirsikkapuisto
 alt: 'Kirkkonummi Kirsikkapuisto park on a sunny summer day. Mostly lawn in view, apartment buildings in the background and some playground equipment in the foreground'
+faq:
+  - q: 'What does the THL school health survey tell us about rainbow young people?'
+    a: 'According to THL school health survey data, one in five lower secondary school pupils belonging to a gender minority has experienced repeated bullying at least once a week. Among sexual minorities, the figure is one in seven. Bullying is two to three times more common than among other young people.'
+  - q: 'Why is flag-flying more than symbolism?'
+    a: 'Research shows that the wellbeing of rainbow young people is supported above all by the experience of being accepted and visibility. Community acceptance is associated with a lower risk of depression, reduced loneliness, and better school attendance.'
+  - q: 'How did the flag-flying decision come about in Kirkkonummi?'
+    a: 'The decision arose from a council initiative on annual rainbow flag-flying. Kirkkonummi municipal council voted 30–14 in favour of flag-flying in March 2026.'
+  - q: 'What does a small gesture cost compared to the costs of social exclusion?'
+    a: 'A flag costs a few dozen euros. The societal costs of a marginalised young person run to tens of thousands of euros per person. Prevention is always cheaper.'
 ---
 
 import BlockQuote from '../../../../../components/body/BlockQuote.astro'
@@ -25,7 +34,7 @@ The figures from the Finnish Institute for Health and Welfare (THL) school healt
 
 ## What does the THL school health survey tell us about rainbow young people?
 
-A [summary published by Seta](https://seta.fi/2026/02/02/uusin-kouluterveyskysely-sateenkaarinuorten-hyvinvointi-ei-parantunut/) — Finland's national LGBTQ+ rights organisation — in February 2026, drawing on THL data, shows that one in five lower secondary school pupils belonging to a gender minority has experienced repeated bullying, at least once a week. Among sexual minorities, the figure is one in seven. Compared to other young people, the rate of bullying is two to three times higher.
+[THL's school health survey](https://thl.fi/tutkimus-ja-kehittaminen/tutkimukset-ja-hankkeet/kouluterveyskysely/kouluterveyskyselyn-tulokset) shows that one in five lower secondary school pupils belonging to a gender minority has experienced repeated bullying, at least once a week. Among sexual minorities, the figure is one in seven. Compared to other young people, the rate of bullying is two to three times higher.
 
 These figures are troubling on their own terms. It is also important to note that they concern young people who have had the courage to respond to the survey disclosing their own identity. Not everyone does.
 

--- a/src/pages/en/blog/55/kirkkonummi-tells-everyone-you-belong-here/index.mdx
+++ b/src/pages/en/blog/55/kirkkonummi-tells-everyone-you-belong-here/index.mdx
@@ -21,7 +21,7 @@ import Paragraph from '../../../../../components/Paragraph.astro'
 
 export const components = { blockquote: BlockQuote, a: SmartLink, h2: H2, h3: H3, p: Paragraph }
 
-The figures from the Finnish Institute for Health and Welfare (THL) school health survey in Kirkkonummi are not merely statistics. They are young people sitting in classrooms, attending hobbies, and moving through our municipality every day. On 10 March 2026, Kirkkonummi municipal council voted 30–14 in favour of rainbow flag-flying. The decision is a small one. Its significance for the young people it was made for is not.
+The figures from the Finnish Institute for Health and Welfare (THL) school health survey are not merely statistics. They are young people sitting in classrooms, attending hobbies, and moving through our municipality every day. On 10 March 2026, Kirkkonummi municipal council voted 30–14 in favour of rainbow flag-flying. The decision is a small one. Its significance for the young people it was made for is not.
 
 ## What does the THL school health survey tell us about rainbow young people?
 

--- a/src/pages/fi/blog/55/kirkkonummi-sanoo-sina-kuulut-tanne/index.mdx
+++ b/src/pages/fi/blog/55/kirkkonummi-sanoo-sina-kuulut-tanne/index.mdx
@@ -11,6 +11,15 @@ tags:
   - kirkkonummi
 heroImage: Kirsikkapuisto
 alt: 'Kirkkonummen Kirsikkapuisto aurinkoisena kesäpäivänä. Näköpiirissä pääasiassa nurmialuetta, taustalla kerrostaloja ja edustalla hieman leikkipuistoja'
+faq:
+  - q: 'Mitä THL:n kouluterveyskysely kertoo sateenkaarinuorista?'
+    a: 'THL:n kouluterveyskyselyn mukaan sukupuolivähemmistöihin kuuluvista yläkoululaisista joka viides on kokenut toistuvaa koulukiusaamista vähintään kerran viikossa. Seksuaalivähemmistöihin kuuluvista joka seitsemäs. Kiusaaminen on kaksin- tai kolminkertaista muihin nuoriin verrattuna.'
+  - q: 'Miksi pride-liputus ei ole pelkkää symboliikkaa?'
+    a: 'Tutkimus osoittaa, että sateenkaarinuorten hyvinvointia tukevat erityisesti hyväksytyksi tulemisen kokemus ja näkyvyys. Yhteisöllinen hyväksyntä on yhteydessä alentuneeseen masennusriskiin, vähentyneeseen yksinäisyyteen ja parempaan koulunkäyntiin.'
+  - q: 'Miten liputuspäätös syntyi Kirkkonummella?'
+    a: 'Päätös syntyi valtuustoaloitteesta vuosittaisesta sateenkaariliputuksesta. Kirkkonummen valtuusto äänesti 30–14 liputuksen puolesta maaliskuussa 2026.'
+  - q: 'Mitä pieni ele maksaa verrattuna syrjäytymisen kustannuksiin?'
+    a: 'Lippu maksaa muutaman kymmenen euroa. Syrjäytyneen nuoren yhteiskunnalliset kustannukset ovat kymmenien tuhansien euron luokkaa per henkilö. Ennaltaehkäisy on aina halvempaa.'
 ---
 
 import BlockQuote from '../../../../../components/body/BlockQuote.astro'
@@ -25,7 +34,7 @@ THL:n kouluterveyskyselyn luvut eivät ole pelkkiä tilastoja. Ne ovat nuoria, j
 
 ## Mitä THL:n kouluterveyskysely kertoo sateenkaarinuorista?
 
-[Setan helmikuussa 2026 julkaisema kooste](https://seta.fi/2026/02/02/uusin-kouluterveyskysely-sateenkaarinuorten-hyvinvointi-ei-parantunut/) THL:n aineistosta osoittaa, että sukupuolivähemmistöihin kuuluvista yläkoululaisista joka viides on kokenut toistuvaa koulukiusaamista, vähintään kerran viikossa. Seksuaalivähemmistöihin kuuluvista joka seitsemäs. Verrattuna muihin nuoriin kiusaaminen on kaksin- tai kolminkertaista.
+[THL:n kouluterveyskysely](https://thl.fi/tutkimus-ja-kehittaminen/tutkimukset-ja-hankkeet/kouluterveyskysely/kouluterveyskyselyn-tulokset) osoittaa, että sukupuolivähemmistöihin kuuluvista yläkoululaisista joka viides on kokenut toistuvaa koulukiusaamista, vähintään kerran viikossa. Seksuaalivähemmistöihin kuuluvista joka seitsemäs. Verrattuna muihin nuoriin kiusaaminen on kaksin- tai kolminkertaista.
 
 Nämä luvut ovat huolestuttavia jo sinänsä. On myös tärkeää huomata, että kyse on nuorista, jotka ovat uskaltaneet vastata kyselyyn omalla identiteetillään. Kaikki eivät sitä tee.
 
@@ -40,8 +49,6 @@ Tutkimus osoittaa johdonmukaisesti, että sateenkaarinuorten hyvinvointia tukee 
 Yhteisöllinen hyväksyntä on tutkitusti yhteydessä alentuneeseen masennusriskiin, vähentyneeseen yksinäisyyteen ja parempaan koulunkäyntiin. Kun kunta näkyvästi osoittaa arvostavansa kaikkia asukkaitaan, se tekee ennaltaehkäisevää mielenterveystyötä ilman erillistä ohjelmaa tai budjettiriviä.
 
 Lippu ei ole sisäinen raportti tai strategiakirjaus. Se on näkyvä, fyysinen viesti, jonka jokainen ohikulkija voi havaita. Juuri siksi sen merkitys on suurempi kuin sen koko antaa ymmärtää.
-
-{/* @SEOReviewer: FAQ schema recommended */}
 
 ## Miten liputuspäätös syntyi Kirkkonummella?
 

--- a/src/pages/fi/blog/55/kirkkonummi-sanoo-sina-kuulut-tanne/index.mdx
+++ b/src/pages/fi/blog/55/kirkkonummi-sanoo-sina-kuulut-tanne/index.mdx
@@ -21,7 +21,7 @@ import Paragraph from '../../../../../components/Paragraph.astro'
 
 export const components = { blockquote: BlockQuote, a: SmartLink, h2: H2, h3: H3, p: Paragraph }
 
-Kirkkonummen THL:n kouluterveyskyselyn luvut eivät ole pelkkiä tilastoja. Ne ovat nuoria, jotka istuvat luokissa, käyvät harrastuksissa ja kulkevat kunnassamme päivittäin. Maaliskuun 10. päivänä 2026 Kirkkonummen valtuusto äänesti 30–14 sateenkaariliputuksen puolesta. Päätös on pieni. Sen merkitys niille nuorille, joita varten se tehtiin, ei ole.
+THL:n kouluterveyskyselyn luvut eivät ole pelkkiä tilastoja. Ne ovat nuoria, jotka istuvat luokissa, käyvät harrastuksissa ja kulkevat kunnassamme päivittäin. Maaliskuun 10. päivänä 2026 Kirkkonummen valtuusto äänesti 30–14 sateenkaariliputuksen puolesta. Päätös on pieni. Sen merkitys niille nuorille, joita varten se tehtiin, ei ole.
 
 ## Mitä THL:n kouluterveyskysely kertoo sateenkaarinuorista?
 

--- a/src/pages/fi/blog/55/kirkkonummi-sanoo-sina-kuulut-tanne/index.mdx
+++ b/src/pages/fi/blog/55/kirkkonummi-sanoo-sina-kuulut-tanne/index.mdx
@@ -21,43 +21,41 @@ import Paragraph from '../../../../../components/Paragraph.astro'
 
 export const components = { blockquote: BlockQuote, a: SmartLink, h2: H2, h3: H3, p: Paragraph }
 
-Kirkkonummen THL:n kouluterveyskyselyn luvut eivät ole pelkkiä tilastoja. Ne ovat nuoria, jotka istuvat luokissa, käyvät harrastuksissa ja kulkevat kunnassamme päivittäin — usein kantaen mukanaan kuormaa, josta muut eivät tiedä. Maaliskuun 10. päivänä 2026 Kirkkonummen valtuusto äänesti 30–14 sateenkaariliputuksen puolesta. Päätös on pieni. Sen merkitys niille nuorille, joita varten se tehtiin, ei ole.
+Kirkkonummen THL:n kouluterveyskyselyn luvut eivät ole pelkkiä tilastoja. Ne ovat nuoria, jotka istuvat luokissa, käyvät harrastuksissa ja kulkevat kunnassamme päivittäin. Maaliskuun 10. päivänä 2026 Kirkkonummen valtuusto äänesti 30–14 sateenkaariliputuksen puolesta. Päätös on pieni. Sen merkitys niille nuorille, joita varten se tehtiin, ei ole.
 
 ## Mitä THL:n kouluterveyskysely kertoo sateenkaarinuorista?
 
-[Setan helmikuussa 2026 julkaisema kooste](https://seta.fi/2026/02/02/uusin-kouluterveyskysely-sateenkaarinuorten-hyvinvointi-ei-parantunut/) THL:n aineistosta osoittaa, että sukupuolivähemmistöihin kuuluvista yläkoululaisista joka viides on kokenut toistuvaa koulukiusaamista — vähintään kerran viikossa. Seksuaalivähemmistöihin kuuluvista joka seitsemäs. Verrattuna muihin nuoriin kiusaaminen on kaksin- tai kolminkertaista.
+[Setan helmikuussa 2026 julkaisema kooste](https://seta.fi/2026/02/02/uusin-kouluterveyskysely-sateenkaarinuorten-hyvinvointi-ei-parantunut/) THL:n aineistosta osoittaa, että sukupuolivähemmistöihin kuuluvista yläkoululaisista joka viides on kokenut toistuvaa koulukiusaamista, vähintään kerran viikossa. Seksuaalivähemmistöihin kuuluvista joka seitsemäs. Verrattuna muihin nuoriin kiusaaminen on kaksin- tai kolminkertaista.
 
-Nämä luvut ovat huolestuttavia jo sinänsä. Kaikkein vakavimpia ne ovat siksi, että kyse on nuorista, jotka ovat uskaltaneet vastata kyselyyn omalla identiteetillään. Suuri osa sateenkaarinuorista ei kerro identiteetistään lainkaan — ei kotona, ei koulussa, ei kavereiden kesken. Tosiasiallinen kiusaamisen kokemus on todennäköisesti laajempaa kuin data paljastaa.
+Nämä luvut ovat huolestuttavia jo sinänsä. On myös tärkeää huomata, että kyse on nuorista, jotka ovat uskaltaneet vastata kyselyyn omalla identiteetillään. Kaikki eivät sitä tee.
 
-Vuoden 2023 jälkeen tilanne ei ole parantunut. Se on pahentunut. Tämä ei tapahdu tyhjiössä: yhteiskunnallinen ilmapiiri on monessa maassa ja myös Suomessa koventunut sateenkaareviin ihmisiin kohdistuvassa puheessa. Kun suvaitsemattomuus normalisoidaan julkisessa keskustelussa, se heijastuu suoraan nuorten arkeen. Nämä ovat kirkkonummelaisia nuoria.
+Vuoden 2023 jälkeen tilanne ei ole parantunut. Se on pahentunut. Tämä ei tapahdu tyhjiössä: yhteiskunnallinen ilmapiiri on monessa maassa ja myös Suomessa koventunut sateenkaareviin ihmisiin kohdistuvassa puheessa. Kun suvaitsemattomuus normalisoidaan julkisessa keskustelussa, se heijastuu suoraan myös kirkkonummelaisten nuorten arkeen.
 
 ## Miksi liputus ei ole pelkkää symboliikkaa?
 
-Symboliikka on konkreettista, kun sen kohde on haavoittuva nuori. Tutkimus osoittaa johdonmukaisesti, että sateenkaarinuorten hyvinvointia tukee ennen kaikkea kaksi asiaa: hyväksytyksi tulemisen kokemus ja näkyvyys — tieto siitä, ettei ole yksin. Nämä eivät ole ainoastaan tunnereaktioita. Ne ovat mitattavia muuttujia, joilla on yhteys nuorten mielenterveyteen ja kouluviihtyvyyteen.
+Tutkimus osoittaa johdonmukaisesti, että sateenkaarinuorten hyvinvointia tukee ennen kaikkea kaksi asiaa: hyväksytyksi tulemisen kokemus ja näkyvyys — tieto siitä, ettei ole yksin.
 
 > Kun nuori näkee, että hänen kuntansa tunnustaa hänen olemassaolonsa, se ei ole tyhjä ele. Se on viesti: sinä kuulut tänne.
 
-Yhteisöllinen hyväksyntä on tutkitusti yhteydessä alentuneeseen masennusriskiin, vähentyneeseen yksinäisyyteen ja parempaan koulunkäyntiin. Kun kunta näkyvästi osoittaa arvostavansa kaikkia asukkaitaan, se tekee ennaltaehkäisevää mielenterveystyötä — ilman erillistä ohjelmaa tai budjettiriviä.
+Yhteisöllinen hyväksyntä on tutkitusti yhteydessä alentuneeseen masennusriskiin, vähentyneeseen yksinäisyyteen ja parempaan koulunkäyntiin. Kun kunta näkyvästi osoittaa arvostavansa kaikkia asukkaitaan, se tekee ennaltaehkäisevää mielenterveystyötä ilman erillistä ohjelmaa tai budjettiriviä.
 
-Lippu ei ole sisäinen raportti tai strategiakirjaus — se on näkyvä, fyysinen viesti, jonka jokainen ohikulkija voi havaita. Juuri siksi sen merkitys on suurempi kuin sen koko antaa ymmärtää.
+Lippu ei ole sisäinen raportti tai strategiakirjaus. Se on näkyvä, fyysinen viesti, jonka jokainen ohikulkija voi havaita. Juuri siksi sen merkitys on suurempi kuin sen koko antaa ymmärtää.
 
 {/* @SEOReviewer: FAQ schema recommended */}
 
 ## Miten liputuspäätös syntyi Kirkkonummella?
 
-Päätös ei syntynyt tyhjästä. Tein [valtuustoaloitteen vuosittaisesta sateenkaariluputuksesta](/fi/blog/39/valtuustoaloite-vuosittainen-pride-liputus-kirkkonummelle/) jo aiemmin, ja asia eteni valmistelun kautta valtuuston käsittelyyn. Maaliskuun 10. istunnossa pidin asiasta [valtuustopuheenvuoron](/fi/blog/52/kirkkonummi-on-tanaan-tasa-arvoisempi-kuin-eilen/), jossa esitin saman argumentin, jonka toistan tässäkin: pienen eleen kustannus on minimaalinen, mutta sen vaikutus niille nuorille, joita se koskee, voi olla mittaamaton.
+Liputuspäätös syntyi [valtuustoaloitteestani vuosittaisesta sateenkaariliputuksesta](/fi/blog/39/valtuustoaloite-vuosittainen-pride-liputus-kirkkonummelle/), jonka valtuusto hyväksyi maaliskuussa. 10. maaliskuun valtuustossa pidin asiasta [puheenvuoron](/fi/blog/52/kirkkonummi-on-tanaan-tasa-arvoisempi-kuin-eilen/) ja toistin saman argumentin, jonka toistan tässäkin: pienen eleen kustannus on minimaalinen, mutta sen vaikutus niille nuorille, joita se koskee, voi olla mittaamaton.
 
-Äänestystulos 30–14 kertoo, että asiasta käytiin aitoa poliittista harkintaa. Osa valtuutetuista äänesti vastaan — se on heidän oikeutensa ja osa demokratiaa. Enemmistö katsoi kuitenkin, että kunnan tehtävä on edistää kaikkien asukkaidensa hyvinvointia. Kuntalaki edellyttää asukkaiden hyvinvoinnin edistämistä, ja kunnan strategia lupaa tasa-arvoa ja yhdenvertaisuutta. Liputuspäätös vie nämä lupaukset käytäntöön.
+Äänestystulos 30–14 kertoo, että enemmistö valtuutetuista ymmärsi luvut ja teki päätöksen niiden pohjalta. Kirkkonummen strategia lupaa tasa-arvoa ja yhdenvertaisuutta, kuntalaki velvoittaa edistämään asukkaiden hyvinvointia. Liputuspäätös vie nämä lupaukset käytäntöön.
 
 ## Mitä pieni ele maksaa verrattuna syrjäytymisen kustannuksiin?
 
-Lippu maksaa muutaman kymmenen euroa. Syrjäytyneen nuoren yhteiskunnalliset kustannukset — menetetyt työvuodet, sosiaalipalvelut, terveydenhuolto — ovat kymmenien tuhansien euron luokkaa per henkilö, joissain laskelmissa huomattavasti enemmän.
+Lippu maksaa muutaman kymmenen euroa. Syrjäytyneen nuoren yhteiskunnalliset kustannukset (menetetyt työvuodet, sosiaalipalvelut, terveydenhuolto) ovat kymmenien tuhansien euron luokkaa per henkilö, joissain laskelmissa huomattavasti enemmän.
 
 > Ennaltaehkäisy on aina halvempaa. Tämä pätee niin terveydenhuollossa kuin nuorisotyössäkin.
 
-En väitä, että liputus yksin ratkaisee sateenkaarinuorten hyvinvointihaasteen. Se ei tee sitä. Tarvitaan kouluihin kohdistuvaa konkreettista kiusaamisen vastaista työtä, riittävästi kuraattori- ja psykologipalveluja sekä yhteisöllinen kulttuuri, jossa erilaisuus on hyväksyttyä — ei vain sallittua. Lippu on alkupiste. Se on signaali siitä, että kunnassa on tahtoa. Ja tahto on edellytys kaikelle muulle, mitä seuraa perässä. Se viestii, millaiseen suuntaan kunta haluaa kehittyä — ja se velvoittaa jatkamaan samaan suuntaan.
-
-Jossain päin Kirkkonummea on tänään nuori, joka ei ole vielä kertonut kenellekään, kuka hän on. Hän ei ehkä tiedä äänestystuloksesta. Ehkä hän näkee lipun ensi kesänä. Ehkä ei. Mutta päätös on tehty — ja se on tehty häntä varten. Kirkkonummi on sanonut ääneen: sinä kuulut tänne.
+En väitä, että liputus yksin ratkaisee sateenkaarinuorten hyvinvointihaasteen. Se ei tee sitä. Tarvitaan kouluihin kohdistuvaa konkreettista kiusaamisen vastaista työtä, riittävästi kuraattori- ja psykologipalveluja sekä yhteisöllinen kulttuuri, jossa erilaisuus on hyväksyttyä, ei pelkästään sallittua. Lippu on alkupiste. Se viestii, millaiseen suuntaan kunta haluaa kehittyä, ja velvoittaa jatkamaan samaan suuntaan.
 
 Kirkkonummi on tänään tasa-arvoisempi kuin eilen. Se ei ole loppupiste — se on lähtölaukaus. Montako muuta pientä elettä odottaa vielä tekemistään?
 

--- a/src/pages/sv/blog/55/kyrkslatt-till-alla-du-hor-hemma-har/index.mdx
+++ b/src/pages/sv/blog/55/kyrkslatt-till-alla-du-hor-hemma-har/index.mdx
@@ -11,6 +11,15 @@ tags:
   - kirkkonummi
 heroImage: Kirsikkapuisto
 alt: 'Kyrkslätt Kirsikkapuisto en solig sommardag. Nästan bara gräsmatta i blickfånget, i bakgrunden flervåningshus och i förgrunden lite lekplatsutrustning'
+faq:
+  - q: 'Vad berättar THL:s enkät om skolhälsa om regnbågsungdomar?'
+    a: 'Enligt THL:s enkät om skolhälsa har var femte högstadieelev som tillhör en könsminoritet upplevt upprepad mobbning minst en gång i veckan. Bland sexuella minoriteter gäller det var sjunde. Mobbningen är dubbelt eller tre gånger så vanlig jämfört med andra unga.'
+  - q: 'Varför är flaggningen mer än symbolik?'
+    a: 'Forskning visar att regnbågsungdomars välmående stöds framför allt av upplevelsen av att bli accepterad och synlighet. Gemenskapens acceptans är kopplad till lägre risk för depression, minskad ensamhet och bättre skolnärvaro.'
+  - q: 'Hur uppstod flaggningsbeslutet i Kyrkslätt?'
+    a: 'Beslutet uppstod ur ett fullmäktigeinitiativ om en årlig regnbågsflaggning. Kyrkslätts fullmäktige röstade 30–14 för flaggning i mars 2026.'
+  - q: 'Vad kostar en liten gest jämfört med kostnaderna för utanförskap?'
+    a: 'En flagga kostar några tiotal euro. De samhälleliga kostnaderna för en marginaliserad ung människa är i storleksordningen tiotusentals euro per person. Förebyggande åtgärder är alltid billigare.'
 ---
 
 import BlockQuote from '../../../../../components/body/BlockQuote.astro'
@@ -25,7 +34,7 @@ Siffrorna från THL:s enkät om skolhälsa i Kyrkslätt är inte bara statistik.
 
 ## Vad berättar THL:s enkät om skolhälsa om regnbågsungdomar?
 
-[Setas sammanfattning från februari 2026](https://seta.fi/2026/02/02/uusin-kouluterveyskysely-sateenkaarinuorten-hyvinvointi-ei-parantunut/) av THL:s material visar att var femte högstadieelev som tillhör en könsminoritet har upplevt upprepad mobbning, minst en gång i veckan. Bland sexuella minoriteter gäller det var sjunde. Jämfört med andra unga är mobbningen dubbelt eller tre gånger så vanlig.
+[THL:s enkät om skolhälsa](https://thl.fi/tutkimus-ja-kehittaminen/tutkimukset-ja-hankkeet/kouluterveyskysely/kouluterveyskyselyn-tulokset) visar att var femte högstadieelev som tillhör en könsminoritet har upplevt upprepad mobbning, minst en gång i veckan. Bland sexuella minoriteter gäller det var sjunde. Jämfört med andra unga är mobbningen dubbelt eller tre gånger så vanlig.
 
 Dessa siffror är oroväckande i sig. Det är också viktigt att notera att de gäller unga som vågat svara på enkäten med sin egen identitet. Alla gör inte det.
 

--- a/src/pages/sv/blog/55/kyrkslatt-till-alla-du-hor-hemma-har/index.mdx
+++ b/src/pages/sv/blog/55/kyrkslatt-till-alla-du-hor-hemma-har/index.mdx
@@ -21,44 +21,42 @@ import Paragraph from '../../../../../components/Paragraph.astro'
 
 export const components = { blockquote: BlockQuote, a: SmartLink, h2: H2, h3: H3, p: Paragraph }
 
-Siffrorna från THL:s enkät om skolhälsa i Kyrkslätt är inte bara statistik. De är unga människor som sitter i klassrum, deltar i hobbyer och rör sig i vår kommun varje dag — och som ofta bär på en börda som ingen annan ser. Den 10 mars 2026 röstade Kyrkslätts fullmäktige 30–14 för regnbågsflaggning. Beslutet är litet. Dess betydelse för de unga det gjordes för är det inte.
+Siffrorna från THL:s enkät om skolhälsa i Kyrkslätt är inte bara statistik. De är unga människor som sitter i klassrum, deltar i hobbyer och rör sig i vår kommun varje dag. Den 10 mars 2026 röstade Kyrkslätts fullmäktige 30–14 för regnbågsflaggning. Beslutet är litet. Dess betydelse för de unga det gjordes för är det inte.
 
 ## Vad berättar THL:s enkät om skolhälsa om regnbågsungdomar?
 
-[Setas sammanfattning från februari 2026](https://seta.fi/2026/02/02/uusin-kouluterveyskysely-sateenkaarinuorten-hyvinvointi-ei-parantunut/) av THL:s material visar att var femte högstadieelev som tillhör en könsminoritet har upplevt upprepad mobbning — minst en gång i veckan. Bland sexuella minoriteter gäller det var sjunde. Jämfört med andra unga är mobbningen dubbelt eller tre gånger så vanlig.
+[Setas sammanfattning från februari 2026](https://seta.fi/2026/02/02/uusin-kouluterveyskysely-sateenkaarinuorten-hyvinvointi-ei-parantunut/) av THL:s material visar att var femte högstadieelev som tillhör en könsminoritet har upplevt upprepad mobbning, minst en gång i veckan. Bland sexuella minoriteter gäller det var sjunde. Jämfört med andra unga är mobbningen dubbelt eller tre gånger så vanlig.
 
-Dessa siffror är oroväckande i sig. Det allvarligaste är att de gäller unga som vågat svara på enkäten och uppge sin identitet. Många regnbågsungdomar berättar inte om sin identitet alls — inte hemma, inte i skolan, inte bland vänner. Den faktiska erfarenheten av mobbning är sannolikt mer utbredd än vad data visar.
+Dessa siffror är oroväckande i sig. Det är också viktigt att notera att de gäller unga som vågat svara på enkäten med sin egen identitet. Alla gör inte det.
 
-Efter 2023 har situationen inte förbättrats. Den har försämrats. Det sker inte i ett vakuum: det samhälleliga klimatet har i många länder, och också i Finland, hårdnat i fråga om hur man talar om och till regnbågsidentifierade personer. När intolerans normaliseras i det offentliga samtalet reflekteras det direkt i ungdomarnas vardag. Det handlar om unga i Kyrkslätt.
+Efter 2023 har situationen inte förbättrats. Den har försämrats. Det sker inte i ett vakuum: det samhälleliga klimatet har i många länder, och också i Finland, hårdnat i fråga om hur man talar om regnbågsidentifierade personer. När intolerans normaliseras i det offentliga samtalet reflekteras det direkt också i ungdomarnas vardag i Kyrkslätt.
 
 ## Varför är flaggningen mer än symbolik?
 
-Symbolik är konkret när mottagaren är en utsatt ung människa. Forskning visar konsekvent att regnbågsungdomars välmående framför allt stöds av två saker: upplevelsen av att bli accepterad och synlighet — vetskapen om att man inte är ensam. Det är inte bara känslomässiga reaktioner. Det är mätbara variabler med koppling till ungdomars psykiska hälsa och trivsel i skolan.
+Forskning visar konsekvent att regnbågsungdomars välmående framför allt stöds av två saker: upplevelsen av att bli accepterad och synlighet — vetskapen om att man inte är ensam.
 
 > När en ung person ser att deras kommun erkänner deras existens är det ingen tom gest. Det är ett budskap: du hör hemma här.
 
-Gemenskapens acceptans är forskningsbelagt kopplad till lägre risk för depression, minskad ensamhet och bättre skolnärvaro. När kommunen synligt visar att den värdesätter alla sina invånare bedriver den förebyggande psykisk hälsovård — utan ett separat program eller en budgetrad.
+Gemenskapens acceptans är forskningsbelagt kopplad till lägre risk för depression, minskad ensamhet och bättre skolnärvaro. När kommunen synligt visar att den värdesätter alla sina invånare bedriver den förebyggande psykisk hälsovård utan ett separat program eller en budgetrad.
 
-Flaggan är inte en intern rapport eller en strategiskrivning — den är ett synligt, fysiskt budskap som alla förbipasserande kan se. Just därför är dess betydelse större än vad dess storlek antyder.
+Flaggan är inte en intern rapport eller en strategiskrivning. Den är ett synligt, fysiskt budskap som alla förbipasserande kan se. Just därför är dess betydelse större än vad dess storlek antyder.
 
 ## Hur uppstod flaggningsbeslutet i Kyrkslätt?
 
 {/* @SEOReviewer: FAQ schema recommended */}
 
-Beslutet kom inte ur tomma luften. Jag lämnade ett [fullmäktigeinitiativ om en årlig regnbågsflaggning](/fi/blog/39/valtuustoaloite-vuosittainen-pride-liputus-kirkkonummelle/) redan tidigare, och frågan gick via beredning till fullmäktige. Vid mötet den 10 mars höll jag ett [fullmäktigeanförande](/fi/blog/52/kirkkonummi-on-tanaan-tasa-arvoisempi-kuin-eilen/) där jag framförde samma argument som jag upprepar även här: kostnaden för en liten gest är minimal, men dess effekt för de unga den berör kan vara omätbar.
+Flaggningsbeslutet uppstod ur [mitt fullmäktigeinitiativ om en årlig regnbågsflaggning](/fi/blog/39/valtuustoaloite-vuosittainen-pride-liputus-kirkkonummelle/), som fullmäktige godkände i mars. Vid mötet den 10 mars höll jag ett [fullmäktigeanförande](/fi/blog/52/kirkkonummi-on-tanaan-tasa-arvoisempi-kuin-eilen/) och framförde samma argument som jag upprepar även här: kostnaden för en liten gest är minimal, men dess effekt för de unga den berör kan vara omätbar.
 
-Röstningsresultatet 30–14 visar att det fördes en äkta politisk diskussion. En del fullmäktigeledamöter röstade emot — det är deras rätt och en del av demokratin. Majoriteten ansåg ändå att kommunens uppgift är att främja alla invånares välbefinnande. Kommunallagen kräver att kommunen verkar för invånarnas välbefinnande, och kommunens strategi utlovar jämställdhet och likabehandling. Flaggningsbeslutet för dessa löften till praktiken.
+Röstningsresultatet 30–14 visar att majoriteten av fullmäktigeledamöterna förstod siffrorna och fattade beslut utifrån dem. Kommunens strategi utlovar jämställdhet och likabehandling, kommunallagen förpliktar till att främja invånarnas välbefinnande. Flaggningsbeslutet för dessa löften till praktiken.
 
 ## Vad kostar en liten gest jämfört med kostnaderna för utanförskap?
 
-En flagga kostar några tiotal euro. De samhälleliga kostnaderna för en marginaliserad ung människa — förlorade arbetsår, socialtjänst, hälsovård — är i storleksordningen tiotusentals euro per person, i vissa beräkningar avsevärt mer.
+En flagga kostar några tiotal euro. De samhälleliga kostnaderna för en marginaliserad ung människa (förlorade arbetsår, socialtjänst, hälsovård) är i storleksordningen tiotusentals euro per person, i vissa beräkningar avsevärt mer.
 
 > Förebyggande åtgärder är alltid billigare. Det gäller såväl hälsovård som ungdomsarbete.
 
-Jag påstår inte att flaggning ensam löser de utmaningar regnbågsungdomar möter i sitt välmående. Det gör den inte. Det behövs konkret mobbningsförebyggande arbete i skolorna, tillräckligt med kuratorer och psykologtjänster, och en gemensamhetskultur där olikhet är accepterad — inte bara tolererad. Flaggan är en startpunkt. Den är ett signal om att kommunen har vilja. Och viljan är en förutsättning för allt annat som följer. Den kommunicerar i vilken riktning kommunen vill utvecklas — och den förpliktar till att fortsätta i samma riktning.
+Jag påstår inte att flaggning ensam löser de utmaningar regnbågsungdomar möter i sitt välmående. Det gör den inte. Det behövs konkret mobbningsförebyggande arbete i skolorna, tillräckligt med kuratorer och psykologtjänster, och en gemensamhetskultur där olikhet är accepterad, inte bara tolererad. Flaggan är en startpunkt. Den kommunicerar i vilken riktning kommunen vill utvecklas och förpliktar till att fortsätta i samma riktning.
 
-Någonstans i Kyrkslätt finns det i dag en ung person som ännu inte berättat för någon vem hen är. Hen kanske inte känner till röstningsresultatet. Kanske ser hen flaggan nästa sommar. Kanske inte. Men beslutet är fattat — och det är fattat för hens skull. Kyrkslätt har sagt högt: du hör hemma här.
-
-Kyrkslätt är i dag mer jämlikt än i går. Det är inte en slutpunkt — det är ett startskott. Och det är inte symbolpolitik — det är förvaltning som fungerar. Hur många fler sådana små gester väntar på att göras?
+Kyrkslätt är i dag mer jämlikt än i går. Det är inte en slutpunkt — det är ett startskott. Hur många fler sådana små gester väntar på att göras?
 
 {/* [SCHEMA: BlogPosting required] */}


### PR DESCRIPTION
## Summary

- Remove burden phrase from opening paragraph
- THL section: remove speculation; state data is from truthful responders only
- Climate sentence now flows directly into Kirkkonummi context (no standalone sentence)
- Symbolism section: remove disconnected framing/measurement sentences
- Council section: foreground initiative origin, fix typo (luputuksesta → liputuksesta), fix session reference (istunnossa → maaliskuun valtuustossa)
- Voting paragraph: remove patronising democratic-right framing; highlight majority understood the facts
- Remove "Jossain päin / Somewhere in / Någonstans" paragraph in all three locales
- FI/EN/SV: reduce en-dashes to exactly 2; convert parenthetical dashes to commas/sentences
- SV: convert third closing dash to a period

## Test plan

- [x] lint-staged passed on commit (validate-titles, validate-translations, check-long-words)
- [x] `npm run build` — 424 pages, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)