### PR TITLE
docs(post-51): add Vantaan Sanomat as alternate publication

### DIFF
--- a/src/pages/en/blog/51/digital-independence-is-a-necessity/index.mdx
+++ b/src/pages/en/blog/51/digital-independence-is-a-necessity/index.mdx
@@ -43,4 +43,6 @@ _[Published in Helsingin Sanomat on 25.2.2026](https://www.hs.fi/mielipide/art-2
 
 _[A different version was published in Kirkkonummen Sanomat on 4.3.2026](https://www.kirkkonummensanomat.fi/digitaalinen-itsenaisyys-on-valttamattomyys-6.175.84176.a535ef70d3)._
 
+_[Published in Vantaan Sanomat on 6.4.2026](https://www.vantaansanomat.fi/paakirjoitus-mielipide/9339946)._
+
 _More information about the digital independence citizens' initiative can be found on the initiative's [website](https://digitaalinenitsenaisyys.fi/)._

--- a/src/pages/fi/blog/51/digitaalinen-itsenaisyys-on-valttamattomyys/index.mdx
+++ b/src/pages/fi/blog/51/digitaalinen-itsenaisyys-on-valttamattomyys/index.mdx
@@ -43,4 +43,6 @@ _[Julkaistu Helsingin Sanomissa 25.2.2026](https://www.hs.fi/mielipide/art-20000
 
 _[Eri versio julkaistu Kirkkonummen Sanomissa 4.3.2026](https://www.kirkkonummensanomat.fi/digitaalinen-itsenaisyys-on-valttamattomyys-6.175.84176.a535ef70d3)._
 
+_[Julkaistu Vantaan Sanomissa 6.4.2026](https://www.vantaansanomat.fi/paakirjoitus-mielipide/9339946)._
+
 _Digitaalinen itsenäisyys -kansalaisaloitteesta löydät lisää tietoa aloitteen [nettisivuilta](https://digitaalinenitsenaisyys.fi/). Voit myös allekirjoittaa sen [kansalaisaloite.fi-palvelussa](https://www.kansalaisaloite.fi/fi/aloite/16691)._

--- a/src/pages/sv/blog/51/digital-sjalvstandighet-ar-en-nodvandighet/index.mdx
+++ b/src/pages/sv/blog/51/digital-sjalvstandighet-ar-en-nodvandighet/index.mdx
@@ -45,4 +45,6 @@ _[Publicerad i Hufvudstadsbladet den 4 mars 2026](https://www.hbl.fi/2026-03-04/
 
 _[Denna här versioner publicerad i Kirkkonummen Sanomat den 4 mars 2026](https://www.kirkkonummensanomat.fi/digital-sjalvstandighet-ar-en-nodvandighet-6.175.84178.8ee82a1eec)._
 
+_[Publicerad i Vantaan Sanomat den 6 april 2026](https://www.vantaansanomat.fi/paakirjoitus-mielipide/9339946)._
+
 _Mer information om medborgarinitiativet Digital Independence finns på initativets [webbplats](https://digitaalinenitsenaisyys.fi/). Du kan också signera det i tjänsten [kansalaisaloite.fi](https://www.kansalaisaloite.fi/fi/aloite/16691)._


### PR DESCRIPTION
## Summary
- Adds Vantaan Sanomat (6.4.2026) as an alternate publication link to post 51 in all three language versions (FI, EN, SV)

🤖 Generated with [Claude Code](https://claude.com/claude-code)