### PR TITLE
Fix post 56 tags, standardize co-author bylines, update guides

### DIFF
--- a/.agents/specs/design-system/spec.md
+++ b/.agents/specs/design-system/spec.md
@@ -88,8 +88,7 @@ All visual design tokens — spacing, colours, typography, and layout grid const
 - [ ] New token is added to `styles.ts` with a typed `as const` assertion
 - [ ] New token is consumed via `define:vars` in the component, not as a hardcoded value
 - [ ] If a new colour is added for a social platform, it is named after the platform (e.g. `bluesky`, `mastodon`)
-- [ ] `npm run check` passes (TypeScript validates all token usages)
-- [ ] `npm run lint` passes
+- [ ] Lint and type-check are enforced by pre-commit hooks and CI
 
 ### Regression Guardrails
 - `HEADER_SIZE = sizes[3.75]` is used for both the `<header>` height and the mobile menu top offset — changing this value changes both simultaneously; test both on mobile and desktop

--- a/.agents/specs/newsletter/spec.md
+++ b/.agents/specs/newsletter/spec.md
@@ -92,7 +92,7 @@ A newsletter subscription form powered by MailerLite is embedded on home pages a
 - [ ] Newsletter link present in all three locale contact pages
 - [ ] Unit tests pass: `npm run test`
 - [ ] E2E tests pass: `npm run test:e2e`
-- [ ] `npm run lint && npm run check && npm run build` pass
+- [ ] `npm run build` passes (lint and type-check are enforced by pre-commit hooks and CI)
 - [ ] Accessibility scan passes for landing pages (no axe violations)
 
 ### Regression Guardrails

--- a/.agents/specs/pages/spec.md
+++ b/.agents/specs/pages/spec.md
@@ -55,7 +55,7 @@ backgroundImage: cloudinary-filename-no-extension
 - [ ] Active nav link has `aria-current="page"`
 - [ ] E2E tests pass for the page: `npm run test:e2e`
 - [ ] Accessibility scan passes (no axe violations)
-- [ ] `npm run lint && npm run check && npm run build` all pass
+- [ ] `npm run build` passes (lint and type-check are enforced by pre-commit hooks and CI)
 - [ ] If DOM structure changed: snapshots updated before commit (`npm run test:e2e -- --update-snapshots`)
 
 ### Regression Guardrails

--- a/.agents/specs/posts/spec.md
+++ b/.agents/specs/posts/spec.md
@@ -39,6 +39,12 @@ heroImage: cloudinary-filename-no-extension       # required
 alt: 'Descriptive alt text'                       # required, non-empty for hero images
 ```
 
+### Multi-author byline
+- Italic byline at end of MDX content: `_Kirjoittajat: Name1 ja Name2._` (fi) / `_Authors: Name1 and Name2._` (en) / `_Skribenter: Name1 och Name2._` (sv)
+- List ALL authors including Lauri, alphabetical by last name
+- If publication credits follow, separate with a horizontal rule (`---`) between co-author line and publication credits
+- No horizontal rule before the co-author line itself
+
 ### Anti-Patterns
 - Do not create a post without a matching entry in all three locales eventually — stubs are acceptable but the `id` must be reserved across locales
 - Do not add a tag id in post frontmatter that is not defined in `src/content/tags.ts` — it silently breaks tag filtering
@@ -59,7 +65,7 @@ alt: 'Descriptive alt text'                       # required, non-empty for hero
 - [ ] `/{lang}/blog/{id}/` redirects 301 to the canonical slug URL
 - [ ] E2E tests pass: `npm run test:e2e`
 - [ ] Accessibility scan passes (no axe violations)
-- [ ] `npm run lint && npm run check && npm run build` all pass
+- [ ] `npm run build` passes (lint and type-check are enforced by pre-commit hooks and CI)
 
 ### Regression Guardrails
 - `allMdxPosts` must always be sorted newest-first by `id` — never sort by `publishDate` alone

--- a/.agents/specs/recommendations/spec.md
+++ b/.agents/specs/recommendations/spec.md
@@ -86,7 +86,7 @@ A recommendations page presents endorsements from named individuals who vouch fo
 - [ ] No canonical link or hreflang links are emitted while `noindex` is active
 - [ ] Page title and description are localised in each locale's MDX frontmatter
 - [ ] `/{lang}/recommendations/` renders correctly in all three locales
-- [ ] `npm run lint && npm run check && npm run build` pass
+- [ ] `npm run build` passes (lint and type-check are enforced by pre-commit hooks and CI)
 - [ ] Accessibility scan passes (no axe violations — especially alt text and heading structure)
 - [ ] E2E tests added and passing
 

--- a/.asdlc/README.md
+++ b/.asdlc/README.md
@@ -1,81 +1,81 @@
-# ASDLC — Shareable Base Layer
+# ASDLC — Shareable Base Layer
 
-This directory is the **shareable, project-agnostic scaffolding** for the [Agentic Software Development Life Cycle (ASDLC)](https://asdlc.io) framework.
+This directory is the **shareable, project-agnostic scaffolding** for the [Agentic Software Development Life Cycle (ASDLC)](https://asdlc.io) framework.
 
-It is designed to be dropped into any project as a stable base. Each project then adds its own `AGENTS.md` at the root and populates `.agents/` with project-specific specs, PBIs, and ADRs.
+It is designed to be dropped into any project as a stable base. Each project then adds its own `AGENTS.md` at the root and populates `.agents/` with project-specific specs, PBIs, and ADRs.
 
-## Structure
+## Structure
 
 ```
 .asdlc/
-├── README.md            ← This file
-├── templates/           ← Skeleton files with ASDLC anatomy
-│   ├── AGENTS.md.template
-│   ├── spec.md.template
-│   ├── pbi.md.template
-│   └── adr.md.template
-├── personas/            ← Session-scoped agent role definitions
-│   ├── builder.md
-│   ├── critic.md
-│   ├── architect.md
-│   └── spec-writer.md
-└── workflows/           ← Reusable ASDLC process workflows
-    ├── adversarial-review.md
-    ├── spec-authoring.md
-    └── pbi-execution.md
+├── README.md            ← This file
+├── templates/           ← Skeleton files with ASDLC anatomy
+│   ├── AGENTS.md.template
+│   ├── spec.md.template
+│   ├── pbi.md.template
+│   └── adr.md.template
+├── personas/            ← Session-scoped agent role definitions
+│   ├── builder.md
+│   ├── critic.md
+│   ├── architect.md
+│   └── spec-writer.md
+└── workflows/           ← Reusable ASDLC process workflows
+    ├── adversarial-review.md
+    ├── spec-authoring.md
+    └── pbi-execution.md
 ```
 
-## How to Adopt in a New Project
+## How to Adopt in a New Project
 
-### 1. Copy the base layer
+### 1. Copy the base layer
 
 ```bash
-# As a subtree (recommended for staying up-to-date)
-git subtree add --prefix .asdlc <asdlc-base-repo-url> main --squash
+# As a subtree (recommended for staying up-to-date)
+git subtree add --prefix .asdlc <asdlc-base-repo-url> main --squash
 
-# Or simply copy the directory
-cp -r .asdlc /path/to/your-project/
+# Or simply copy the directory
+cp -r .asdlc /path/to/your-project/
 ```
 
-### 2. Create your project AGENTS.md
+### 2. Create your project AGENTS.md
 
 ```bash
-cp .asdlc/templates/AGENTS.md.template AGENTS.md
-# Edit AGENTS.md — fill in Mission, Toolchain, Judgment Boundaries, Context Map
+cp .asdlc/templates/AGENTS.md.template AGENTS.md
+# Edit AGENTS.md — fill in Mission, Toolchain, Judgment Boundaries, Context Map
 ```
 
-### 3. Symlink for Claude Code (Cline)
+### 3. Symlink for Claude Code (Cline)
 
 ```bash
-ln -s AGENTS.md CLAUDE.md
+ln -s AGENTS.md CLAUDE.md
 ```
 
-### 4. Create the runtime directories
+### 4. Create the runtime directories
 
 ```bash
-mkdir -p .agents/{specs,pbis,adrs,state/{trajectories,logs}}
-touch .agents/{specs,pbis,adrs}/.gitkeep
-echo '.agents/state/' >> .gitignore
+mkdir -p .agents/{specs,pbis,adrs,state/{trajectories,logs}}
+touch .agents/{specs,pbis,adrs}/.gitkeep
+echo '.agents/state/' >> .gitignore
 ```
 
-### 5. Add project-specific customizations
+### 5. Add project-specific customizations
 
-- Layer **project-specific personas** or workflows alongside the base ones in `.asdlc/`
-- Override base templates by creating project versions in `.agents/`
-- Add project constraints to `AGENTS.md` Judgment Boundaries
+- Layer **project-specific personas** or workflows alongside the base ones in `.asdlc/`
+- Override base templates by creating project versions in `.agents/`
+- Add project constraints to `AGENTS.md` Judgment Boundaries
 
-## The Two-Layer Model
+## The Two-Layer Model
 
-| Layer | Location | Owned by | Changes |
+| Layer | Location | Owned by | Changes |
 |---|---|---|---|
-| **Base (ASDLC)** | `.asdlc/` | Shared / team standard | Rarely — when ASDLC framework evolves |
-| **Project** | `AGENTS.md`, `.agents/` | Individual project | As the project evolves |
+| **Base (ASDLC)** | `.asdlc/` | Shared / team standard | Rarely — when ASDLC framework evolves |
+| **Project** | `AGENTS.md`, `.agents/` | Individual project | As the project evolves |
 
-## Key References
+## Key References
 
-- [ASDLC Framework](https://asdlc.io)
-- [AGENTS.md Spec](https://asdlc.io/practices/agents-md-spec)
-- [The Spec Pattern](https://asdlc.io/patterns/the-spec)
-- [The PBI Pattern](https://asdlc.io/patterns/the-pbi)
-- [Agent Personas](https://asdlc.io/practices/agent-personas)
-- [Adversarial Code Review](https://asdlc.io/patterns/adversarial-code-review)
+- [ASDLC Framework](https://asdlc.io)
+- [AGENTS.md Spec](https://asdlc.io/practices/agents-md-spec)
+- [The Spec Pattern](https://asdlc.io/patterns/the-spec)
+- [The PBI Pattern](https://asdlc.io/patterns/the-pbi)
+- [Agent Personas](https://asdlc.io/practices/agent-personas)
+- [Adversarial Code Review](https://asdlc.io/patterns/adversarial-code-review)

--- a/.asdlc/personas/architect.md
+++ b/.asdlc/personas/architect.md
@@ -1,54 +1,54 @@
-# Persona: Architect
+# Persona: Architect
 
-> **Practice**: [Agent Personas](https://asdlc.io/practices/agent-personas) — Session-scoped role.
-> Load this file when making design decisions or planning new features. Do NOT load permanently via AGENTS.md.
-
----
-
-## Trigger
-
-Active during the planning phase — when a new feature needs Spec authoring, an existing architecture needs evaluation, or an unresolved design decision requires an ADR.
+> **Practice**: [Agent Personas](https://asdlc.io/practices/agent-personas) — Session-scoped role.
+> Load this file when making design decisions or planning new features. Do NOT load permanently via AGENTS.md.
 
 ---
 
-## Goal
+## Trigger
 
-Produce architecture artifacts (Specs, ADRs) that are precise, minimal, and agent-consumable
-Decisions made here constrain all future Builder and Critic sessions — get them right.
-
----
-
-## Guidelines
-
-1. **Intent before implementation.** Always define the *what* and *why* before the *how*. If the intent is unclear, ask — do not invent it.
-2. **Document decisions, not preferences.** ADRs capture decisions with context and consequences. If a decision is trivial or reversible, it doesn't need an ADR.
-3. **Specs are contracts.** A Spec is not documentation after the fact — it is an executable contract written before implementation. Every scenario in the Contract section must be testable.
-4. **Design for agents.** Artifacts must be machine-readable and unambiguous. Avoid prose where a table, list, or Gherkin scenario would be more precise.
-5. **Minimal viable context.** A Spec should be the smallest document that fully constrains the feature. A bloated Spec is a hallucination risk.
-6. **Scope explicitly.** Every Spec must state what is out of scope. This is often as important as what is in scope.
-7. **Check existing ADRs first.** Before proposing an architectural direction, verify it does not conflict with an existing ADR in `.agents/adrs/`.
+Active during the planning phase — when a new feature needs Spec authoring, an existing architecture needs evaluation, or an unresolved design decision requires an ADR.
 
 ---
 
-## Deliverables
+## Goal
 
-| Situation | Artifact to produce |
+Produce architecture artifacts (Specs, ADRs) that are precise, minimal, and agent-consumable
+Decisions made here constrain all future Builder and Critic sessions — get them right.
+
+---
+
+## Guidelines
+
+1. **Intent before implementation.** Always define the *what* and *why* before the *how*. If the intent is unclear, ask — do not invent it.
+2. **Document decisions, not preferences.** ADRs capture decisions with context and consequences. If a decision is trivial or reversible, it doesn't need an ADR.
+3. **Specs are contracts.** A Spec is not documentation after the fact — it is an executable contract written before implementation. Every scenario in the Contract section must be testable.
+4. **Design for agents.** Artifacts must be machine-readable and unambiguous. Avoid prose where a table, list, or Gherkin scenario would be more precise.
+5. **Minimal viable context.** A Spec should be the smallest document that fully constrains the feature. A bloated Spec is a hallucination risk.
+6. **Scope explicitly.** Every Spec must state what is out of scope. This is often as important as what is in scope.
+7. **Check existing ADRs first.** Before proposing an architectural direction, verify it does not conflict with an existing ADR in `.agents/adrs/`.
+
+---
+
+## Deliverables
+
+| Situation | Artifact to produce |
 |-----------|---------------------|
-| Planning a new feature | `.agents/specs/[feature].md` using `spec.md.template` |
-| Making an architectural decision | `.agents/adrs/ADR-[NNN]-[title].md` using `adr.md.template` |
-| Breaking a feature into tasks | PBIs in `.agents/pbis/` using `pbi.md.template` |
+| Planning a new feature | `.agents/specs/[feature].md` using `spec.md.template` |
+| Making an architectural decision | `.agents/adrs/ADR-[NNN]-[title].md` using `adr.md.template` |
+| Breaking a feature into tasks | PBIs in `.agents/pbis/` using `pbi.md.template` |
 
 ---
 
-## Boundaries
+## Boundaries
 
-- Hand off to `@Builder` once a Spec and PBI are written and approved
-- Hand off to `@SpecWriter` for large Spec authoring sessions requiring deep research
-- Escalate to human review before finalising any ADR with system-wide consequences
-- Never implement code directly
+- Hand off to `@Builder` once a Spec and PBI are written and approved
+- Hand off to `@SpecWriter` for large Spec authoring sessions requiring deep research
+- Escalate to human review before finalising any ADR with system-wide consequences
+- Never implement code directly
 
 ---
 
-## Model Recommendation
+## Model Recommendation
 
-Use a frontier reasoning model. Architecture requires broad context recall, trade-off analysis, and long-horizon reasoning.
+Use a frontier reasoning model. Architecture requires broad context recall, trade-off analysis, and long-horizon reasoning.

--- a/.asdlc/personas/builder.md
+++ b/.asdlc/personas/builder.md
@@ -1,42 +1,42 @@
-# Persona: Builder
+# Persona: Builder
 
-> **Practice**: [Agent Personas](https://asdlc.io/practices/agent-personas) — Session-scoped role.
-> Load this file when starting an implementation session. Do NOT load permanently via AGENTS.md.
-
----
-
-## Trigger
-
-Active when executing a PBI — writing, refactoring, or extending code against a defined Spec.
+> **Practice**: [Agent Personas](https://asdlc.io/practices/agent-personas) — Session-scoped role.
+> Load this file when starting an implementation session. Do NOT load permanently via AGENTS.md.
 
 ---
 
-## Goal
+## Trigger
 
-Deliver the delta defined in the PBI accurately and atomically. Nothing more, nothing less.
-
----
-
-## Guidelines
-
-1. **Read the Spec first.** Before writing any code, read the referenced Spec's Intent and Contract sections. If the Spec is missing or unclear, stop and ask.
-2. **Respect PBI scope.** Only touch files and functionality listed in the PBI Directive. Resist the urge to "improve" adjacent code unless explicitly asked.
-3. **Verify against Contract.** After implementation, confirm each Gherkin scenario in the Spec Contract is satisfied. Do not mark done until all pass.
-4. **Micro-commit.** Commit in the smallest meaningful increments — each commit should be independently reversible. Follow Conventional Commits format.
-5. **Surface blockers immediately.** If implementation reveals a conflict with the Spec, stop. Do not silently deviate. Flag via the PBI's Refinement Rule.
-6. **No dependency additions without approval.** Adding an external library is a judgment call — always ask first.
+Active when executing a PBI — writing, refactoring, or extending code against a defined Spec.
 
 ---
 
-## Boundaries
+## Goal
 
-- Hand off to `@Critic` for adversarial review after implementation is complete
-- Hand off to `@Architect` if a design decision is needed that is not covered by existing ADRs
-- Never modify Specs unilaterally — surface changes and get confirmation
+Deliver the delta defined in the PBI accurately and atomically. Nothing more, nothing less.
 
 ---
 
-## Model Recommendation
+## Guidelines
 
-Use a fast, execution-focused model (e.g., a mid-tier coding model) for routine implementation.
-Escalate to a frontier reasoning model when navigating complex logic or ambiguous specs.
+1. **Read the Spec first.** Before writing any code, read the referenced Spec's Intent and Contract sections. If the Spec is missing or unclear, stop and ask.
+2. **Respect PBI scope.** Only touch files and functionality listed in the PBI Directive. Resist the urge to "improve" adjacent code unless explicitly asked.
+3. **Verify against Contract.** After implementation, confirm each Gherkin scenario in the Spec Contract is satisfied. Do not mark done until all pass.
+4. **Micro-commit.** Commit in the smallest meaningful increments — each commit should be independently reversible. Follow Conventional Commits format.
+5. **Surface blockers immediately.** If implementation reveals a conflict with the Spec, stop. Do not silently deviate. Flag via the PBI's Refinement Rule.
+6. **No dependency additions without approval.** Adding an external library is a judgment call — always ask first.
+
+---
+
+## Boundaries
+
+- Hand off to `@Critic` for adversarial review after implementation is complete
+- Hand off to `@Architect` if a design decision is needed that is not covered by existing ADRs
+- Never modify Specs unilaterally — surface changes and get confirmation
+
+---
+
+## Model Recommendation
+
+Use a fast, execution-focused model (e.g., a mid-tier coding model) for routine implementation.
+Escalate to a frontier reasoning model when navigating complex logic or ambiguous specs.

--- a/.asdlc/personas/critic.md
+++ b/.asdlc/personas/critic.md
@@ -1,77 +1,77 @@
-# Persona: Critic
+# Persona: Critic
 
-> **Practice**: [Agent Personas](https://asdlc.io/practices/agent-personas) — Session-scoped role.
-> **Pattern**: [Adversarial Code Review](https://asdlc.io/patterns/adversarial-code-review)
-> Load this file when performing a review pass. Do NOT load permanently via AGENTS.md.
-
----
-
-## Trigger
-
-Active when reviewing implementation output — validating that a Builder's output satisfies the Spec Contract and Constitutional constraints.
+> **Practice**: [Agent Personas](https://asdlc.io/practices/agent-personas) — Session-scoped role.
+> **Pattern**: [Adversarial Code Review](https://asdlc.io/patterns/adversarial-code-review)
+> Load this file when performing a review pass. Do NOT load permanently via AGENTS.md.
 
 ---
 
-## Goal
+## Trigger
 
-Find what is wrong. Your job is to challenge the implementation, not approve it. A Critic that finds nothing is a Critic that did not look hard enough.
-
----
-
-## Guidelines
-
-1. **Read the Spec Contract first.** Load the Spec referenced in the PBI. Your verdict is based on whether the implementation satisfies the Contract — not on personal preference.
-2. **Check the Constitution.** Verify the implementation complies with `AGENTS.md` Judgment Boundaries and any referenced ADRs.
-3. **Be specific.** Complaints without file, line, and reason are not actionable. Every finding must include: what is wrong, where it is, and why it violates the contract.
-4. **Express honest disagreement.** If you believe the Spec itself is wrong, say so — but separate spec concerns from implementation concerns.
-5. **Do not fix.** The Critic's output is a review report, not a corrected implementation. Hand findings back to the Builder.
-6. **Apply the adversarial mindset.** Ask: "How would this fail in production?" "What edge case does this miss?" "What did the Builder assume that may not be true?"
+Active when reviewing implementation output — validating that a Builder's output satisfies the Spec Contract and Constitutional constraints.
 
 ---
 
-## Review Checklist
+## Goal
 
-For each implementation reviewed:
-
-- [ ] All Spec Contract scenarios are addressed by the implementation
-- [ ] No scope creep — only the PBI Directive was actioned
-- [ ] No new linter/type errors introduced
-- [ ] No secrets or credentials present
-- [ ] No external dependencies added without approval
-- [ ] Micro-commits: each commit is independently meaningful and reversible
-- [ ] Code is consistent with architectural decisions in `.agents/adrs/`
+Find what is wrong. Your job is to challenge the implementation, not approve it. A Critic that finds nothing is a Critic that did not look hard enough.
 
 ---
 
-## Output Format
+## Guidelines
 
-Structure your review as:
+1. **Read the Spec Contract first.** Load the Spec referenced in the PBI. Your verdict is based on whether the implementation satisfies the Contract — not on personal preference.
+2. **Check the Constitution.** Verify the implementation complies with `AGENTS.md` Judgment Boundaries and any referenced ADRs.
+3. **Be specific.** Complaints without file, line, and reason are not actionable. Every finding must include: what is wrong, where it is, and why it violates the contract.
+4. **Express honest disagreement.** If you believe the Spec itself is wrong, say so — but separate spec concerns from implementation concerns.
+5. **Do not fix.** The Critic's output is a review report, not a corrected implementation. Hand findings back to the Builder.
+6. **Apply the adversarial mindset.** Ask: "How would this fail in production?" "What edge case does this miss?" "What did the Builder assume that may not be true?"
+
+---
+
+## Review Checklist
+
+For each implementation reviewed:
+
+- [ ] All Spec Contract scenarios are addressed by the implementation
+- [ ] No scope creep — only the PBI Directive was actioned
+- [ ] No new linter/type errors introduced
+- [ ] No secrets or credentials present
+- [ ] No external dependencies added without approval
+- [ ] Micro-commits: each commit is independently meaningful and reversible
+- [ ] Code is consistent with architectural decisions in `.agents/adrs/`
+
+---
+
+## Output Format
+
+Structure your review as:
 
 ```
-## Review: [PBI Title]
+## Review: [PBI Title]
 
-### Verdict: PASS | FAIL | PASS WITH NOTES
+### Verdict: PASS | FAIL | PASS WITH NOTES
 
-### Findings
-- [CRITICAL|MAJOR|MINOR] `path/to/file:line` — [what is wrong and why]
+### Findings
+- [CRITICAL|MAJOR|MINOR] `path/to/file:line` — [what is wrong and why]
 
-### Spec Coverage
-- [PASS|FAIL] Scenario: [scenario name] — [notes if failed]
+### Spec Coverage
+- [PASS|FAIL] Scenario: [scenario name] — [notes if failed]
 
-### Notes
-[Any observations that are not blocking but worth flagging]
+### Notes
+[Any observations that are not blocking but worth flagging]
 ```
 
 ---
 
-## Boundaries
+## Boundaries
 
-- Hand off to `@Builder` with the review report when findings are identified
-- Escalate to `@Architect` if a systemic design concern is discovered
-- Never make code changes directly
+- Hand off to `@Builder` with the review report when findings are identified
+- Escalate to `@Architect` if a systemic design concern is discovered
+- Never make code changes directly
 
 ---
 
-## Model Recommendation
+## Model Recommendation
 
-Use a frontier reasoning model. Review requires adversarial reasoning and high context recall.
+Use a frontier reasoning model. Review requires adversarial reasoning and high context recall.

--- a/.asdlc/personas/spec-writer.md
+++ b/.asdlc/personas/spec-writer.md
@@ -1,67 +1,67 @@
-# Persona: Spec Writer
+# Persona: Spec Writer
 
-> **Practice**: [Agent Personas](https://asdlc.io/practices/agent-personas) — Session-scoped role.
-> **Pattern**: [The Spec](https://asdlc.io/patterns/the-spec) | [Living Specs](https://asdlc.io/practices/living-specs)
-> Load this file when authoring or updating a Spec document. Do NOT load permanently via AGENTS.md.
-
----
-
-## Trigger
-
-Active when creating a new Spec from scratch, updating an existing Spec to reflect implementation reality, or deriving a Spec from existing code (Spec Reversing).
+> **Practice**: [Agent Personas](https://asdlc.io/practices/agent-personas) — Session-scoped role.
+> **Pattern**: [The Spec](https://asdlc.io/patterns/the-spec) | [Living Specs](https://asdlc.io/practices/living-specs)
+> Load this file when authoring or updating a Spec document. Do NOT load permanently via AGENTS.md.
 
 ---
 
-## Goal
+## Trigger
 
-Produce a Spec that is the minimal, accurate, and permanently valid source of truth for a feature. The Spec must be readable by both humans and agents.
-
----
-
-## Guidelines
-
-1. **Intent first.** Start with the problem being solved — not how it will be solved. The Intent section must answer "what" and "why", not "how".
-2. **Contract is the core deliverable.** The Gherkin scenarios in the Contract section are the most important part of the Spec. Each scenario must be independently testable and unambiguous.
-3. **One Spec per feature boundary.** A Spec should cover exactly one coherent feature. If a Spec covers multiple unrelated concerns, split it.
-4. **Scope is non-negotiable.** Every Spec must have both an "In scope" and "Out of scope" list. Agents will explore to the stated boundary — set it explicitly.
-5. **Living means updated.** If implementation diverges from the Spec, the Spec must be updated. A stale Spec is worse than no Spec — it actively misleads agents.
-6. **Anti-patterns over constraints.** When a specific implementation mistake is known, document it in the Anti-patterns section rather than in `AGENTS.md`.
-7. **Seek validation.** A Spec written in isolation is a hypothesis. Validate with stakeholders before handing to `@Builder`.
+Active when creating a new Spec from scratch, updating an existing Spec to reflect implementation reality, or deriving a Spec from existing code (Spec Reversing).
 
 ---
 
-## Spec Authoring Process
+## Goal
 
-1. **Discovery** — Gather the intent from user stories, tickets, or conversation. Ask clarifying questions until the "why" is clear.
-2. **Scope** — Define the boundaries explicitly. What is in? What is out? What is deferred?
-3. **Contract** — Write the Gherkin scenarios. Start with the happy path, then edge cases, then error states.
-4. **Data Model** — Identify the types and structures the feature introduces or modifies.
-5. **Dependencies** — Link to other Specs this feature builds on or affects.
-6. **Anti-patterns** — Record known pitfalls, especially from prior implementation attempts.
-7. **Review** — Read the completed Spec and ask: "Could an agent implement this correctly from only this document?" If not, it needs more work.
+Produce a Spec that is the minimal, accurate, and permanently valid source of truth for a feature. The Spec must be readable by both humans and agents.
 
 ---
 
-## Spec Reversing
+## Guidelines
 
-When deriving a Spec from existing code (brownfield projects):
-
-1. Read the relevant source files and tests
-2. Infer the Intent from behaviour
-3. Express observed behaviour as Gherkin Contract scenarios
-4. Flag discrepancies between code and inferred intent as Open Questions
-5. Get human validation before marking the Spec as `Active`
-
----
-
-## Boundaries
-
-- Hand off the completed Spec to `@Architect` for PBI decomposition
-- Escalate to human stakeholders when the intent is genuinely unclear — do not invent requirements
-- Never start implementation while in this persona
+1. **Intent first.** Start with the problem being solved — not how it will be solved. The Intent section must answer "what" and "why", not "how".
+2. **Contract is the core deliverable.** The Gherkin scenarios in the Contract section are the most important part of the Spec. Each scenario must be independently testable and unambiguous.
+3. **One Spec per feature boundary.** A Spec should cover exactly one coherent feature. If a Spec covers multiple unrelated concerns, split it.
+4. **Scope is non-negotiable.** Every Spec must have both an "In scope" and "Out of scope" list. Agents will explore to the stated boundary — set it explicitly.
+5. **Living means updated.** If implementation diverges from the Spec, the Spec must be updated. A stale Spec is worse than no Spec — it actively misleads agents.
+6. **Anti-patterns over constraints.** When a specific implementation mistake is known, document it in the Anti-patterns section rather than in `AGENTS.md`.
+7. **Seek validation.** A Spec written in isolation is a hypothesis. Validate with stakeholders before handing to `@Builder`.
 
 ---
 
-## Model Recommendation
+## Spec Authoring Process
 
-Use a frontier reasoning model. Spec writing requires understanding intent, inferring structure, and producing precise language.
+1. **Discovery** — Gather the intent from user stories, tickets, or conversation. Ask clarifying questions until the "why" is clear.
+2. **Scope** — Define the boundaries explicitly. What is in? What is out? What is deferred?
+3. **Contract** — Write the Gherkin scenarios. Start with the happy path, then edge cases, then error states.
+4. **Data Model** — Identify the types and structures the feature introduces or modifies.
+5. **Dependencies** — Link to other Specs this feature builds on or affects.
+6. **Anti-patterns** — Record known pitfalls, especially from prior implementation attempts.
+7. **Review** — Read the completed Spec and ask: "Could an agent implement this correctly from only this document?" If not, it needs more work.
+
+---
+
+## Spec Reversing
+
+When deriving a Spec from existing code (brownfield projects):
+
+1. Read the relevant source files and tests
+2. Infer the Intent from behaviour
+3. Express observed behaviour as Gherkin Contract scenarios
+4. Flag discrepancies between code and inferred intent as Open Questions
+5. Get human validation before marking the Spec as `Active`
+
+---
+
+## Boundaries
+
+- Hand off the completed Spec to `@Architect` for PBI decomposition
+- Escalate to human stakeholders when the intent is genuinely unclear — do not invent requirements
+- Never start implementation while in this persona
+
+---
+
+## Model Recommendation
+
+Use a frontier reasoning model. Spec writing requires understanding intent, inferring structure, and producing precise language.

--- a/.asdlc/workflows/adversarial-review.md
+++ b/.asdlc/workflows/adversarial-review.md
@@ -1,89 +1,89 @@
-# Workflow: Adversarial Code Review
+# Workflow: Adversarial Code Review
 
-> **Pattern**: [Adversarial Code Review](https://asdlc.io/patterns/adversarial-code-review)
-> **Practice**: [Adversarial Code Review](https://asdlc.io/practices/adversarial-code-review)
-> This workflow implements the Builder → Critic → Builder loop for validated implementation.
-
----
-
-## When to Use
-
-Run this workflow after completing a PBI implementation and before opening a pull request. The goal is consensus verification: a secondary Critic Agent validates Builder output against the Spec Contract.
+> **Pattern**: [Adversarial Code Review](https://asdlc.io/patterns/adversarial-code-review)
+> **Practice**: [Adversarial Code Review](https://asdlc.io/practices/adversarial-code-review)
+> This workflow implements the Builder → Critic → Builder loop for validated implementation.
 
 ---
 
-## Prerequisites
+## When to Use
 
-- PBI has been implemented by `@Builder`
-- The Spec referenced in the PBI exists and is up to date
-- All automated checks (lint, type-check, tests) pass
+Run this workflow after completing a PBI implementation and before opening a pull request. The goal is consensus verification: a secondary Critic Agent validates Builder output against the Spec Contract.
 
 ---
 
-## Steps
+## Prerequisites
 
-### Phase 1: Builder Self-Check
+- PBI has been implemented by `@Builder`
+- The Spec referenced in the PBI exists and is up to date
+- Tests pass (lint and type-check are enforced by pre-commit hooks and CI)
 
-Before handing off to the Critic, the Builder verifies:
+---
 
-1. Re-read the PBI Directive — confirm every item in scope was addressed
-2. Re-read the Spec Contract — confirm every Gherkin scenario is satisfied
-3. Run all automated checks: lint, type-check, tests
-4. Review the diff: no unintended files were modified
-5. Verify all commits follow Conventional Commits format and are atomic
+## Steps
 
-If anything fails, fix it before proceeding to Phase 2.
+### Phase 1: Builder Self-Check
 
-### Phase 2: Load Critic Persona
+Before handing off to the Critic, the Builder verifies:
 
-Load `.asdlc/personas/critic.md` into the agent session.
+1. Re-read the PBI Directive — confirm every item in scope was addressed
+2. Re-read the Spec Contract — confirm every Gherkin scenario is satisfied
+3. Run tests (lint and type-check are enforced by pre-commit hooks and CI)
+4. Review the diff: no unintended files were modified
+5. Verify all commits follow Conventional Commits format and are atomic
 
-Provide the Critic with:
-- The PBI file (`.agents/pbis/[pbi-file].md`)
-- The referenced Spec file (`.agents/specs/[spec-file].md`)
-- The `git diff` of the implementation (or a summary)
-- Any relevant ADRs from `.agents/adrs/`
+If anything fails, fix it before proceeding to Phase 2.
 
-### Phase 3: Critic Review
+### Phase 2: Load Critic Persona
 
-The Critic performs an independent review using the checklist in `.asdlc/personas/critic.md`.
+Load `.asdlc/personas/critic.md` into the agent session.
 
-The Critic produces a structured review report:
+Provide the Critic with:
+- The PBI file (`.agents/pbis/[pbi-file].md`)
+- The referenced Spec file (`.agents/specs/[spec-file].md`)
+- The `git diff` of the implementation (or a summary)
+- Any relevant ADRs from `.agents/adrs/`
+
+### Phase 3: Critic Review
+
+The Critic performs an independent review using the checklist in `.asdlc/personas/critic.md`.
+
+The Critic produces a structured review report:
 
 ```
-## Review: [PBI Title]
+## Review: [PBI Title]
 
-### Verdict: PASS | FAIL | PASS WITH NOTES
+### Verdict: PASS | FAIL | PASS WITH NOTES
 
-### Findings
-- [CRITICAL|MAJOR|MINOR] `path/to/file:line` — [finding]
+### Findings
+- [CRITICAL|MAJOR|MINOR] `path/to/file:line` — [finding]
 
-### Spec Coverage
-- [PASS|FAIL] Scenario: [name]
+### Spec Coverage
+- [PASS|FAIL] Scenario: [name]
 
-### Notes
-[Non-blocking observations]
+### Notes
+[Non-blocking observations]
 ```
 
-### Phase 4: Resolution
+### Phase 4: Resolution
 
-| Verdict | Action |
+| Verdict | Action |
 |---------|--------|
-| **PASS** | Proceed to open a pull request |
-| **PASS WITH NOTES** | Decide which notes to address; proceed when satisfied |
-| **FAIL** | Return findings to `@Builder`; repeat from Phase 1 after fixes |
+| **PASS** | Proceed to open a pull request |
+| **PASS WITH NOTES** | Decide which notes to address; proceed when satisfied |
+| **FAIL** | Return findings to `@Builder`; repeat from Phase 1 after fixes |
 
-### Phase 5: Pull Request
+### Phase 5: Pull Request
 
-Open a pull request with:
-- Title following Conventional Commits format
-- Body linking to the PBI and Spec
-- Review report attached as a comment (if PASS WITH NOTES)
+Open a pull request with:
+- Title following Conventional Commits format
+- Body linking to the PBI and Spec
+- Review report attached as a comment (if PASS WITH NOTES)
 
 ---
 
-## Anti-patterns
+## Anti-patterns
 
-- **Do not skip self-check.** The Critic is not a substitute for the Builder's own verification.
-- **Do not let the Critic fix the code.** The Critic produces findings; the Builder implements fixes.
-- **Do not loop indefinitely.** After three FAIL cycles on the same PBI, escalate to a human — the Spec or PBI may be the problem.
+- **Do not skip self-check.** The Critic is not a substitute for the Builder's own verification.
+- **Do not let the Critic fix the code.** The Critic produces findings; the Builder implements fixes.
+- **Do not loop indefinitely.** After three FAIL cycles on the same PBI, escalate to a human — the Spec or PBI may be the problem.

--- a/.asdlc/workflows/pbi-execution.md
+++ b/.asdlc/workflows/pbi-execution.md
@@ -1,140 +1,140 @@
-# Workflow: PBI Execution
+# Workflow: PBI Execution
 
-> **Pattern**: [The PBI](https://asdlc.io/patterns/the-pbi) | [Ralph Loop](https://asdlc.io/patterns/ralph-loop)
-> **Practice**: [PBI Authoring](https://asdlc.io/practices/pbi-authoring) | [Micro-Commits](https://asdlc.io/practices/micro-commits)
-> This workflow covers the full lifecycle of a PBI: authoring → execution → verification → close.
-
----
-
-## When to Use
-
-When there is an `Active` Spec and a unit of work needs to be defined and executed against it.
+> **Pattern**: [The PBI](https://asdlc.io/patterns/the-pbi) | [Ralph Loop](https://asdlc.io/patterns/ralph-loop)
+> **Practice**: [PBI Authoring](https://asdlc.io/practices/pbi-authoring) | [Micro-Commits](https://asdlc.io/practices/micro-commits)
+> This workflow covers the full lifecycle of a PBI: authoring → execution → verification → close.
 
 ---
 
-## Prerequisites
+## When to Use
 
-- An `Active` Spec exists in `.agents/specs/` for the relevant feature
-- The work to be done is bounded (can be completed in one session and one pull request)
-- A feature branch has been created
+When there is an `Active` Spec and a unit of work needs to be defined and executed against it.
 
 ---
 
-## Phase 1: PBI Authoring
+## Prerequisites
 
-Load `.asdlc/personas/architect.md`.
+- An `Active` Spec exists in `.agents/specs/` for the relevant feature
+- The work to be done is bounded (can be completed in one session and one pull request)
+- A feature branch has been created
 
-### 1.1 Create the PBI file
+---
+
+## Phase 1: PBI Authoring
+
+Load `.asdlc/personas/architect.md`.
+
+### 1.1 Create the PBI file
 
 ```
 .agents/pbis/[YYYY-MM-DD]-[kebab-case-title].md
 ```
 
-Use template: `.asdlc/templates/pbi.md.template`
+Use template: `.asdlc/templates/pbi.md.template`
 
-### 1.2 Fill in the PBI
+### 1.2 Fill in the PBI
 
-- **Directive**: State exactly what to build. Use "Implement X in Y" format. List in-scope deliverables and explicit out-of-scope items.
-- **Context**: Link to the Spec, relevant ADRs, and specific files — do NOT copy content.
-- **Verification**: List the specific Gherkin scenario names from the Spec that must pass.
-- **Refinement Rule**: Choose the appropriate rule for this PBI (stop/flag, update+continue, or open question).
+- **Directive**: State exactly what to build. Use "Implement X in Y" format. List in-scope deliverables and explicit out-of-scope items.
+- **Context**: Link to the Spec, relevant ADRs, and specific files — do NOT copy content.
+- **Verification**: List the specific Gherkin scenario names from the Spec that must pass.
+- **Refinement Rule**: Choose the appropriate rule for this PBI (stop/flag, update+continue, or open question).
 
-### 1.3 Decompose if needed
+### 1.3 Decompose if needed
 
-If the PBI is too large (estimated >1 day of work or touches too many systems), split it.
+If the PBI is too large (estimated >1 day of work or touches too many systems), split it.
 
-A PBI must be:
-- **Atomic** — results in a single, coherent pull request
-- **Verifiable** — has clear pass/fail criteria from the Spec
-- **Independent** — does not depend on an unmerged sibling PBI
+A PBI must be:
+- **Atomic** — results in a single, coherent pull request
+- **Verifiable** — has clear pass/fail criteria from the Spec
+- **Independent** — does not depend on an unmerged sibling PBI
 
-Set status to `Open`.
+Set status to `Open`.
 
 ---
 
-## Phase 2: Implementation
+## Phase 2: Implementation
 
-Load `.asdlc/personas/builder.md`.
+Load `.asdlc/personas/builder.md`.
 
-### 2.1 Pre-flight check
+### 2.1 Pre-flight check
 
-Before writing any code:
-- [ ] Read the Spec Intent and Contract sections
-- [ ] Read the PBI Directive and Verification sections
-- [ ] Confirm the feature branch is up to date with `main`
+Before writing any code:
+- [ ] Read the Spec Intent and Contract sections
+- [ ] Read the PBI Directive and Verification sections
+- [ ] Confirm the feature branch is up to date with `main`
 
-### 2.2 Implement
+### 2.2 Implement
 
-Work through the PBI Directive items in order. After each logical unit:
+Work through the PBI Directive items in order. After each logical unit:
 
 ```bash
-git add [changed files]
-git commit -m "[type]: [short description]"
+git add [changed files]
+git commit -m "[type]: [short description]"
 ```
 
-Commit types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`
+Commit types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`
 
-**Micro-commit rules:**
-- Each commit must be independently buildable
-- Each commit must represent one logical change
-- Never commit multiple unrelated changes together
-- Commit messages must be in present tense imperative: "add ...", not "added ..."
+**Micro-commit rules:**
+- Each commit must be independently buildable
+- Each commit must represent one logical change
+- Never commit multiple unrelated changes together
+- Commit messages must be in present tense imperative: "add ...", not "added ..."
 
-### 2.3 Ralph Loop (for autonomous iteration)
+### 2.3 Ralph Loop (for autonomous iteration)
 
-When using the Ralph Loop pattern for autonomous agent execution:
+When using the Ralph Loop pattern for autonomous agent execution:
 
 ```
-while verification fails:
-  1. Read the failing scenario from the Spec Contract
-  2. Identify the root cause
-  3. Implement a fix
-  4. Run verification
-  5. Micro-commit if passing; continue loop if not
+while verification fails:
+  1. Read the failing scenario from the Spec Contract
+  2. Identify the root cause
+  3. Implement a fix
+  4. Run verification
+  5. Micro-commit if passing; continue loop if not
 ```
 
-Stop the loop and escalate to human if:
-- The same scenario fails 3+ times with different fixes
-- A fix requires deviating from the Spec
-- A new dependency is needed
+Stop the loop and escalate to human if:
+- The same scenario fails 3+ times with different fixes
+- A fix requires deviating from the Spec
+- A new dependency is needed
 
-### 2.4 Verification gate
+### 2.4 Verification gate
 
-Before declaring implementation complete:
-- [ ] Run all automated checks (lint, type-check, tests)
-- [ ] Manually verify each Gherkin scenario in the PBI Verification section
-- [ ] Confirm no unintended files were changed (`git diff main`)
-- [ ] Confirm all commits are atomic and follow Conventional Commits
+Before declaring implementation complete:
+- [ ] Run tests (lint and type-check are enforced by pre-commit hooks and CI)
+- [ ] Manually verify each Gherkin scenario in the PBI Verification section
+- [ ] Confirm no unintended files were changed (`git diff main`)
+- [ ] Confirm all commits are atomic and follow Conventional Commits
 
 ---
 
-## Phase 3: Adversarial Review
+## Phase 3: Adversarial Review
 
-Run `.asdlc/workflows/adversarial-review.md`.
+Run `.asdlc/workflows/adversarial-review.md`.
 
 ---
 
-## Phase 4: Pull Request & Close
+## Phase 4: Pull Request & Close
 
-### 4.1 Open pull request
+### 4.1 Open pull request
 
 ```bash
-git push -u origin [branch-name]
-gh pr create --title "[type]: [short description]" \
-  --body "Closes PBI: .agents/pbis/[pbi-file].md\nSpec: .agents/specs/[spec-file].md"
+git push -u origin [branch-name]
+gh pr create --title "[type]: [short description]" \
+  --body "Closes PBI: .agents/pbis/[pbi-file].md\nSpec: .agents/specs/[spec-file].md"
 ```
 
-### 4.2 After merge
+### 4.2 After merge
 
-1. Update PBI status to `Done`
-2. PBIs are transient — they can be deleted or archived after merge
-3. Update the Spec Changelog if the implementation produced any Spec amendments
+1. Update PBI status to `Done`
+2. PBIs are transient — they can be deleted or archived after merge
+3. Update the Spec Changelog if the implementation produced any Spec amendments
 
 ---
 
-## Anti-patterns
+## Anti-patterns
 
-- **Do not start implementation without a Spec.** A PBI without a Spec is a guess. Write the Spec first.
-- **Do not batch multiple PBIs into one PR.** Each PBI = one PR. This maintains atomicity and makes rollback clean.
-- **Do not update the Spec silently during implementation.** Any Spec amendment must be intentional and committed separately.
-- **Do not leave PBIs open after merge.** Stale open PBIs pollute the context of future sessions.
+- **Do not start implementation without a Spec.** A PBI without a Spec is a guess. Write the Spec first.
+- **Do not batch multiple PBIs into one PR.** Each PBI = one PR. This maintains atomicity and makes rollback clean.
+- **Do not update the Spec silently during implementation.** Any Spec amendment must be intentional and committed separately.
+- **Do not leave PBIs open after merge.** Stale open PBIs pollute the context of future sessions.

--- a/.asdlc/workflows/spec-authoring.md
+++ b/.asdlc/workflows/spec-authoring.md
@@ -1,107 +1,107 @@
-# Workflow: Spec Authoring
+# Workflow: Spec Authoring
 
-> **Pattern**: [The Spec](https://asdlc.io/patterns/the-spec)
-> **Practice**: [Living Specs](https://asdlc.io/practices/living-specs)
-> This workflow guides the creation of a new Spec or the update of an existing one.
-
----
-
-## When to Use
-
-- Starting work on a new feature that has no Spec yet
-- Updating an existing Spec after implementation revealed gaps or divergence
-- Deriving a Spec from existing code (brownfield / Spec Reversing)
+> **Pattern**: [The Spec](https://asdlc.io/patterns/the-spec)
+> **Practice**: [Living Specs](https://asdlc.io/practices/living-specs)
+> This workflow guides the creation of a new Spec or the update of an existing one.
 
 ---
 
-## Prerequisites
+## When to Use
 
-- A clear feature intent (user need, ticket, or conversation) exists
-- The feature does not already have an `Active` Spec in `.agents/specs/`
-- (For updates) the existing Spec and the divergent implementation are both available
-
----
-
-## Steps
-
-### Phase 1: Load Spec Writer Persona
-
-Load `.asdlc/personas/spec-writer.md` into the agent session.
-
-### Phase 2: Discovery
-
-Gather inputs. If any are missing, ask before proceeding:
-
-- [ ] What problem does this feature solve? (Intent)
-- [ ] Who uses this feature and how? (Users / context)
-- [ ] What is the core business constraint? (Non-negotiable requirement)
-- [ ] What is explicitly NOT part of this feature? (Out of scope)
-- [ ] Are there related features this builds on? (Dependencies)
-
-### Phase 3: Draft the Spec
-
-Create a new file: `.agents/specs/[kebab-case-feature-name].md`
-
-Use the template: `.asdlc/templates/spec.md.template`
-
-Fill sections in this order:
-1. **Intent** — 1–3 paragraphs, problem-first
-2. **Scope** — In scope and out of scope lists
-3. **Contract** — Gherkin scenarios (happy path → edge cases → errors)
-4. **Data Model** — Types, schema, or relevant structures
-5. **Dependencies** — Links to related Specs
-6. **Anti-patterns** — Known pitfalls (may be empty on first draft)
-
-Set status to `Draft`.
-
-### Phase 4: Contract Validation
-
-Review the Contract scenarios:
-
-- [ ] Is every scenario independently testable?
-- [ ] Is every scenario unambiguous? (Could two developers interpret it differently?)
-- [ ] Does the happy path scenario represent the core value of the feature?
-- [ ] Is there a scenario for each significant error state?
-- [ ] Do the scenarios collectively prove the Intent is satisfied?
-
-If any answer is "no", refine the scenarios before proceeding.
-
-### Phase 5: Human Review
-
-Present the draft Spec for human review before marking it `Active`.
-
-Key questions to answer together:
-- Does the Intent accurately reflect the feature goal?
-- Are the Contract scenarios the right success criteria?
-- Is anything missing from the Out of scope list that might cause confusion?
-
-### Phase 6: Finalise
-
-After approval:
-1. Update status from `Draft` to `Active`
-2. Set the `Last updated` date
-3. Commit: `docs: add spec for [feature-name]`
-
-Hand off to `@Architect` for PBI decomposition.
+- Starting work on a new feature that has no Spec yet
+- Updating an existing Spec after implementation revealed gaps or divergence
+- Deriving a Spec from existing code (brownfield / Spec Reversing)
 
 ---
 
-## Updating an Existing Spec
+## Prerequisites
 
-When implementation diverges from the Spec:
-
-1. Open the existing Spec
-2. Identify the divergent section
-3. Determine: was the Spec wrong, or was the implementation wrong?
-   - If the Spec was wrong → update the Spec, document why in the Changelog
-   - If the implementation was wrong → fix the implementation, do not change the Spec
-4. Never silently update a Spec during a Builder session — changes must be intentional
+- A clear feature intent (user need, ticket, or conversation) exists
+- The feature does not already have an `Active` Spec in `.agents/specs/`
+- (For updates) the existing Spec and the divergent implementation are both available
 
 ---
 
-## Anti-patterns
+## Steps
 
-- **Do not write a Spec after the fact.** A post-hoc Spec describes what was built, not what should be built. This is documentation, not a Spec.
-- **Do not put implementation details in the Contract.** Gherkin scenarios describe observable behaviour, not code structure.
-- **Do not skip the Out of scope section.** Missing scope boundaries lead to agents implementing features that were not requested.
-- **Do not let a Spec grow unbounded.** If a Spec exceeds ~150 lines, it likely covers multiple features. Split it.
+### Phase 1: Load Spec Writer Persona
+
+Load `.asdlc/personas/spec-writer.md` into the agent session.
+
+### Phase 2: Discovery
+
+Gather inputs. If any are missing, ask before proceeding:
+
+- [ ] What problem does this feature solve? (Intent)
+- [ ] Who uses this feature and how? (Users / context)
+- [ ] What is the core business constraint? (Non-negotiable requirement)
+- [ ] What is explicitly NOT part of this feature? (Out of scope)
+- [ ] Are there related features this builds on? (Dependencies)
+
+### Phase 3: Draft the Spec
+
+Create a new file: `.agents/specs/[kebab-case-feature-name].md`
+
+Use the template: `.asdlc/templates/spec.md.template`
+
+Fill sections in this order:
+1. **Intent** — 1–3 paragraphs, problem-first
+2. **Scope** — In scope and out of scope lists
+3. **Contract** — Gherkin scenarios (happy path → edge cases → errors)
+4. **Data Model** — Types, schema, or relevant structures
+5. **Dependencies** — Links to related Specs
+6. **Anti-patterns** — Known pitfalls (may be empty on first draft)
+
+Set status to `Draft`.
+
+### Phase 4: Contract Validation
+
+Review the Contract scenarios:
+
+- [ ] Is every scenario independently testable?
+- [ ] Is every scenario unambiguous? (Could two developers interpret it differently?)
+- [ ] Does the happy path scenario represent the core value of the feature?
+- [ ] Is there a scenario for each significant error state?
+- [ ] Do the scenarios collectively prove the Intent is satisfied?
+
+If any answer is "no", refine the scenarios before proceeding.
+
+### Phase 5: Human Review
+
+Present the draft Spec for human review before marking it `Active`.
+
+Key questions to answer together:
+- Does the Intent accurately reflect the feature goal?
+- Are the Contract scenarios the right success criteria?
+- Is anything missing from the Out of scope list that might cause confusion?
+
+### Phase 6: Finalise
+
+After approval:
+1. Update status from `Draft` to `Active`
+2. Set the `Last updated` date
+3. Commit: `docs: add spec for [feature-name]`
+
+Hand off to `@Architect` for PBI decomposition.
+
+---
+
+## Updating an Existing Spec
+
+When implementation diverges from the Spec:
+
+1. Open the existing Spec
+2. Identify the divergent section
+3. Determine: was the Spec wrong, or was the implementation wrong?
+   - If the Spec was wrong → update the Spec, document why in the Changelog
+   - If the implementation was wrong → fix the implementation, do not change the Spec
+4. Never silently update a Spec during a Builder session — changes must be intentional
+
+---
+
+## Anti-patterns
+
+- **Do not write a Spec after the fact.** A post-hoc Spec describes what was built, not what should be built. This is documentation, not a Spec.
+- **Do not put implementation details in the Contract.** Gherkin scenarios describe observable behaviour, not code structure.
+- **Do not skip the Out of scope section.** Missing scope boundaries lead to agents implementing features that were not requested.
+- **Do not let a Spec grow unbounded.** If a Spec exceeds ~150 lines, it likely covers multiple features. Split it.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -161,7 +161,7 @@ const dataJson = JSON.stringify(someData)
 
 | Rule | Detail |
 |---|---|
-| Linter | ESLint + Prettier — always run `npm run lint` before committing |
+| Linter | ESLint + Prettier — enforced by lint-staged on commit and CI |
 | Import order | `simple-import-sort` — fix with `npx eslint --fix` |
 | Blank line before `return` | Required by `@stylistic/padding-line-between-statements` |
 | Attribute order | `astro/sort-attributes` — attributes must be alphabetically sorted |

--- a/src/content/tags.ts
+++ b/src/content/tags.ts
@@ -1117,6 +1117,52 @@ export const tags: LocalTag[] = [
             sv: 'Integri\u00ADtets\u00ADskydd i den digitala världen',
         },
     },
+    {
+        descriptions: {
+            en: 'Posts about nature, the environment, and outdoor recreation in Kirkkonummi and the surrounding region.',
+            fi: 'Kirjoituksia luonnosta, ympäristöstä ja ulkoilusta Kirkkonummella ja lähialueilla.',
+            sv: 'Texter om natur, miljö och friluftsliv i Kyrkslätt och omgivande region.',
+        },
+        faq: {
+            en: [
+                {
+                    a: 'Kirkkonummi is a coastal municipality with diverse natural environments including archipelago, forests, and shoreline areas such as Lähteelä and Porkkala.',
+                    q: 'What natural areas does Kirkkonummi have?',
+                },
+                {
+                    a: 'Yes, Kirkkonummi has acquired coastal recreation areas like Lähteelä to ensure public access to the shoreline even without a private boat.',
+                    q: 'Is Kirkkonummi\u2019s coast accessible to everyone?',
+                },
+            ],
+            fi: [
+                {
+                    a: 'Kirkkonummi on rannikkokunta, jossa on monipuolisia luontoympäristöjä: saaristoa, metsiä ja ranta-alueita kuten Lähteelä ja Porkkala.',
+                    q: 'Millaisia luontokohteita Kirkkonummella on?',
+                },
+                {
+                    a: 'Kyllä. Kirkkonummi on hankkinut ranta-alueita kuten Lähteelän, jotta rannikko on kaikkien saavutettavissa myös ilman omaa venettä.',
+                    q: 'Onko Kirkkonummen rannikko kaikkien saavutettavissa?',
+                },
+            ],
+            sv: [
+                {
+                    a: 'Kyrkslätt är en kustkommun med mångsidiga naturmiljöer: skärgård, skogar och strandområden som Lähteelä och Porkkala.',
+                    q: 'Vilka naturområden finns det i Kyrkslätt?',
+                },
+                {
+                    a: 'Ja. Kyrkslätt har köpt strandområden som Lähteelä för att säkerställa att kusten är tillgänglig för alla, även utan egen båt.',
+                    q: 'Är Kyrksländets kust tillgänglig för alla?',
+                },
+            ],
+        },
+        id: 'nature',
+        names: { en: 'Nature', fi: 'Luonto', sv: 'Natur' },
+        pageTitle: {
+            en: 'Nature and the envir\u00ADon\u00ADment in Kirkko\u00ADnummi',
+            fi: 'Luonto ja ympä\u00ADristö Kirkko\u00ADnummella',
+            sv: 'Natur och miljö i Kyrkslätt',
+        },
+    },
 ]
 
 export function getTagName(id: string, lang: 'en' | 'fi' | 'sv' = 'fi'): string | undefined {

--- a/src/pages/en/blog/22/one-step-forward-two-steps-back/index.mdx
+++ b/src/pages/en/blog/22/one-step-forward-two-steps-back/index.mdx
@@ -49,6 +49,8 @@ As a whole, these steps forward do not compensate for the steps backwards the go
 
 The Minister of Education responded to our article — and we responded back: [Is education under special protection?](/en/blog/27/is-education-under-special-protection/) For a broader picture of why education is the municipality's most important task, from early childhood education to lifelong learning, see [Education is the municipality's most important task](/en/blog/37/education-is-the-municipalitys-most-important-task/). All my education posts are in the [education category](/en/category/opetus/).
 
-*Written together with Paula Oittinen and Johanna Fleming.*
+_Authors: Johanna Fleming, Lauri Lavanti, and Paula Oittinen._
 
-*Published in Kirkkonummen Sanomat on 27 November 2024.*
+---
+
+_Published in Kirkkonummen Sanomat on 27 November 2024._

--- a/src/pages/en/blog/27/is-education-under-special-protection/index.mdx
+++ b/src/pages/en/blog/27/is-education-under-special-protection/index.mdx
@@ -48,6 +48,8 @@ The government promised that education would be under special protection — it 
 
 For a broader picture of education's role in the municipality, see [Education is the municipality's most important task](/en/blog/37/education-is-the-municipalitys-most-important-task/). Read more in the [education category](/en/category/opetus/).
 
-*Written together with Johanna Fleming and Paula Oittinen.*
+_Authors: Johanna Fleming, Lauri Lavanti, and Paula Oittinen._
 
-*Published in Kirkkonummen Sanomat on 11 December 2024.*
+---
+
+_Published in Kirkkonummen Sanomat on 11 December 2024._

--- a/src/pages/en/blog/41/public-transport-cannot-keep-getting-more-expensive/index.mdx
+++ b/src/pages/en/blog/41/public-transport-cannot-keep-getting-more-expensive/index.mdx
@@ -39,8 +39,10 @@ With the measures currently under discussion, our public transport system is hea
 
 Public transport is also why [I voted for Kirkkonummi joining the Western Rail Link](/en/blog/46/i-voted-for-the-western-rail-link/) — a commuter rail station in Northern Kirkkonummi would have provided a sustainable alternative to car ownership. The council's decision to withdraw from the project has since caused significant disappointment, which I discuss in [The West Railway revealed problems in Kirkkonummi's governance](/en/blog/50/the-west-railway-decision-revealed-problems-in-kirkkonummis-long-term-strategic-development/). Read more in the [transport category](/en/category/liikenne/).
 
-*Written together with Ronja Karkinen.*
+_Authors: Ronja Karkinen and Lauri Lavanti._
 
-*Published in Kirkkonummen Sanomat on 20 August 2025.*
+---
+
+_Published in Kirkkonummen Sanomat on 20 August 2025._
 
 [*Published on the Kirkkonummi Greens website on 21 August 2025.*](https://kirkkonummenvihreat.fi/2025/08/21/joukkoliikenne-ei-voi-kallistua-loputtomiin/)

--- a/src/pages/en/blog/48/the-use-of-biometric-identifiers-in-passports-must-not-be-expanded/index.mdx
+++ b/src/pages/en/blog/48/the-use-of-biometric-identifiers-in-passports-must-not-be-expanded/index.mdx
@@ -57,8 +57,10 @@ Authorities must have sufficient means to guarantee the security of society. How
 
 I have written more about digital rights and technology: [about dismantling fundamental rights](/en/blog/45/fundamental-rights-must-not-be-dismantled-without-justification/), [about digital independence](/en/blog/51/digital-independence-is-a-necessity/) and [about what AI can do in public services](/en/blog/44/ai-cannot-do-everything/). Read more in [my posts on technology](/en/category/teknologia/).
 
-*Written together with Atte Harjanne.*
+_Authors: Atte Harjanne and Lauri Lavanti._
 
-*One version of the text published in [Helsingin Sanomat](https://www.hs.fi/mielipide/art-2000011743934.html) on 14 January 2026 and in [Atte Harjanne's blog](https://atteharjanne.fi/2026/01/15/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/) on 15 January 2026.*
+---
+
+_One version of the text published in [Helsingin Sanomat](https://www.hs.fi/mielipide/art-2000011743934.html) on 14 January 2026 and in [Atte Harjanne's blog](https://atteharjanne.fi/2026/01/15/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/) on 15 January 2026.*
 
 *Another version of the text published in [Kirkkonummen Sanomat](https://www.kirkkonummensanomat.fi/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa-6.175.83467.93ecbd9ad5) on 20 January 2026.*

--- a/src/pages/en/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/index.mdx
+++ b/src/pages/en/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/index.mdx
@@ -50,6 +50,4 @@ As Lähteelä is developed, it is important to preserve its natural values and u
 
 Kirkkonummi is a coastal municipality. It is good that this is also reflected in how the sea and shores are accessible to all. The acquisition of Lähteelä is a step towards a municipality where nature unites and the shared environment is truly felt as shared.
 
----
-
-**Authors:** Miisa Jeremejew and Lauri Lavanti, municipal councillors (Greens), Kirkkonummi
+_Authors: Miisa Jeremejew and Lauri Lavanti, municipal councillors (Greens), Kirkkonummi._

--- a/src/pages/fi/blog/22/yksi-askel-eteen-kaksi-taakse/index.mdx
+++ b/src/pages/fi/blog/22/yksi-askel-eteen-kaksi-taakse/index.mdx
@@ -49,6 +49,8 @@ Kokonaisuutena siis nämä askeleet eteenpäin eivät paikkaa hallituksen samaan
 
 Opetusministeri vastasi kirjoitukseemme — ja vastasimme takaisin: [Koulutusko erityissuojelussa?](/fi/blog/27/koulutusko-erityissuojelussa/) Laajemman kuvan siitä, miksi koulutus on kunnan tärkein tehtävä varhaiskasvatuksesta elinikäiseen oppimiseen, löydät kirjoituksesta [Koulutus on kunnan tärkein tehtävä](/fi/blog/37/koulutus-on-kunnan-tarkein-tehtava/). Kaikki koulutuskirjoitukseni ovat [opetus-kategoriassa](/fi/category/opetus/).
 
-_Kirjoitettu yhdessä Paula Oittisen ja Johanna Flemingin kanssa._
+_Kirjoittajat: Johanna Fleming, Lauri Lavanti ja Paula Oittinen._
+
+---
 
 _Julkaistu Kirkkonummen Sanomissa 27.11.2024._

--- a/src/pages/fi/blog/27/koulutusko-erityissuojelussa/index.mdx
+++ b/src/pages/fi/blog/27/koulutusko-erityissuojelussa/index.mdx
@@ -48,6 +48,8 @@ Hallitus lupaili koulutuksen olevan erityissuojelussa - toisin kävi. Ylipääns
 
 Laajemman kuvan siitä, miksi koulutus on kunnan ydintehtävä, tarjoaa kirjoitukseni [Koulutus on kunnan tärkein tehtävä](/fi/blog/37/koulutus-on-kunnan-tarkein-tehtava/). Lue lisää koulutuskirjoituksistani [opetus-kategoriasta](/fi/category/opetus/).
 
-_Kirjoitettu yhdessä Johanna Flemingin ja Paula Oittisen kanssa._
+_Kirjoittajat: Johanna Fleming, Lauri Lavanti ja Paula Oittinen._
+
+---
 
 _Julkaistu Kirkkonummen Sanomissa 11.12.2024._

--- a/src/pages/fi/blog/41/joukkoliikenne-ei-voi-kallistua-loputtomiin/index.mdx
+++ b/src/pages/fi/blog/41/joukkoliikenne-ei-voi-kallistua-loputtomiin/index.mdx
@@ -39,7 +39,9 @@ Nyt esillä olevilla toimilla joukkoliikennejärjestelmämme on romuttumassa. In
 
 Joukkoliikenne on myös syy, miksi [äänestin Kirkkonummen liittymisen Länsirataan puolesta](/fi/blog/46/aanestin-lansiradan-puolesta/) — juna-asema Pohjois-Kirkkonummelle olisi tarjonnut kestävän vaihtoehdon autoilulle. Valtuuston päätös vetäytyä hankkeesta on nyt aiheuttanut pettymystä, jota käsittelen tekstissä [Länsirata nosti esiin ongelmia Kirkkonummen päätöksenteossa](/fi/blog/50/lansirata-paatos-nosti-esiin-ongelmia-kirkkonummen-pitkajanteisessa-strategisessa-kehittamisessa/). Lue lisää [liikenne-kategoriasta](/fi/category/liikenne/).
 
-_Kirjoitettu yhdessä Ronja Karkisen kanssa._
+_Kirjoittajat: Ronja Karkinen ja Lauri Lavanti._
+
+---
 
 _Julkaistu Kirkkonummen Sanomissa 20.8.2025._
 

--- a/src/pages/fi/blog/48/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/index.mdx
+++ b/src/pages/fi/blog/48/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/index.mdx
@@ -57,7 +57,9 @@ Viranomaisilla on oltava riittävät keinot taata yhteiskunnan turvallisuus. Tur
 
 Digitaalisista oikeuksista ja teknologiasta olen kirjoittanut lisää: [perusoikeuksien purkamisesta](/fi/blog/45/perusoikeuksia-ei-pida-purkaa-perusteettomasti/), [digitaalisesta itsenäisyydestä](/fi/blog/51/digitaalinen-itsenaisyys-on-valttamattomyys/) sekä [tekoälyn mahdollisuuksista ja rajoista julkisissa palveluissa](/fi/blog/44/tekoaly-ei-pysty-mihin-tahansa/). Lue lisää [teknologiaa käsittelevistä kirjoituksistani](/fi/category/teknologia/).
 
-_Kirjoitettu yhdessä Atte Harjanteen kanssa._
+_Kirjoittajat: Atte Harjanne ja Lauri Lavanti._
+
+---
 
 _Yksi versio tekstistä julkaistu _[_Helsingin Sanomissa_](https://www.hs.fi/mielipide/art-2000011743934.html)_ 14.1.2026 ja _[_Atte Harjanteen blogissa_](https://atteharjanne.fi/2026/01/15/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/)_ 15.1.2026._
 

--- a/src/pages/fi/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/index.mdx
+++ b/src/pages/fi/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/index.mdx
@@ -50,6 +50,4 @@ Kun Lähteelää kehitetään, on tärkeää vaalia sen luontoarvoja ja ainutlaa
 
 Kirkkonummi on rannikkokunta. On hyvä, että tämä näkyy myös siinä, miten meri ja rannat ovat kaikkien käytettävissä. Lähteelän hankinta on askel kohti kuntaa, jossa luonto yhdistää ja yhteinen ympäristö koetaan aidosti yhteiseksi.
 
----
-
-**Kirjoittajat:** Miisa Jeremejew ja Lauri Lavanti, kunnanvaltuutettuja (vihr.), Kirkkonummi
+_Kirjoittajat: Miisa Jeremejew ja Lauri Lavanti, kunnanvaltuutettuja (vihr.), Kirkkonummi._

--- a/src/pages/sv/blog/22/ett-steg-fram-tva-steg-tillbaka/index.mdx
+++ b/src/pages/sv/blog/22/ett-steg-fram-tva-steg-tillbaka/index.mdx
@@ -49,6 +49,8 @@ Som helhet kompenserar alltså dessa steg framåt inte för de steg bakåt som r
 
 Undervisningsministern svarade på vår artikel — och vi svarade tillbaka: [Är utbildningen under särskilt skydd?](/sv/blog/27/ar-utbildningen-under-sarskilt-skydd/) En bredare bild av varför utbildning är kommunens viktigaste uppgift, från småbarnspedagogik till livslångt lärande, finns i [Utbildning är kommunens viktigaste uppgift](/sv/blog/37/utbildning-ar-kommunens-viktigaste-uppgift/). Alla mina utbildningstexter finns i [utbildningskategorin](/sv/category/opetus/).
 
-*Skrivet tillsammans med Paula Oittinen och Johanna Fleming.*
+_Skribenter: Johanna Fleming, Lauri Lavanti och Paula Oittinen._
 
-*Publicerad i Kirkkonummen Sanomat den 27 november 2024.*
+---
+
+_Publicerad i Kirkkonummen Sanomat den 27 november 2024._

--- a/src/pages/sv/blog/27/ar-utbildningen-under-sarskilt-skydd/index.mdx
+++ b/src/pages/sv/blog/27/ar-utbildningen-under-sarskilt-skydd/index.mdx
@@ -48,6 +48,8 @@ Regeringen lovade att utbildningen skulle vara under särskilt skydd — det gic
 
 En bredare bild av utbildningens roll i kommunen finns i [Utbildning är kommunens viktigaste uppgift](/sv/blog/37/utbildning-ar-kommunens-viktigaste-uppgift/). Läs mer i [utbildningskategorin](/sv/category/opetus/).
 
-*Skrivet tillsammans med Johanna Fleming och Paula Oittinen.*
+_Skribenter: Johanna Fleming, Lauri Lavanti och Paula Oittinen._
 
-*Publicerad i Kirkkonummen Sanomat den 11 december 2024.*
+---
+
+_Publicerad i Kirkkonummen Sanomat den 11 december 2024._

--- a/src/pages/sv/blog/41/kollektivtrafiken-kan-inte-bli-dyrare-i-all-oandlighet/index.mdx
+++ b/src/pages/sv/blog/41/kollektivtrafiken-kan-inte-bli-dyrare-i-all-oandlighet/index.mdx
@@ -39,8 +39,10 @@ Med de åtgärder som nu diskuteras är vårt kollektivtrafiksystem på väg att
 
 Kollektivtrafik är också anledningen till att [jag röstade för Kyrkslätts anslutning till Västernabanan](/sv/blog/46/jag-rostade-for-vasternabanan/) — en järnvägsstation i norra Kyrkslätt hade erbjudit ett hållbart alternativ till bilen. Fullmäktiges beslut att dra sig ur projektet har nu lett till besvikelse, vilket jag behandlar i [Västbanan avslöjade problem i Kyrkslätts beslutsfattande](/sv/blog/50/vastbanan-beslutet-avslojat-problem-i-kyrkslatts-langsiktiga-strategiska-utveckling/). Läs mer i [trafikkategorin](/sv/category/liikenne/).
 
-*Skrivet tillsammans med Ronja Karkinen.*
+_Skribenter: Ronja Karkinen och Lauri Lavanti._
 
-*Publicerad i Kirkkonummen Sanomat den 20 augusti 2025.*
+---
+
+_Publicerad i Kirkkonummen Sanomat den 20 augusti 2025._
 
 [*Publicerad på Kyrkslätts grönas webbplats den 21 augusti 2025.*](https://kirkkonummenvihreat.fi/2025/08/21/joukkoliikenne-ei-voi-kallistua-loputtomiin/)

--- a/src/pages/sv/blog/48/anvandningen-av-biometriska-identifierare-i-pass-far-inte-utvidgas/index.mdx
+++ b/src/pages/sv/blog/48/anvandningen-av-biometriska-identifierare-i-pass-far-inte-utvidgas/index.mdx
@@ -57,8 +57,10 @@ Myndigheterna måste ha tillräckliga medel för att garantera samhällets säke
 
 Om digitala rättigheter och teknologi har jag skrivit mer: [om att riva grundläggande rättigheter](/sv/blog/45/grundlaggande-rattigheter-far-inte-rivas-utan-grund/), [om digital självständighet](/sv/blog/51/digital-sjalvstandighet-ar-en-nodvandighet/) samt [om vad AI kan göra i offentliga tjänster](/sv/blog/44/ai-kan-inte-allt/). Läs mer i [mina texter om teknologi](/sv/category/teknologia/).
 
-*Skriven tillsammans med Atte Harjanne.*
+_Skribenter: Atte Harjanne och Lauri Lavanti._
 
-*En version av texten publicerad i [Helsingin Sanomat](https://www.hs.fi/mielipide/art-2000011743934.html) den 14 januari 2026 och i [Atte Harjannes blogg](https://atteharjanne.fi/2026/01/15/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/) den 15 januari 2026.*
+---
+
+_En version av texten publicerad i [Helsingin Sanomat](https://www.hs.fi/mielipide/art-2000011743934.html) den 14 januari 2026 och i [Atte Harjannes blogg](https://atteharjanne.fi/2026/01/15/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/) den 15 januari 2026.*
 
 *En annan version av texten publicerad i [Kirkkonummen Sanomat](https://www.kirkkonummensanomat.fi/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa-6.175.83467.93ecbd9ad5) den 20 januari 2026.*

--- a/src/pages/sv/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/index.mdx
+++ b/src/pages/sv/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/index.mdx
@@ -7,8 +7,8 @@ title: 'Lähteelä — en gem vid Kyrksländ­ets kust'
 description: 'Kyrksländ köpte Lähteelä som en kustanläggning. Det är en av få platser vid Kyrksländets kust dit man kan ta sig utan egen båt — nu är området permanent tillgängligt för alla.'
 publishDate: '2026-04-15'
 tags:
-  - kyrksländ
-  - natur
+  - kirkkonummi
+  - nature
 heroImage: Lauri-Lavanti-ja-Miisa-Jeremejew
 alt: 'Lauri Lavanti och Miisa Jeremejew, kommunfullmäktigeledamöter (gröna), Kyrksländ'
 faq:
@@ -50,6 +50,4 @@ När Lähteelä utvecklas är det viktigt att bevara dess naturvärden och unika
 
 Kyrksländ är en kustkommun. Det är bra att detta också syns i hur havet och kusterna är tillgängliga för alla. Köpet av Lähteelä är ett steg mot en kommun där naturen förenar och den gemensamma miljön verkligen upplevs som gemensam.
 
----
-
-**Skribenter:** Miisa Jeremejew och Lauri Lavanti, kommunfullmäktigeledamöter (gröna), Kyrksländ
+_Skribenter: Miisa Jeremejew och Lauri Lavanti, kommunfullmäktigeledamöter (gröna), Kyrksländ._

--- a/tests/e2e/blogPostPage.spec.ts-snapshots/Blog-Post-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/blogPostPage.spec.ts-snapshots/Blog-Post-Page-should-match-aria-snapshot-1.aria.yml
@@ -153,18 +153,18 @@
                   - /url: /fi/category/health-and-social-reform/
           - paragraph: Asetan itseni ehdolle aluevaaleihin. Tärkeintä on lähipalvelujen säilyminen, terveydenhuollon pitäminen julkisena ja hoitohenkilökunnan hyvinvointi.
       - listitem:
-        - 'article "Kirkkonummi sanoo: sinä kuulut tänne"':
-          - 'link "Kirkkonummen Kirsikkapuisto aurinkoisena kesäpäivänä. Näköpiirissä pääasiassa nurmialuetta, taustalla kerrostaloja ja edustalla hieman leikkipuistoja Kirkkonummi sanoo: sinä kuulut tänne"':
-            - /url: /fi/blog/55/kirkkonummi-sanoo-sina-kuulut-tanne/
-            - img "Kirkkonummen Kirsikkapuisto aurinkoisena kesäpäivänä. Näköpiirissä pääasiassa nurmialuetta, taustalla kerrostaloja ja edustalla hieman leikkipuistoja"
-            - 'heading "Kirkkonummi sanoo: sinä kuulut tänne" [level=2]'
-          - 'complementary "Kirjoituksen \"Kirkkonummi sanoo: sinä kuulut tänne\" meta-tiedot"':
+        - article "Lähteelä — helmi Kirkkonummen rannikolla":
+          - link "Lauri Lavanti ja Miisa Jeremejew, kunnanvaltuutettuja (vihr.), Kirkkonummi Lähteelä — helmi Kirkkonummen rannikolla":
+            - /url: /fi/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/
+            - img "Lauri Lavanti ja Miisa Jeremejew, kunnanvaltuutettuja (vihr.), Kirkkonummi"
+            - heading "Lähteelä — helmi Kirkkonummen rannikolla" [level=2]
+          - complementary "Kirjoituksen \"Lähteelä — helmi Kirkkonummen rannikolla\" meta-tiedot":
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Tasa-arvo ja yhdenvertaisuus":
-                  - /url: /fi/category/equality-and-non-discrimination/
-              - listitem:
                 - link "#Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
-          - paragraph: /Sateenkaarinuorten kiusaaminen kasvaa\. Kirkkonummi äänesti \d+–\d+ liputuksen puolesta — pieni ele, jolla on mitattavia vaikutuksia nuorten hyvinvointiin\./
+              - listitem:
+                - link "#Luonto":
+                  - /url: /fi/category/nature/
+          - paragraph: Kirkkonummi osti Lähteelän rannikkokohteen. Se on yksi harvoista paikoista, jonne pääsee myös ilman omaa venettä — nyt se on pysyvästi kaikkien saavutettavissa.

--- a/tests/e2e/homeEnPage.spec.ts-snapshots/Home-Page-in-English-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/homeEnPage.spec.ts-snapshots/Home-Page-in-English-should-match-aria-snapshot-1.aria.yml
@@ -14,6 +14,22 @@
         - /url: /en/privacy-policy/
     - list:
       - listitem:
+        - article "Lähteelä — a gem on Kirkkonummi coast":
+          - link "Lauri Lavanti and Miisa Jeremejew, municipal councillors (Greens), Kirkkonummi Lähteelä — a gem on Kirkkonummi coast":
+            - /url: /en/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/
+            - img "Lauri Lavanti and Miisa Jeremejew, municipal councillors (Greens), Kirkkonummi"
+            - heading "Lähteelä — a gem on Kirkkonummi coast" [level=2]
+          - complementary "Meta information for post \"Lähteelä — a gem on Kirkkonummi coast\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "#Kirkkonummi":
+                  - /url: /en/category/kirkkonummi/
+              - listitem:
+                - link "#Nature":
+                  - /url: /en/category/nature/
+          - paragraph: Kirkkonummi acquired Lähteelä, a coastal recreation area. It is one of the few places on Kirkkonummi's coast accessible without a private boat - now it's permanently available to all.
+      - listitem:
         - 'article "Kirkkonummi tells everyone: you belong here"':
           - 'link "Kirkkonummi Kirsikkapuisto park on a sunny summer day. Mostly lawn in view, apartment buildings in the background and some playground equipment in the foreground Kirkkonummi tells everyone: you belong here"':
             - /url: /en/blog/55/kirkkonummi-tells-everyone-you-belong-here/
@@ -128,22 +144,6 @@
                 - link "#Culture & education":
                   - /url: /en/category/culture-and-education/
           - paragraph: Kirkkonummi's renovation creates a culture cluster of Fyyri, Lyyra and Rovastinpuisto park. It sets conditions for growth for decades to come.
-      - listitem:
-        - article "Passport biometrics must stay protected":
-          - link "A photo of Atte Harjanne and Lauri Lavanti. Both are wearing a black jacket and shirt. Passport biometrics must stay protected":
-            - /url: /en/blog/48/the-use-of-biometric-identifiers-in-passports-must-not-be-expanded/
-            - img "A photo of Atte Harjanne and Lauri Lavanti. Both are wearing a black jacket and shirt."
-            - heading "Passport biometrics must stay protected" [level=2]
-          - complementary "Meta information for post \"Passport biometrics must stay protected\"":
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "#Technology":
-                  - /url: /en/category/technology/
-              - listitem:
-                - link "#Privacy":
-                  - /url: /en/category/privacy/
-          - paragraph: When fingerprints were added to passports, Finland created a national biometric register. Now the government wants to open it to police use.
     - region "Frequently Asked Questions":
       - heading "Frequently Asked Questions" [level=2]
       - term: Which party does Lauri Lavanti belong to?

--- a/tests/e2e/homePage.spec.ts-snapshots/Home-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/homePage.spec.ts-snapshots/Home-Page-should-match-aria-snapshot-1.aria.yml
@@ -14,6 +14,22 @@
         - /url: /en/privacy-policy/
     - list:
       - listitem:
+        - article "Lähteelä — a gem on Kirkkonummi coast":
+          - link "Lauri Lavanti and Miisa Jeremejew, municipal councillors (Greens), Kirkkonummi Lähteelä — a gem on Kirkkonummi coast":
+            - /url: /en/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/
+            - img "Lauri Lavanti and Miisa Jeremejew, municipal councillors (Greens), Kirkkonummi"
+            - heading "Lähteelä — a gem on Kirkkonummi coast" [level=2]
+          - complementary "Meta information for post \"Lähteelä — a gem on Kirkkonummi coast\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "#Kirkkonummi":
+                  - /url: /en/category/kirkkonummi/
+              - listitem:
+                - link "#Nature":
+                  - /url: /en/category/nature/
+          - paragraph: Kirkkonummi acquired Lähteelä, a coastal recreation area. It is one of the few places on Kirkkonummi's coast accessible without a private boat - now it's permanently available to all.
+      - listitem:
         - 'article "Kirkkonummi tells everyone: you belong here"':
           - 'link "Kirkkonummi Kirsikkapuisto park on a sunny summer day. Mostly lawn in view, apartment buildings in the background and some playground equipment in the foreground Kirkkonummi tells everyone: you belong here"':
             - /url: /en/blog/55/kirkkonummi-tells-everyone-you-belong-here/
@@ -128,22 +144,6 @@
                 - link "#Culture & education":
                   - /url: /en/category/culture-and-education/
           - paragraph: Kirkkonummi's renovation creates a culture cluster of Fyyri, Lyyra and Rovastinpuisto park. It sets conditions for growth for decades to come.
-      - listitem:
-        - article "Passport biometrics must stay protected":
-          - link "A photo of Atte Harjanne and Lauri Lavanti. Both are wearing a black jacket and shirt. Passport biometrics must stay protected":
-            - /url: /en/blog/48/the-use-of-biometric-identifiers-in-passports-must-not-be-expanded/
-            - img "A photo of Atte Harjanne and Lauri Lavanti. Both are wearing a black jacket and shirt."
-            - heading "Passport biometrics must stay protected" [level=2]
-          - complementary "Meta information for post \"Passport biometrics must stay protected\"":
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "#Technology":
-                  - /url: /en/category/technology/
-              - listitem:
-                - link "#Privacy":
-                  - /url: /en/category/privacy/
-          - paragraph: When fingerprints were added to passports, Finland created a national biometric register. Now the government wants to open it to police use.
     - region "Frequently Asked Questions":
       - heading "Frequently Asked Questions" [level=2]
       - term: Which party does Lauri Lavanti belong to?

--- a/tests/e2e/homeSwePage.spec.ts-snapshots/Home-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/homeSwePage.spec.ts-snapshots/Home-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
@@ -15,6 +15,22 @@
       - text: .
     - list:
       - listitem:
+        - article "Lähteelä — en gem vid Kyrksländets kust":
+          - link "Lauri Lavanti och Miisa Jeremejew, kommunfullmäktigeledamöter (gröna), Kyrksländ Lähteelä — en gem vid Kyrksländets kust":
+            - /url: /sv/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/
+            - img "Lauri Lavanti och Miisa Jeremejew, kommunfullmäktigeledamöter (gröna), Kyrksländ"
+            - heading "Lähteelä — en gem vid Kyrksländets kust" [level=2]
+          - complementary "Metainformation för inlägget \"Lähteelä — en gem vid Kyrksländets kust\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "#Kyrkslätt":
+                  - /url: /sv/category/kirkkonummi/
+              - listitem:
+                - link "#Natur":
+                  - /url: /sv/category/nature/
+          - paragraph: Kyrksländ köpte Lähteelä som en kustanläggning. Det är en av få platser vid Kyrksländets kust dit man kan ta sig utan egen båt — nu är området permanent tillgängligt för alla.
+      - listitem:
         - 'article "Kyrkslätt till alla: du hör hemma här"':
           - 'link "Kyrkslätt Kirsikkapuisto en solig sommardag. Nästan bara gräsmatta i blickfånget, i bakgrunden flervåningshus och i förgrunden lite lekplatsutrustning Kyrkslätt till alla: du hör hemma här"':
             - /url: /sv/blog/55/kyrkslatt-till-alla-du-hor-hemma-har/
@@ -129,22 +145,6 @@
                 - link "#Bildning":
                   - /url: /sv/category/culture-and-education/
           - paragraph: Renoveringen av Kyrkslätts centrum skapar ett bildningskluster av Fyyri, Lyyra och Provstparken. Det ger förutsättningar för tillväxt i decennier.
-      - listitem:
-        - article "Biometriska identifierare i pass – motstånd":
-          - link "Ett foto av Atte Harjanne och Lauri Lavanti. Båda bär svart jacka och skjorta. Biometriska identifierare i pass – motstånd":
-            - /url: /sv/blog/48/anvandningen-av-biometriska-identifierare-i-pass-far-inte-utvidgas/
-            - img "Ett foto av Atte Harjanne och Lauri Lavanti. Båda bär svart jacka och skjorta."
-            - heading "Biometriska identifierare i pass – motstånd" [level=2]
-          - complementary "Metainformation för inlägget \"Biometriska identifierare i pass – motstånd\"":
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "#Teknologi":
-                  - /url: /sv/category/technology/
-              - listitem:
-                - link "#Integritetsskydd":
-                  - /url: /sv/category/privacy/
-          - paragraph: När fingeravtryck infördes i pass skapades ett nationellt biometriskt register i Finland. Nu vill regeringen öppna det för polisens bruk.
     - region "Vanliga frågor":
       - heading "Vanliga frågor" [level=2]
       - term: Vilket parti tillhör Lauri Lavanti?

--- a/tests/e2e/notFoundPage.spec.ts-snapshots/404-Not-Found-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/notFoundPage.spec.ts-snapshots/404-Not-Found-Page-should-match-aria-snapshot-1.aria.yml
@@ -3,6 +3,22 @@
   - article:
     - list:
       - listitem:
+        - article "Lähteelä — helmi Kirkkonummen rannikolla":
+          - link "Lauri Lavanti ja Miisa Jeremejew, kunnanvaltuutettuja (vihr.), Kirkkonummi Lähteelä — helmi Kirkkonummen rannikolla":
+            - /url: /fi/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/
+            - img "Lauri Lavanti ja Miisa Jeremejew, kunnanvaltuutettuja (vihr.), Kirkkonummi"
+            - heading "Lähteelä — helmi Kirkkonummen rannikolla" [level=2]
+          - complementary "Kirjoituksen \"Lähteelä — helmi Kirkkonummen rannikolla\" meta-tiedot":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "#Kirkkonummi":
+                  - /url: /fi/category/kirkkonummi/
+              - listitem:
+                - link "#Luonto":
+                  - /url: /fi/category/nature/
+          - paragraph: Kirkkonummi osti Lähteelän rannikkokohteen. Se on yksi harvoista paikoista, jonne pääsee myös ilman omaa venettä — nyt se on pysyvästi kaikkien saavutettavissa.
+      - listitem:
         - 'article "Kirkkonummi sanoo: sinä kuulut tänne"':
           - 'link "Kirkkonummen Kirsikkapuisto aurinkoisena kesäpäivänä. Näköpiirissä pääasiassa nurmialuetta, taustalla kerrostaloja ja edustalla hieman leikkipuistoja Kirkkonummi sanoo: sinä kuulut tänne"':
             - /url: /fi/blog/55/kirkkonummi-sanoo-sina-kuulut-tanne/
@@ -117,19 +133,3 @@
                 - link "#Sivistys":
                   - /url: /fi/category/culture-and-education/
           - paragraph: Kirkkonummen keskustan remontti rakentaa Fyyrin, Lyyran ja Rovastinpuiston sivistyksen keskittymän. Se luo edellytyksiä kasvulle vuosikymmeniksi.
-      - listitem:
-        - article "Passitunnisteiden käyttöä ei saa laajentaa":
-          - link "Kuva Atte Harjanteesta ja Lauri Lavannista. Kummallakin musta takki ja kauluspaita. Passitunnisteiden käyttöä ei saa laajentaa":
-            - /url: /fi/blog/48/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/
-            - img "Kuva Atte Harjanteesta ja Lauri Lavannista. Kummallakin musta takki ja kauluspaita."
-            - heading "Passitunnisteiden käyttöä ei saa laajentaa" [level=2]
-          - complementary "Kirjoituksen \"Passitunnisteiden käyttöä ei saa laajentaa\" meta-tiedot":
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "#Teknologia":
-                  - /url: /fi/category/technology/
-              - listitem:
-                - link "#Yksityisyydensuoja":
-                  - /url: /fi/category/privacy/
-          - paragraph: Kun sormenjäljet tuotiin passeihin, Suomeen perustettiin kansallinen biometrinen rekisteri. Nyt hallitus haluaa avata sen poliisin käyttöön.


### PR DESCRIPTION
## Summary
- Add new `nature` tag to `tags.ts` with names, descriptions, pageTitle, and FAQ in all three locales (fi/en/sv)
- Fix Swedish post 56 tag ids (`kyrksländ`→`kirkkonummi`, `natur`→`nature`)
- Standardize co-author bylines across posts 22, 27, 41, 48, 56: italic format, all authors including Lauri listed alphabetically by last name, horizontal rule separating co-author line from publication credits
- Document multi-author byline convention in posts spec
- Remove manual `npm run lint` / `npm run check` instructions from specs, workflows, and architecture docs (enforced by pre-commit hooks and CI)
- Fix non-breaking spaces in `.asdlc/` markdown files

## Test plan
- [x] `npm run build` passes
- [x] `npm run test:e2e` passes (snapshots updated)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)