### PR TITLE
fix(blog): remove soft hyphens from slug frontmatter + enforce

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,6 +110,19 @@ jobs:
       - name: Check all page titles meet SEO length requirements
         run: node scripts/validate-titles.mjs
 
+  validate-slugs:
+    runs-on: ubuntu-latest
+    name: Validate slugs
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+      - name: Check all slugs are free of soft hyphens
+        run: node scripts/validate-slugs.mjs
+
   unit-test:
     runs-on: ubuntu-latest
     name: Unit tests

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -4,6 +4,7 @@ export default {
         `node scripts/check-long-words.mjs ${files.map((f) => `"${f}"`).join(' ')}`,
         'node scripts/validate-translations.mjs',
         'node scripts/validate-titles.mjs',
+        'node scripts/validate-slugs.mjs',
     ],
     '**/content/tags.ts': (files) =>
         `node scripts/check-long-words.mjs ${files.map((f) => `"${f}"`).join(' ')}`,

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "validate-page-titles": "node scripts/check-long-words.mjs src/content/tags.ts",
     "validate-titles": "node scripts/validate-titles.mjs",
     "validate-translations": "node scripts/validate-translations.mjs",
+    "validate-slugs": "node scripts/validate-slugs.mjs",
     "preview": "astro preview",
     "astro": "astro",
     "test": "vitest",

--- a/scripts/validate-slugs.mjs
+++ b/scripts/validate-slugs.mjs
@@ -1,0 +1,47 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url))
+const pagesRoot = join(__dirname, '..', 'src', 'pages')
+const repoRoot = join(__dirname, '..')
+const SOFT_HYPHEN = '\u00AD'
+
+function collectMdxFiles(dir) {
+    const entries = readdirSync(dir, { withFileTypes: true })
+    const files = []
+    for (const entry of entries) {
+        const fullPath = join(dir, entry.name)
+        if (entry.isDirectory()) {
+            files.push(...collectMdxFiles(fullPath))
+        } else if (entry.name === 'index.mdx') {
+            files.push(fullPath)
+        }
+    }
+    return files
+}
+
+function extractSlug(content) {
+    const m = content.match(/^slug:\s*'([^']*)'/m) ?? content.match(/^slug:\s*"([^"]*)"/m)
+    return m ? m[1] : null
+}
+
+const files = collectMdxFiles(pagesRoot)
+let hasError = false
+
+for (const file of files) {
+    const content = readFileSync(file, 'utf8')
+    const slug = extractSlug(content)
+    if (slug === null) continue
+    if (slug.includes(SOFT_HYPHEN)) {
+        const relFile = file.replace(repoRoot + '/', '')
+        console.error(`ERROR: soft hyphen in slug: "${slug}" — ${relFile}`)
+        hasError = true
+    }
+}
+
+if (hasError) {
+    process.exit(1)
+} else {
+    console.log(`OK: all ${files.length} MDX slugs are free of soft hyphens`)
+}

--- a/src/pages/fi/blog/15/kunnan-pitaa-suunnitella-pitkajanteisesti/index.mdx
+++ b/src/pages/fi/blog/15/kunnan-pitaa-suunnitella-pitkajanteisesti/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: '../../../../../layouts/PostLayout.astro'
 id: 15
-slug: 'kunnan-pitaa-suunni­tella-pitkajanteisesti'
+slug: 'kunnan-pitaa-suunnitella-pitkajanteisesti'
 lang: 'fi'
 title: 'Kunnan pitää suunni­tella pitkä­jänteis­esti'
 description: 'Kunnan on suunniteltava pitkäjänteisesti. Lyhytnäköiset päätökset johtavat lisäkustannuksiin ja heikompiin palveluihin asukkaille.'

--- a/src/pages/fi/blog/18/osuuskauppavaalit-koskettavat-meita-kaikkia/index.mdx
+++ b/src/pages/fi/blog/18/osuuskauppavaalit-koskettavat-meita-kaikkia/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: '../../../../../layouts/PostLayout.astro'
 id: 18
-slug: 'osuuskauppavaalit-kosket­tavat-meita-kaikkia'
+slug: 'osuuskauppavaalit-koskettavat-meita-kaikkia'
 lang: 'fi'
 title: 'VBO:n vaalit kosket­tavat meitä kaikkia'
 description: 'Varuboden-Oslan osuuskauppavaalit ovat nyt käynnissä. Äänestämällä vaikutat ihmisten työpaikkoihin, kulutuskäyttäytymiseen sekä lähipalveluihin.'

--- a/src/pages/fi/blog/30/turvapaikan-saaneista/index.mdx
+++ b/src/pages/fi/blog/30/turvapaikan-saaneista/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: '../../../../../layouts/PostLayout.astro'
 id: 30
-slug: 'turva­paikan-saaneista'
+slug: 'turvapaikan-saaneista'
 lang: 'fi'
 title: 'Esseitä maahan­muutosta: turva­paikan saaneet'
 description: 'Turvapaikan saaminen ei ole itsestäänselvyys, vaan tarkoin määritelty prosessi. Usein unohdetaan, keitä ihmiset ovat, jotka paikkaa hakevat.'

--- a/src/pages/fi/blog/33/kuntavaaleissa-ratkaistaan-arjen-asioita/index.mdx
+++ b/src/pages/fi/blog/33/kuntavaaleissa-ratkaistaan-arjen-asioita/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: '../../../../../layouts/PostLayout.astro'
 id: 33
-slug: 'kuntavaaleissa-ratkais­taan-arjen-asioita'
+slug: 'kuntavaaleissa-ratkaistaan-arjen-asioita'
 lang: 'fi'
 title: 'Kunta­vaaleissa ratkais­taan arjen asioita'
 description: 'Kuntavaalit saattavat tuntua monimutkaisilta, mutta kyse on arjen asioista: kouluista, päiväkodeista ja liikenneyhteyksistä. Sinulla on vaikutusvaltaa.'

--- a/src/pages/fi/blog/41/joukkoliikenne-ei-voi-kallistua-loputtomiin/index.mdx
+++ b/src/pages/fi/blog/41/joukkoliikenne-ei-voi-kallistua-loputtomiin/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: '../../../../../layouts/PostLayout.astro'
 id: 41
-slug: 'joukkoliikenne-ei-voi-kallistua-loputto­miin'
+slug: 'joukkoliikenne-ei-voi-kallistua-loputtomiin'
 lang: 'fi'
 title: 'Joukko­liikenne ei voi kallistua loputto­miin'
 description: 'Pääkaupunkiseudun joukkoliikenteestä vastaava HSL-kuntayhtymä suunnittelee lähivuosille tuntuvia korotuksia bussien ja junien lippujen hintoihin.'

--- a/src/pages/fi/blog/5/hyvin-suunniteltu-on-puoliksi-tehty-mutta/index.mdx
+++ b/src/pages/fi/blog/5/hyvin-suunniteltu-on-puoliksi-tehty-mutta/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: '../../../../../layouts/PostLayout.astro'
 id: 5
-slug: 'hyvin-suunni­teltu-on-puoliksi-tehty-mutta'
+slug: 'hyvin-suunniteltu-on-puoliksi-tehty-mutta'
 lang: 'fi'
 title: 'Hyvin suunni­teltu on puoliksi tehty, mutta'
 description: 'Gesterbyn koulukeskuksen hankesuunnitelmaa on palautettu lisävalmisteluun kolmesti. Hanketta on selvitetty kuusi vuotta ilman lopputulosta.'

--- a/src/pages/fi/blog/54/chat-control-parlamentti-toimi-oikein/index.mdx
+++ b/src/pages/fi/blog/54/chat-control-parlamentti-toimi-oikein/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: '../../../../../layouts/PostLayout.astro'
 id: 54
-slug: 'chat-control-parla­mentti-toimi-oikein'
+slug: 'chat-control-parlamentti-toimi-oikein'
 lang: 'fi'
 title: 'Chat control: parla­mentti toimi oikein'
 description: 'Chat control -lain jatkoaika kaatui Euroopan parlamentissa. KRP:n luvut ovat todellisia, mutta parlamentti toimi silti oikein — ja tässä syy, miksi.'

--- a/src/pages/sv/blog/54/chat-control-parlamentet-handlade-ratt/index.mdx
+++ b/src/pages/sv/blog/54/chat-control-parlamentet-handlade-ratt/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: '../../../../../layouts/PostLayout.astro'
 id: 54
-slug: 'chat-control-parla­mentet-handlade-ratt'
+slug: 'chat-control-parlamentet-handlade-ratt'
 lang: 'sv'
 title: 'Chat control: parla­mentet handlade rätt'
 description: 'Chat control-lagens förlängning röstades ned i Europaparlamentet. KRP:s siffror är verkliga, men parlamentet handlade ändå rätt — och här är skälet.'


### PR DESCRIPTION
## Summary

- Remove U+00AD (soft hyphen) from `slug:` frontmatter in 8 blog posts (fi/5, 15, 18, 30, 33, 41, 54; sv/54) — corrupts URLs
- Add `scripts/validate-slugs.mjs` to catch any future recurrence
- Wire check into lint-staged (pre-commit) and CI

## Notes

Soft hyphens in MDX **content** (headings, body text) are intentional for mobile word-breaking and are untouched.

## Test plan

- [x] `node scripts/validate-slugs.mjs` passes on clean corpus (189 files)
- [ ] CI `validate-slugs` job passes
- [ ] Build passes