### PR TITLE
feat(legal): license site content under CC BY-SA 4.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+## Code License
+
 MIT License
 
 Copyright (c) 2024 Lauri Lavanti
@@ -19,3 +21,12 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+## Content License
+
+All site content — including MDX files, blog posts, and written text — is licensed under
+Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0).
+
+https://creativecommons.org/licenses/by-sa/4.0/

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -50,15 +50,23 @@ const licenseText: Record<Lang, string> = {
         width: 100%;
     }
 
-    .container > div,
-    .container > ul {
+    .top {
+        align-items: center;
+        display: flex;
+        flex-direction: column;
+        gap: var(--sizes15);
+        width: 100%;
+    }
+
+    .top > div,
+    .top > ul {
         align-items: center;
         display: flex;
         flex-direction: row;
         justify-content: center;
     }
 
-    .container > ul {
+    .top > ul {
         flex: 1;
         flex-wrap: wrap;
         gap: var(--sizes15);
@@ -77,45 +85,55 @@ const licenseText: Record<Lang, string> = {
 
     @media (min-width: 1200px) {
         .container {
-            flex-direction: row;
             padding-left: var(--contentPadding);
             padding-right: var(--contentPadding);
             width: var(--contentSize);
         }
 
-        .container > div {
+        .top {
+            flex-direction: row;
+        }
+
+        .top > div {
             justify-content: flex-start;
         }
 
-        .container > ul {
+        .top > ul {
             justify-content: flex-end;
         }
     }
 </style>
 <footer id="footer">
     <div class="container">
-        <div>
-            <img
-                alt={footerLogoAlt[lang]}
-                height="45"
-                loading="lazy"
-                src="/images/greensLogo3Languages.min.svg"
-                width="144"
-            />
-        </div>
-        <ul>
-            {
-                footerLinks.map((link) =>
-                    link.icon === 'instagram' ? (
-                        <InstagramLink ariaLabel={getAriaLabel(link.title)} title={link.title} url={link.url} />
-                    ) : link.icon === 'tiktok' ? (
-                        <TikTokLink ariaLabel={getAriaLabel(link.title)} title={link.title} url={link.url} />
-                    ) : (
-                        <Link ariaLabel={getAriaLabel(link.title)} icon={link.icon} title={link.title} url={link.url} />
+        <div class="top">
+            <div>
+                <img
+                    alt={footerLogoAlt[lang]}
+                    height="45"
+                    loading="lazy"
+                    src="/images/greensLogo3Languages.min.svg"
+                    width="144"
+                />
+            </div>
+            <ul>
+                {
+                    footerLinks.map((link) =>
+                        link.icon === 'instagram' ? (
+                            <InstagramLink ariaLabel={getAriaLabel(link.title)} title={link.title} url={link.url} />
+                        ) : link.icon === 'tiktok' ? (
+                            <TikTokLink ariaLabel={getAriaLabel(link.title)} title={link.title} url={link.url} />
+                        ) : (
+                            <Link
+                                ariaLabel={getAriaLabel(link.title)}
+                                icon={link.icon}
+                                title={link.title}
+                                url={link.url}
+                            />
+                        )
                     )
-                )
-            }
-        </ul>
+                }
+            </ul>
+        </div>
         <p class="license">
             {licenseText[lang]}
             {' '}

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -13,6 +13,14 @@ interface Props {
 
 const { lang = 'fi' } = Astro.props
 const getAriaLabel = footerAriaLabel[lang]
+
+const year = new Date().getFullYear()
+
+const licenseText: Record<Lang, string> = {
+    en: `© ${year} Lauri Lavanti. Content licensed under`,
+    fi: `© ${year} Lauri Lavanti. Sisältö lisensoitu`,
+    sv: `© ${year} Lauri Lavanti. Innehåll licensierat under`,
+}
 ---
 
 <style
@@ -53,6 +61,17 @@ const getAriaLabel = footerAriaLabel[lang]
         flex: 1;
         flex-wrap: wrap;
         gap: var(--sizes15);
+    }
+
+    .license {
+        font-size: 0.75rem;
+        opacity: 0.7;
+        text-align: center;
+        width: 100%;
+    }
+
+    .license a {
+        color: inherit;
     }
 
     @media (min-width: 1200px) {
@@ -96,5 +115,10 @@ const getAriaLabel = footerAriaLabel[lang]
                 )
             }
         </ul>
+        <p class="license">
+            {licenseText[lang]}
+            {' '}
+            <a href="https://creativecommons.org/licenses/by-sa/4.0/" rel="license">CC BY-SA 4.0</a>.
+        </p>
     </div>
 </footer>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -74,7 +74,6 @@ const licenseText: Record<Lang, string> = {
 
     .license {
         font-size: var(--sizes0875);
-        opacity: 0.7;
         text-align: center;
         width: 100%;
     }

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -30,6 +30,7 @@ const licenseText: Record<Lang, string> = {
         contentPadding: CONTENT_PADDING,
         contentSize: CONTENT_SIZE,
         gridAreasFooter: gridAreas.footer,
+        sizes0875: sizes[0.875],
         sizes15: sizes[1.5],
     }}
 >
@@ -64,7 +65,7 @@ const licenseText: Record<Lang, string> = {
     }
 
     .license {
-        font-size: 0.75rem;
+        font-size: var(--sizes0875);
         opacity: 0.7;
         text-align: center;
         width: 100%;

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -97,6 +97,7 @@ const jsonLd = JSON.stringify({
     },
     description,
     headline: title,
+    license: 'https://creativecommons.org/licenses/by-sa/4.0/',
     url: canonical,
     ...(ogImageUrl ? { image: ogImageUrl } : {}),
     ...(type === BLOGPOSTING
@@ -235,3 +236,4 @@ const keywords = [
 <link crossorigin="" href="https://res.cloudinary.com" rel="preconnect" />
 <link href="https://res.cloudinary.com" rel="dns-prefetch" />
 <link href="/sitemap-index.xml" rel="sitemap" />
+<link href="https://creativecommons.org/licenses/by-sa/4.0/" rel="license" />

--- a/src/lib/styles.ts
+++ b/src/lib/styles.ts
@@ -52,7 +52,7 @@ export const gridAreas = {
     main: 'main' as const,
 } as const
 
-export const gridTemplateRowsLayout = `1fr ${sizes[6]}` as const
+export const gridTemplateRowsLayout = `1fr auto` as const
 export const gridTemplateRowsLayoutMobile = `1fr auto` as const
 export const gridTemplateColumns = 'repeat(1, minmax(0, 1fr))' as const
 export const gridTemplateColumnsArticle =


### PR DESCRIPTION
> This PR contains AI-generated code. The author has reviewed and is responsible for all AI-generated content.

## Summary

- Adds CC BY-SA 4.0 copyright notice to the footer (trilingual fi/en/sv, year resolved at build time)
- Adds `<link rel="license">` to `<head>` for machine-readable license declaration
- Adds `license` field to all JSON-LD structured data objects
- Updates `LICENSE` file to distinguish MIT (code) from CC BY-SA 4.0 (content)

## Test plan

- [ ] Footer shows copyright notice with working CC BY-SA 4.0 link
- [ ] Page source contains `<link rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/">`
- [ ] JSON-LD in page source contains `"license":"https://creativecommons.org/licenses/by-sa/4.0/"`
- [ ] Build passes cleanly