### PR TITLE
perf(images): use non-transparent hero image on mobile

### DIFF
--- a/src/components/HeroBanner.astro
+++ b/src/components/HeroBanner.astro
@@ -7,12 +7,13 @@ interface Props {
     alt?: string
     backgroundImage?: string
     heroImage?: string
+    mobileHeroImage?: string
     secondaryTitle?: string
     subtitle?: string
     title: string
 }
 
-const { alt, backgroundImage, heroImage, secondaryTitle, subtitle, title } = Astro.props
+const { alt, backgroundImage, heroImage, mobileHeroImage, secondaryTitle, subtitle, title } = Astro.props
 ---
 
 <style
@@ -40,5 +41,5 @@ const { alt, backgroundImage, heroImage, secondaryTitle, subtitle, title } = Ast
 </style>
 <div>
     <Titles secondaryTitle={secondaryTitle} subtitle={subtitle} title={title} />
-    <Images alt={alt} backgroundImage={backgroundImage} heroImage={heroImage} />
+    <Images alt={alt} backgroundImage={backgroundImage} heroImage={heroImage} mobileHeroImage={mobileHeroImage} />
 </div>

--- a/src/components/heroBanner/Images.astro
+++ b/src/components/heroBanner/Images.astro
@@ -9,9 +9,10 @@ interface Props {
     alt?: string
     backgroundImage?: string
     heroImage?: string
+    mobileHeroImage?: string
 }
 
-const { alt, backgroundImage, heroImage } = Astro.props
+const { alt, backgroundImage, heroImage, mobileHeroImage } = Astro.props
 ---
 
 <style define:vars={{ sizes1Negative: `-${sizes[1]}`, sizes14Negative: `-${sizes[14]}` }}>
@@ -27,6 +28,14 @@ const { alt, backgroundImage, heroImage } = Astro.props
         margin-left: var(--sizes1Negative);
     }
 
+    .image-mobile {
+        display: block;
+    }
+
+    .image-desktop {
+        display: none;
+    }
+
     @media (min-width: 1200px) {
         .container {
             overflow: visible;
@@ -40,12 +49,43 @@ const { alt, backgroundImage, heroImage } = Astro.props
             right: var(--sizes14Negative);
             margin-top: auto;
         }
+
+        .image-mobile {
+            display: none;
+        }
+
+        .image-desktop {
+            display: block;
+        }
     }
 </style>
 <div class="container">
     <BackgroundImage image={backgroundImage} />
     {
-        heroImage && (
+        heroImage && mobileHeroImage ? (
+            <>
+                <CldImage
+                    alt={alt ?? ''}
+                    class="image image-mobile"
+                    crop={{ aspectRatio: '1:1', gravity: 'face', source: true, type: 'fill' }}
+                    fetchpriority="high"
+                    height={562}
+                    layout="constrained"
+                    src={mobileHeroImage}
+                    width={560}
+                />
+                <CldImage
+                    alt={alt ?? ''}
+                    class="image image-desktop"
+                    crop={{ aspectRatio: '1:1', gravity: 'face', source: true, type: 'fill' }}
+                    fetchpriority="high"
+                    height={562}
+                    layout="constrained"
+                    src={heroImage}
+                    width={560}
+                />
+            </>
+        ) : heroImage ? (
             <CldImage
                 alt={alt ?? ''}
                 class="image"
@@ -56,6 +96,6 @@ const { alt, backgroundImage, heroImage } = Astro.props
                 src={heroImage}
                 width={560}
             />
-        )
+        ) : null
     }
 </div>

--- a/src/layouts/FrontPageLayout.astro
+++ b/src/layouts/FrontPageLayout.astro
@@ -15,6 +15,7 @@ type Props = MDXLayoutProps<{
     heroImage?: string
     heroTitle?: string
     lang?: 'en' | 'fi' | 'sv'
+    mobileHeroImage?: string
     secondaryTitle?: string
     slug?: string
     subtitle?: string
@@ -31,6 +32,7 @@ const {
     heroImage,
     heroTitle,
     lang,
+    mobileHeroImage,
     secondaryTitle,
     slug,
     subtitle,
@@ -57,6 +59,7 @@ const ogImage = heroImage
         alt={alt}
         backgroundImage={backgroundImage}
         heroImage={heroImage}
+        mobileHeroImage={mobileHeroImage}
         secondaryTitle={secondaryTitle}
         slot="banner"
         subtitle={subtitle}

--- a/src/pages/en/index.mdx
+++ b/src/pages/en/index.mdx
@@ -10,6 +10,7 @@ heroBanner: true
 secondaryTitle: 'About everyday life at the heart of digitalisation'
 backgroundImage: Kirkkonummen-keskusta
 heroImage: Lauri-Lavanti-nojaamassa-kasiin
+mobileHeroImage: Lauri-Lavanti-nojaamassa-kasiin-sinisella-taustalla
 alt: 'Lauri Lavanti resting his hands against each other and looking at the camera with a smile. He is wearing a white dress shirt and a dark blazer. Photo by Erkki Laine.'
 faq:
   - q: 'Which party does Lauri Lavanti belong to?'

--- a/src/pages/fi/index.mdx
+++ b/src/pages/fi/index.mdx
@@ -10,6 +10,7 @@ heroBanner: true
 secondaryTitle: 'Arjesta digitalisaation keskellä'
 backgroundImage: 'Kirkkonummen-keskusta'
 heroImage: Lauri-Lavanti-nojaamassa-kasiin
+mobileHeroImage: Lauri-Lavanti-nojaamassa-kasiin-sinisella-taustalla
 alt: 'Lauri Lavanti nojaamassa käsiinsä ja katsoo kameraan hymyssä suin. Päällä hänellä on valkoinen kauluspaita ja tumma pikkutakki. Kuvan ottanut Erkki Laine.'
 faq:
   - q: 'Mihin puolueeseen Lauri Lavanti kuuluu?'

--- a/src/pages/sv/index.mdx
+++ b/src/pages/sv/index.mdx
@@ -10,6 +10,7 @@ heroBanner: true
 secondaryTitle: 'Om vardagen mitt i digitaliseringen'
 backgroundImage: Kirkkonummen-keskusta
 heroImage: Lauri-Lavanti-nojaamassa-kasiin
+mobileHeroImage: Lauri-Lavanti-nojaamassa-kasiin-sinisella-taustalla
 alt: 'Lauri Lavanti lutar sig mot händerna och tittar in i kameran med ett leende. Han bär en vit skjorta och en mörk kavaj. Foto av Erkki Laine.'
 faq:
   - q: 'Vilket parti tillhör Lauri Lavanti?'


### PR DESCRIPTION
## Summary
- Show `Lauri-Lavanti-nojaamassa-kasiin-sinisella-taustalla` (blue background, non-transparent) on mobile (< 1200px) for better rendering performance
- Keep original transparent `Lauri-Lavanti-nojaamassa-kasiin` on desktop (≥ 1200px)
- New `mobileHeroImage` frontmatter prop threaded through FrontPageLayout → HeroBanner → Images
- Backward compatible — pages without `mobileHeroImage` render single image as before

## Test plan
- [ ] Verify mobile viewport shows blue-background image
- [ ] Verify desktop viewport shows original transparent image
- [ ] Verify breakpoint switch at 1200px
- [ ] E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)