### PR TITLE
fix(seo): remove parliamentary candidacy from Person schema and meta

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -19,7 +19,7 @@ interface Props {
 }
 
 const {
-    description = 'Lauri Lavanti on informaatioverkostojen diplomi-insinööri, Lead Developer ja Kirkkonummelainen kunnanvaltuutettu, joka keskittyy digitalisaatioon ja yksityisyyden suojaan nopeasti muuttuvassa maailmassa.',
+    description = 'Lauri Lavanti on diplomi-insinööri, johtava ohjelmistokehittäjä ja Kirkkonummen kunnanvaltuutettu (Vihreät). Hän keskittyy digitalisaatioon, yksityisyyden suojaan, tekoälyn vastuulliseen käyttöönottoon ja talouteen.',
     faq,
     lang = 'fi',
     langAlternates,
@@ -75,15 +75,15 @@ const threads = 'https://www.threads.com/@laurilavanti'
 const tikTok = 'https://www.tiktok.com/@laurilavanti'
 
 const personJobTitle: Record<Lang, string> = {
-    en: 'Parliamentary candidate',
-    fi: 'Kansanedustajaehdokas',
-    sv: 'Riksdagskandidat',
+    en: 'Municipal councillor & Lead Developer',
+    fi: 'Kunnanvaltuutettu ja johtava ohjelmistokehittäjä',
+    sv: 'Kommunfullmäktigeledamot och ledande mjukvarutvecklare',
 }
 
 const personDescription: Record<Lang, string> = {
-    en: 'Green parliamentary candidate in the Uusimaa constituency in 2027. Focused on economics, entrepreneurship, and digital independence.',
-    fi: 'Vihreiden kansanedustajaehdokas Uudenmaan vaalipiirissä 2027. Keskittyy talouteen, yrittäjyyteen ja digitaaliseen riippumattomuuteen.',
-    sv: 'Grönas riksdagskandidat i Nylands valkrets 2027. Fokuserar på ekonomi, företagande och digital självständighet.',
+    en: 'Municipal councillor in Kirkkonummi (Greens) and lead software developer. Focused on economics, entrepreneurship, digital independence, and responsible AI policy.',
+    fi: 'Kirkkonummen kunnanvaltuutettu (Vihreät) ja johtava ohjelmistokehittäjä. Keskittyy talouteen, yrittäjyyteen, digitaaliseen riippumattomuuteen ja vastuulliseen tekoälypolitiikkaan.',
+    sv: 'Kommunfullmäktigeledamot i Kyrkslätt (De Gröna) och ledande mjukvarutvecklare. Fokuserar på ekonomi, företagande, digital självständighet och ansvarsfull AI-politik.',
 }
 
 const sameAs = [bluesky, facebook, instagram, linkedIn, mastodon, threads, tikTok]
@@ -157,17 +157,21 @@ const keywords = [
     'Kirkkonummi',
     'Länsi-Uusimaa',
     'Uusimaa',
-    'kuntavaalit',
-    'aluevaalit',
     'Vihreät',
     'Lauri Lavanti',
     'Lauri',
     'Lavanti',
     'poliitikko',
+    'kunnanvaltuutettu',
     'digitalisaatio',
     'tekoäly',
     'teknologia',
     'tietopolitiikka',
+    'digitaalinen riippumattomuus',
+    'yksityisyydensuoja',
+    'vastuullinen tekoäly',
+    'yrittäjyys',
+    'talous',
 ].join(', ')
 ---
 

--- a/src/components/Head.spec.ts
+++ b/src/components/Head.spec.ts
@@ -241,7 +241,7 @@ describe('<Head />', () => {
         const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
         expect(jsonLd['@type']).toBe('Person')
         expect(jsonLd.name).toBe('Lauri Lavanti')
-        expect(jsonLd.jobTitle).toBe('Kansanedustajaehdokas')
+        expect(jsonLd.jobTitle).toBe('Kunnanvaltuutettu ja johtava ohjelmistokehittäjä')
         expect(jsonLd.sameAs).toHaveLength(7)
         expect(jsonLd.memberOf['@type']).toBe('PoliticalParty')
         expect(jsonLd.memberOf.name).toBe('Vihreä liitto')
@@ -260,7 +260,7 @@ describe('<Head />', () => {
 
         const jsonLdScript = result.querySelector('script[type="application/ld+json"]')
         const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
-        expect(jsonLd.jobTitle).toBe('Parliamentary candidate')
+        expect(jsonLd.jobTitle).toBe('Municipal councillor & Lead Developer')
     })
 
     it('should localise Person jobTitle for Swedish', async () => {
@@ -274,7 +274,7 @@ describe('<Head />', () => {
 
         const jsonLdScript = result.querySelector('script[type="application/ld+json"]')
         const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
-        expect(jsonLd.jobTitle).toBe('Riksdagskandidat')
+        expect(jsonLd.jobTitle).toBe('Kommunfullmäktigeledamot och ledande mjukvarutvecklare')
     })
 
     it('should emit noindex robots meta tag when noindex is true', async () => {


### PR DESCRIPTION
> This PR containes AI-generated code. The author has reviewed and is responsible for all AI-generated content.

## Summary

- Replaces `personJobTitle` (all 3 languages) — removes "Kansanedustajaehdokas" / "Parliamentary candidate" / "Riksdagskandidat"
- Replaces `personDescription` (all 3 languages) — removes candidacy and 2027 references
- Updates default meta `description` to reflect current public role
- Updates `keywords` — removes `kuntavaalit`/`aluevaalit`, adds topic terms
- Updates unit test assertions in `Head.spec.ts` to match new values

Closes #1161

## Test plan

- [ ] `npm run build` passes without errors
- [ ] Grep built output: no `Kansanedustajaehdokas`, `Parliamentary candidate`, `Riksdagskandidat`, or `2027` in metadata
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)