### PR TITLE
fix(seo): update keywords, knowsAbout and PERSON description

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -82,8 +82,8 @@ const personJobTitle: Record<Lang, string> = {
 
 const personDescription: Record<Lang, string> = {
     en: 'Municipal councillor in Kirkkonummi (Greens) and lead software developer. Focused on economics, entrepreneurship, digital independence, and responsible AI policy.',
-    fi: 'Kirkkonummen kunnanvaltuutettu (Vihreät) ja johtava ohjelmistokehittäjä. Keskittyy talouteen, yrittäjyyteen, digitaaliseen riippumattomuuteen ja vastuulliseen tekoälypolitiikkaan.',
-    sv: 'Kommunfullmäktigeledamot i Kyrkslätt (De Gröna) och ledande mjukvarutvecklare. Fokuserar på ekonomi, företagande, digital självständighet och ansvarsfull AI-politik.',
+    fi: 'Kirkkonummen kunnanvaltuutettu (Vihreät) ja johtava ohjelmistokehittäjä. Keskittyy talouteen, yrittäjyyteen, digitaaliseen itsenäisyyteen ja vastuulliseen tekoälypolitiikkaan. Seuraa eduskuntavaaleja.',
+    sv: 'Kommunfullmäktigeledamot i Kyrkslätt (De Gröna) och ledande mjukvarutvecklare. Fokuserar på ekonomi, företagande, digital självständighet och ansvarsfull AI-politik. Följer riksdagsvalen.',
 }
 
 const sameAs = [bluesky, facebook, instagram, linkedIn, mastodon, threads, tikTok]
@@ -123,8 +123,12 @@ const jsonLd = JSON.stringify({
                   'Talouspolitiikka',
                   'Yrittäjyys',
                   'Innovaatiopolitiikka',
+                  'Digitaalinen itsenäisyys',
                   'Digitaalinen riippumattomuus',
+                  'Tekoäly',
+                  'Vastuullinen tekoäly',
                   'Vihreä siirtymä',
+                  'Eduskuntavaalit',
               ],
               memberOf: {
                   '@type': 'PoliticalParty',
@@ -163,15 +167,18 @@ const keywords = [
     'Lavanti',
     'poliitikko',
     'kunnanvaltuutettu',
+    'eduskuntavaalit',
     'digitalisaatio',
     'tekoäly',
     'teknologia',
     'tietopolitiikka',
+    'digitaalinen itsenäisyys',
     'digitaalinen riippumattomuus',
     'yksityisyydensuoja',
     'vastuullinen tekoäly',
     'yrittäjyys',
     'talous',
+    'innovaatiopolitiikka',
 ].join(', ')
 ---
 

--- a/src/components/Head.spec.ts
+++ b/src/components/Head.spec.ts
@@ -246,7 +246,7 @@ describe('<Head />', () => {
         expect(jsonLd.memberOf['@type']).toBe('PoliticalParty')
         expect(jsonLd.memberOf.name).toBe('Vihreä liitto')
         expect(jsonLd.memberOf.url).toBe('https://www.vihreat.fi')
-        expect(jsonLd.knowsAbout).toHaveLength(5)
+        expect(jsonLd.knowsAbout).toHaveLength(9)
     })
 
     it('should localise Person jobTitle for English', async () => {


### PR DESCRIPTION
> This PR contains AI-generated code. The author has reviewed and is responsible for all AI-generated content.

Closes #1170

## Summary

- Adds `digitaalinen itsenäisyys` (the canonical citizens'-initiative term, distinct from `digitaalinen riippumattomuus`) and `innovaatiopolitiikka` to the meta keywords list
- Expands the PERSON JSON-LD `knowsAbout` array with `Tekoäly`, `Digitaalinen itsenäisyys`, `Vastuullinen tekoäly`, and `Eduskuntavaalit` for stronger AEO/AI-crawler signal
- Adds `eduskuntavaalit` to meta keywords and weaves it into the Finnish and Swedish PERSON JSON-LD `description` fields — machine-readable only, not visible to users

## Test plan

- [ ] `npm run build` succeeds
- [ ] `npm run test` passes (updated `knowsAbout` length assertion in `Head.spec.ts`)
- [ ] Inspect `dist/fi/index.html`: meta keywords contain all new terms
- [ ] Inspect `dist/fi/index.html`: JSON-LD `knowsAbout` array contains all new topics