### PR TITLE
fix(blog): add publication bylines to post #55 (fi, sv, en)

### DIFF
--- a/src/pages/en/blog/55/kirkkonummi-tells-everyone-you-belong-here/index.mdx
+++ b/src/pages/en/blog/55/kirkkonummi-tells-everyone-you-belong-here/index.mdx
@@ -68,4 +68,7 @@ I am not claiming that flag-flying alone resolves the wellbeing challenges faced
 
 Kirkkonummi is more equal today than it was yesterday. That is not an endpoint — it is a starting gun. How many more small gestures are still waiting to be made?
 
+_Published in [Kirkkonummen Sanomat](https://www.kirkkonummensanomat.fi/kirkkonummi-sanoo-kaikille-sina-kuulut-tanne-6.175.84393.2950465b2f) on 25 March 2026._
+_Published in Länsiväylä on 8 April 2026._
+
 {/* [SCHEMA: BlogPosting required] */}

--- a/src/pages/fi/blog/55/kirkkonummi-sanoo-sina-kuulut-tanne/index.mdx
+++ b/src/pages/fi/blog/55/kirkkonummi-sanoo-sina-kuulut-tanne/index.mdx
@@ -66,4 +66,7 @@ En väitä, että liputus yksin ratkaisee sateenkaarinuorten hyvinvointihaasteen
 
 Kirkkonummi on tänään tasa-arvoisempi kuin eilen. Se ei ole loppupiste — se on lähtölaukaus. Montako muuta pientä elettä odottaa vielä tekemistään?
 
+_Julkaistu [Kirkkonummen Sanomissa](https://www.kirkkonummensanomat.fi/kirkkonummi-sanoo-kaikille-sina-kuulut-tanne-6.175.84393.2950465b2f) 25.3.2026._
+_Julkaistu Länsiväylässä 8.4.2026._
+
 {/* [SCHEMA: BlogPosting required] */}

--- a/src/pages/sv/blog/55/kyrkslatt-till-alla-du-hor-hemma-har/index.mdx
+++ b/src/pages/sv/blog/55/kyrkslatt-till-alla-du-hor-hemma-har/index.mdx
@@ -68,4 +68,7 @@ Jag påstår inte att flaggning ensam löser de utmaningar regnbågsungdomar mö
 
 Kyrkslätt är i dag mer jämlikt än i går. Det är inte en slutpunkt — det är ett startskott. Hur många fler sådana små gester väntar på att göras?
 
+_Publicerat i [Kirkkonummen Sanomat](https://www.kirkkonummensanomat.fi/kyrkslatt-sager-till-alla-du-hor-hemma-har-6.175.84395.d8e9c188ab) 25.3.2026._
+_Publicerat i Länsiväylä 8.4.2026._
+
 {/* [SCHEMA: BlogPosting required] */}


### PR DESCRIPTION
## Summary
- Adds missing publication bylines to all three locale MDX files for blog post #55

## Publications added
- FI: Kirkkonummen Sanomat 25.3.2026 (FI URL), Länsiväylä 8.4.2026
- SV: Kirkkonummen Sanomat 25.3.2026 (SV URL), Länsiväylä 8.4.2026
- EN: Kirkkonummen Sanomat 25.3.2026 (FI URL), Länsiväylä 8.4.2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)