### PR TITLE
feat(ui): restyle tags as GitHub-style label pills

### DIFF
--- a/src/components/Meta.astro
+++ b/src/components/Meta.astro
@@ -1,6 +1,7 @@
 ---
 import { getTagName } from '../content/tags'
-import { colors, sizes, typographics } from '../lib/styles'
+import { sizes, typographics } from '../lib/styles'
+import TagPill from './TagPill.astro'
 
 interface Props {
     ariaLabel: string
@@ -20,20 +21,12 @@ const dateToDisplay = `${day}.${month}.${year}`
 
 const tagsToRender = tags
     .map((tagId) => ({ id: tagId, name: getTagName(tagId, lang) }))
-    .filter((tag) => tag.name !== undefined)
+    .filter((tag): tag is { id: string; name: string } => tag.name !== undefined)
 ---
 
 <style
     define:vars={{
-        colorsDarkMoss: colors.darkMoss,
-        definitionFontFamily: typographics.definition.fontFamily,
-        definitionFontSize: typographics.definition.fontSize,
-        definitionFontWeight: typographics.definition.fontWeight,
-        definitionLineHeight: typographics.definition.lineHeight,
-        definitionTextTransform: typographics.definition.textTransform,
-        sizes0: sizes[0],
         sizes05: sizes[0.5],
-        sizes1: sizes[1],
     }}
 >
     aside {
@@ -42,27 +35,16 @@ const tagsToRender = tags
     }
 
     ul {
+        align-items: center;
         display: flex;
         flex-direction: row;
         flex-wrap: wrap;
+        gap: var(--sizes05);
         margin-top: var(--sizes05);
     }
 
     li {
-        margin-right: var(--sizes1);
-    }
-
-    li:last-child {
-        margin-right: var(--sizes0);
-    }
-
-    a {
-        color: var(--colorsDarkMoss);
-        font-size: var(--definitionFontSize);
-        line-height: var(--definitionLineHeight);
-        font-family: var(--definitionFontFamily);
-        font-weight: var(--definitionFontWeight);
-        text-transform: var(--definitionTextTransform);
+        list-style: none;
     }
 </style>
 <aside aria-label={ariaLabel}>
@@ -72,18 +54,7 @@ const tagsToRender = tags
             <ul>
                 {tagsToRender.map((tag) => (
                     <li>
-                        <a
-                            href={`${tagBasePaths[lang]}/${tag.id}/`}
-                            style={{
-                                alignItems: 'center',
-                                display: 'inline-flex',
-                                height: '2.75rem',
-                                justifyContent: 'center',
-                                minWidth: '2.75rem',
-                            }}
-                        >
-                            #{tag.name}
-                        </a>
+                        <TagPill href={`${tagBasePaths[lang]}/${tag.id}/`} label={tag.name} />
                     </li>
                 ))}
             </ul>

--- a/src/components/TagPill.astro
+++ b/src/components/TagPill.astro
@@ -11,18 +11,20 @@ const { href, label } = Astro.props
 
 <style
     define:vars={{
-        colorsDarkMoss: colors.darkMoss,
-        colorsSand: colors.sand,
+        colorsBlack: colors.black,
+        colorsEvening: colors.evening,
+        colorsSky: colors.sky,
+        colorsWhite: colors.white,
         fontFamilyMono: fontFamilies.mono,
         fontWeightMedium: fontWeights.medium,
     }}
 >
     a {
         align-items: center;
-        background-color: var(--colorsSand);
-        border: 1px solid var(--colorsDarkMoss);
+        background-color: var(--colorsSky);
+        border: 1px solid var(--colorsEvening);
         border-radius: 0.375rem;
-        color: var(--colorsDarkMoss);
+        color: var(--colorsBlack);
         display: inline-flex;
         font-family: var(--fontFamilyMono);
         font-size: 0.75rem;
@@ -34,8 +36,8 @@ const { href, label } = Astro.props
     }
 
     a:hover {
-        background-color: var(--colorsDarkMoss);
-        color: var(--colorsSand);
+        background-color: var(--colorsEvening);
+        color: var(--colorsWhite);
     }
 </style>
 <a href={href}>{label}</a>

--- a/src/components/TagPill.astro
+++ b/src/components/TagPill.astro
@@ -21,6 +21,14 @@ const { href, label } = Astro.props
 >
     a {
         align-items: center;
+        display: inline-flex;
+        height: 2.75rem;
+        justify-content: center;
+        text-decoration: none;
+    }
+
+    span {
+        align-items: center;
         background-color: var(--colorsSky);
         border: 1px solid var(--colorsEvening);
         border-radius: 0.375rem;
@@ -29,15 +37,14 @@ const { href, label } = Astro.props
         font-family: var(--fontFamilyMono);
         font-size: 0.75rem;
         font-weight: var(--fontWeightMedium);
-        height: 2.75rem;
+        height: 1.5rem;
         line-height: 1;
         padding: 0 0.5rem;
-        text-decoration: none;
     }
 
-    a:hover {
+    a:hover span {
         background-color: var(--colorsEvening);
         color: var(--colorsWhite);
     }
 </style>
-<a href={href}>{label}</a>
+<a href={href}><span>{label}</span></a>

--- a/src/components/TagPill.astro
+++ b/src/components/TagPill.astro
@@ -29,7 +29,7 @@ const { href, label } = Astro.props
         font-family: var(--fontFamilyMono);
         font-size: 0.75rem;
         font-weight: var(--fontWeightMedium);
-        height: 1.5rem;
+        height: 2.75rem;
         line-height: 1;
         padding: 0 0.5rem;
         text-decoration: none;

--- a/src/components/TagPill.astro
+++ b/src/components/TagPill.astro
@@ -1,0 +1,41 @@
+---
+import { colors, fontFamilies, fontWeights } from '../lib/styles'
+
+interface Props {
+    href: string
+    label: string
+}
+
+const { href, label } = Astro.props
+---
+
+<style
+    define:vars={{
+        colorsDarkMoss: colors.darkMoss,
+        colorsSand: colors.sand,
+        fontFamilyMono: fontFamilies.mono,
+        fontWeightMedium: fontWeights.medium,
+    }}
+>
+    a {
+        align-items: center;
+        background-color: var(--colorsSand);
+        border: 1px solid var(--colorsDarkMoss);
+        border-radius: 0.375rem;
+        color: var(--colorsDarkMoss);
+        display: inline-flex;
+        font-family: var(--fontFamilyMono);
+        font-size: 0.75rem;
+        font-weight: var(--fontWeightMedium);
+        height: 1.5rem;
+        line-height: 1;
+        padding: 0 0.5rem;
+        text-decoration: none;
+    }
+
+    a:hover {
+        background-color: var(--colorsDarkMoss);
+        color: var(--colorsSand);
+    }
+</style>
+<a href={href}>{label}</a>

--- a/src/components/TopicsTagList.astro
+++ b/src/components/TopicsTagList.astro
@@ -27,6 +27,7 @@ const items = ids.map((id) => tags.find((t) => t.id === id)).filter((t): t is No
         flex-wrap: wrap;
         gap: var(--sizes05);
         grid-column-start: 3;
+        justify-content: space-between;
         list-style: none;
         padding: 0;
     }

--- a/src/components/TopicsTagList.astro
+++ b/src/components/TopicsTagList.astro
@@ -1,0 +1,41 @@
+---
+import type { Lang } from '../content/nav'
+
+import { tags } from '../content/tags'
+import { sizes } from '../lib/styles'
+import TagPill from './TagPill.astro'
+
+interface Props {
+    ids: string[]
+    lang: Lang
+}
+
+const { ids, lang } = Astro.props
+
+const items = ids.map((id) => tags.find((t) => t.id === id)).filter((t): t is NonNullable<typeof t> => t !== undefined)
+---
+
+<style
+    define:vars={{
+        sizes05: sizes[0.5],
+    }}
+>
+    ul {
+        align-items: center;
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        gap: var(--sizes05);
+        list-style: none;
+        padding: 0;
+    }
+</style>
+<ul>
+    {
+        items.map((tag) => (
+            <li>
+                <TagPill href={`/${lang}/category/${tag.id}/`} label={tag.names[lang]} />
+            </li>
+        ))
+    }
+</ul>

--- a/src/components/TopicsTagList.astro
+++ b/src/components/TopicsTagList.astro
@@ -27,7 +27,6 @@ const items = ids.map((id) => tags.find((t) => t.id === id)).filter((t): t is No
         flex-wrap: wrap;
         gap: var(--sizes05);
         grid-column-start: 3;
-        justify-content: space-between;
         list-style: none;
         padding: 0;
     }

--- a/src/components/TopicsTagList.astro
+++ b/src/components/TopicsTagList.astro
@@ -26,6 +26,7 @@ const items = ids.map((id) => tags.find((t) => t.id === id)).filter((t): t is No
         flex-direction: row;
         flex-wrap: wrap;
         gap: var(--sizes05);
+        grid-column-start: 3;
         list-style: none;
         padding: 0;
     }

--- a/src/lib/styles.spec.ts
+++ b/src/lib/styles.spec.ts
@@ -95,6 +95,7 @@ describe('styles', () => {
                 peach: 'rgb(248, 207, 169)',
                 regionalPurple: '#865C97',
                 sand: 'rgb(214, 210, 196)',
+                sky: '#bbdde6',
                 threads: 'rgb(0, 0, 0)',
                 transparent: 'transparent',
                 white: 'rgb(255, 255, 255)',

--- a/src/lib/styles.ts
+++ b/src/lib/styles.ts
@@ -78,6 +78,7 @@ export const colors = {
     peach: 'rgb(248, 207, 169)' as const,
     regionalPurple: '#865C97' as const,
     sand: 'rgb(214, 210, 196)' as const,
+    sky: '#bbdde6' as const,
     threads: 'rgb(0, 0, 0)' as const,
     transparent: 'transparent' as const,
     white: 'rgb(255, 255, 255)' as const,

--- a/src/pages/en/blog/index.mdx
+++ b/src/pages/en/blog/index.mdx
@@ -26,7 +26,7 @@ I have over a decade of hands-on experience building secure software and banking
 
 <TopicsTagList
     lang="en"
-    ids={['artificial-intelligence', 'economy', 'learning', 'freedom', 'digital-independence']}
+    ids={['artificial-intelligence', 'economy', 'learning', 'freedom', 'digital-independence', 'kirkkonummi']}
 />
 
 ## Featured

--- a/src/pages/en/blog/index.mdx
+++ b/src/pages/en/blog/index.mdx
@@ -12,7 +12,7 @@ alt: 'Lauri Lavanti sitting on a stool leaning against a tall table. He is weari
 import ExcerptList from '../../../components/ExcerptList.astro'
 import H2 from '../../../components/H2.astro'
 import Paragraph from '../../../components/Paragraph.astro'
-import TopicsList from '../../../components/TopicsList.astro'
+import TopicsTagList from '../../../components/TopicsTagList.astro'
 
 export const components = { h2: H2, p: Paragraph }
 
@@ -24,7 +24,7 @@ I have over a decade of hands-on experience building secure software and banking
 
 ## By topic
 
-<TopicsList
+<TopicsTagList
     lang="en"
     ids={['artificial-intelligence', 'economy', 'learning', 'freedom', 'digital-independence']}
 />

--- a/src/pages/fi/blog/index.mdx
+++ b/src/pages/fi/blog/index.mdx
@@ -26,7 +26,7 @@ Käytännön kokemukseni on yli vuosikymmenen ajalta turvallisten ohjelmistojen 
 
 <TopicsTagList
     lang="fi"
-    ids={['artificial-intelligence', 'economy', 'learning', 'freedom', 'digital-independence']}
+    ids={['artificial-intelligence', 'economy', 'learning', 'freedom', 'digital-independence', 'kirkkonummi']}
 />
 
 ## Nostot

--- a/src/pages/fi/blog/index.mdx
+++ b/src/pages/fi/blog/index.mdx
@@ -12,7 +12,7 @@ alt: 'Lauri Lavanti istumassa jakkaralla ja nojaa korkeaan pöytään. Päällä
 import ExcerptList from '../../../components/ExcerptList.astro'
 import H2 from '../../../components/H2.astro'
 import Paragraph from '../../../components/Paragraph.astro'
-import TopicsList from '../../../components/TopicsList.astro'
+import TopicsTagList from '../../../components/TopicsTagList.astro'
 
 export const components = { h2: H2, p: Paragraph }
 
@@ -24,7 +24,7 @@ Käytännön kokemukseni on yli vuosikymmenen ajalta turvallisten ohjelmistojen 
 
 ## Aiheittain
 
-<TopicsList
+<TopicsTagList
     lang="fi"
     ids={['artificial-intelligence', 'economy', 'learning', 'freedom', 'digital-independence']}
 />

--- a/src/pages/sv/blog/index.mdx
+++ b/src/pages/sv/blog/index.mdx
@@ -12,7 +12,7 @@ alt: 'Lauri Lavanti sitter på en pall och lutar sig mot ett högt bord. Han har
 import ExcerptList from '../../../components/ExcerptList.astro'
 import H2 from '../../../components/H2.astro'
 import Paragraph from '../../../components/Paragraph.astro'
-import TopicsList from '../../../components/TopicsList.astro'
+import TopicsTagList from '../../../components/TopicsTagList.astro'
 
 export const components = { h2: H2, p: Paragraph }
 
@@ -24,7 +24,7 @@ Jag har över ett årtiondes praktisk erfarenhet av att bygga säker programvara
 
 ## Efter ämne
 
-<TopicsList
+<TopicsTagList
     lang="sv"
     ids={['artificial-intelligence', 'economy', 'learning', 'freedom', 'digital-independence']}
 />

--- a/src/pages/sv/blog/index.mdx
+++ b/src/pages/sv/blog/index.mdx
@@ -26,7 +26,7 @@ Jag har över ett årtiondes praktisk erfarenhet av att bygga säker programvara
 
 <TopicsTagList
     lang="sv"
-    ids={['artificial-intelligence', 'economy', 'learning', 'freedom', 'digital-independence']}
+    ids={['artificial-intelligence', 'economy', 'learning', 'freedom', 'digital-independence', 'kirkkonummi']}
 />
 
 ## Utvalda

--- a/tests/__snapshots__/components/TitleBanner.spec.ts.snap
+++ b/tests/__snapshots__/components/TitleBanner.spec.ts.snap
@@ -53,7 +53,7 @@ exports[`<TitleBanner /> > should render 1`] = `
             <a
               data-astro-cid-marlabwr=""
               href="/fi/category/artificial-intelligence/"
-              style="--colorsDarkMoss: rgb(72, 75, 0);--colorsSand: rgb(214, 210, 196);--fontFamilyMono: "IBM Plex Mono", Lucida Sans Typewriter;--fontWeightMedium: 500;"
+              style="--colorsBlack: rgb(0, 0, 0);--colorsEvening: rgb(0, 98, 114);--colorsSky: #bbdde6;--colorsWhite: rgb(255, 255, 255);--fontFamilyMono: "IBM Plex Mono", Lucida Sans Typewriter;--fontWeightMedium: 500;"
             >
               Tekoäly
             </a>

--- a/tests/__snapshots__/components/TitleBanner.spec.ts.snap
+++ b/tests/__snapshots__/components/TitleBanner.spec.ts.snap
@@ -55,7 +55,12 @@ exports[`<TitleBanner /> > should render 1`] = `
               href="/fi/category/artificial-intelligence/"
               style="--colorsBlack: rgb(0, 0, 0);--colorsEvening: rgb(0, 98, 114);--colorsSky: #bbdde6;--colorsWhite: rgb(255, 255, 255);--fontFamilyMono: "IBM Plex Mono", Lucida Sans Typewriter;--fontWeightMedium: 500;"
             >
-              Tekoäly
+              <span
+                data-astro-cid-marlabwr=""
+                style="--colorsBlack: rgb(0, 0, 0);--colorsEvening: rgb(0, 98, 114);--colorsSky: #bbdde6;--colorsWhite: rgb(255, 255, 255);--fontFamilyMono: "IBM Plex Mono", Lucida Sans Typewriter;--fontWeightMedium: 500;"
+              >
+                Tekoäly
+              </span>
             </a>
              
           </li>

--- a/tests/__snapshots__/components/TitleBanner.spec.ts.snap
+++ b/tests/__snapshots__/components/TitleBanner.spec.ts.snap
@@ -29,34 +29,33 @@ exports[`<TitleBanner /> > should render 1`] = `
       <aside
         aria-label="Kirjoituksen Test Title meta-tiedot"
         data-astro-cid-k4jemuzu=""
-        style="--colorsDarkMoss: rgb(72, 75, 0);--definitionFontFamily: "IBM Plex Mono", Lucida Sans Typewriter;--definitionFontSize: 1rem;--definitionFontWeight: 500;--definitionLineHeight: 1.5rem;--definitionTextTransform: uppercase;--sizes0: 0px;--sizes05: 0.5rem;--sizes1: 1rem;"
+        style="--sizes05: 0.5rem;"
       >
          
         <time
           data-astro-cid-k4jemuzu=""
           datetime="2026-01-01"
-          style="font-size:1.875rem;line-height:2.25rem;font-family:"IBM Plex Sans", Trebuchet MS;font-weight:300;--colorsDarkMoss: rgb(72, 75, 0);--definitionFontFamily: "IBM Plex Mono", Lucida Sans Typewriter;--definitionFontSize: 1rem;--definitionFontWeight: 500;--definitionLineHeight: 1.5rem;--definitionTextTransform: uppercase;--sizes0: 0px;--sizes05: 0.5rem;--sizes1: 1rem;"
+          style="font-size:1.875rem;line-height:2.25rem;font-family:"IBM Plex Sans", Trebuchet MS;font-weight:300;--sizes05: 0.5rem;"
         >
           01.01.2026
         </time>
          
         <ul
           data-astro-cid-k4jemuzu=""
-          style="--colorsDarkMoss: rgb(72, 75, 0);--definitionFontFamily: "IBM Plex Mono", Lucida Sans Typewriter;--definitionFontSize: 1rem;--definitionFontWeight: 500;--definitionLineHeight: 1.5rem;--definitionTextTransform: uppercase;--sizes0: 0px;--sizes05: 0.5rem;--sizes1: 1rem;"
+          style="--sizes05: 0.5rem;"
         >
            
           <li
             data-astro-cid-k4jemuzu=""
-            style="--colorsDarkMoss: rgb(72, 75, 0);--definitionFontFamily: "IBM Plex Mono", Lucida Sans Typewriter;--definitionFontSize: 1rem;--definitionFontWeight: 500;--definitionLineHeight: 1.5rem;--definitionTextTransform: uppercase;--sizes0: 0px;--sizes05: 0.5rem;--sizes1: 1rem;"
+            style="--sizes05: 0.5rem;"
           >
              
             <a
-              data-astro-cid-k4jemuzu=""
+              data-astro-cid-marlabwr=""
               href="/fi/category/artificial-intelligence/"
-              style="align-items:center;display:inline-flex;height:2.75rem;justify-content:center;min-width:2.75rem;--colorsDarkMoss: rgb(72, 75, 0);--definitionFontFamily: "IBM Plex Mono", Lucida Sans Typewriter;--definitionFontSize: 1rem;--definitionFontWeight: 500;--definitionLineHeight: 1.5rem;--definitionTextTransform: uppercase;--sizes0: 0px;--sizes05: 0.5rem;--sizes1: 1rem;"
+              style="--colorsDarkMoss: rgb(72, 75, 0);--colorsSand: rgb(214, 210, 196);--fontFamilyMono: "IBM Plex Mono", Lucida Sans Typewriter;--fontWeightMedium: 500;"
             >
-              
-#Tekoäly 
+              Tekoäly
             </a>
              
           </li>

--- a/tests/__snapshots__/components/titleBanner/Title.spec.ts.snap
+++ b/tests/__snapshots__/components/titleBanner/Title.spec.ts.snap
@@ -17,34 +17,33 @@ exports[`<Title /> > should render 1`] = `
   <aside
     aria-label="Kirjoituksen Test Title meta-tiedot"
     data-astro-cid-k4jemuzu=""
-    style="--colorsDarkMoss: rgb(72, 75, 0);--definitionFontFamily: "IBM Plex Mono", Lucida Sans Typewriter;--definitionFontSize: 1rem;--definitionFontWeight: 500;--definitionLineHeight: 1.5rem;--definitionTextTransform: uppercase;--sizes0: 0px;--sizes05: 0.5rem;--sizes1: 1rem;"
+    style="--sizes05: 0.5rem;"
   >
      
     <time
       data-astro-cid-k4jemuzu=""
       datetime="2026-01-01"
-      style="font-size:1.875rem;line-height:2.25rem;font-family:"IBM Plex Sans", Trebuchet MS;font-weight:300;--colorsDarkMoss: rgb(72, 75, 0);--definitionFontFamily: "IBM Plex Mono", Lucida Sans Typewriter;--definitionFontSize: 1rem;--definitionFontWeight: 500;--definitionLineHeight: 1.5rem;--definitionTextTransform: uppercase;--sizes0: 0px;--sizes05: 0.5rem;--sizes1: 1rem;"
+      style="font-size:1.875rem;line-height:2.25rem;font-family:"IBM Plex Sans", Trebuchet MS;font-weight:300;--sizes05: 0.5rem;"
     >
       01.01.2026
     </time>
      
     <ul
       data-astro-cid-k4jemuzu=""
-      style="--colorsDarkMoss: rgb(72, 75, 0);--definitionFontFamily: "IBM Plex Mono", Lucida Sans Typewriter;--definitionFontSize: 1rem;--definitionFontWeight: 500;--definitionLineHeight: 1.5rem;--definitionTextTransform: uppercase;--sizes0: 0px;--sizes05: 0.5rem;--sizes1: 1rem;"
+      style="--sizes05: 0.5rem;"
     >
        
       <li
         data-astro-cid-k4jemuzu=""
-        style="--colorsDarkMoss: rgb(72, 75, 0);--definitionFontFamily: "IBM Plex Mono", Lucida Sans Typewriter;--definitionFontSize: 1rem;--definitionFontWeight: 500;--definitionLineHeight: 1.5rem;--definitionTextTransform: uppercase;--sizes0: 0px;--sizes05: 0.5rem;--sizes1: 1rem;"
+        style="--sizes05: 0.5rem;"
       >
          
         <a
-          data-astro-cid-k4jemuzu=""
+          data-astro-cid-marlabwr=""
           href="/fi/category/artificial-intelligence/"
-          style="align-items:center;display:inline-flex;height:2.75rem;justify-content:center;min-width:2.75rem;--colorsDarkMoss: rgb(72, 75, 0);--definitionFontFamily: "IBM Plex Mono", Lucida Sans Typewriter;--definitionFontSize: 1rem;--definitionFontWeight: 500;--definitionLineHeight: 1.5rem;--definitionTextTransform: uppercase;--sizes0: 0px;--sizes05: 0.5rem;--sizes1: 1rem;"
+          style="--colorsDarkMoss: rgb(72, 75, 0);--colorsSand: rgb(214, 210, 196);--fontFamilyMono: "IBM Plex Mono", Lucida Sans Typewriter;--fontWeightMedium: 500;"
         >
-          
-#Tekoäly 
+          Tekoäly
         </a>
          
       </li>

--- a/tests/__snapshots__/components/titleBanner/Title.spec.ts.snap
+++ b/tests/__snapshots__/components/titleBanner/Title.spec.ts.snap
@@ -41,7 +41,7 @@ exports[`<Title /> > should render 1`] = `
         <a
           data-astro-cid-marlabwr=""
           href="/fi/category/artificial-intelligence/"
-          style="--colorsDarkMoss: rgb(72, 75, 0);--colorsSand: rgb(214, 210, 196);--fontFamilyMono: "IBM Plex Mono", Lucida Sans Typewriter;--fontWeightMedium: 500;"
+          style="--colorsBlack: rgb(0, 0, 0);--colorsEvening: rgb(0, 98, 114);--colorsSky: #bbdde6;--colorsWhite: rgb(255, 255, 255);--fontFamilyMono: "IBM Plex Mono", Lucida Sans Typewriter;--fontWeightMedium: 500;"
         >
           Tekoäly
         </a>

--- a/tests/__snapshots__/components/titleBanner/Title.spec.ts.snap
+++ b/tests/__snapshots__/components/titleBanner/Title.spec.ts.snap
@@ -43,7 +43,12 @@ exports[`<Title /> > should render 1`] = `
           href="/fi/category/artificial-intelligence/"
           style="--colorsBlack: rgb(0, 0, 0);--colorsEvening: rgb(0, 98, 114);--colorsSky: #bbdde6;--colorsWhite: rgb(255, 255, 255);--fontFamilyMono: "IBM Plex Mono", Lucida Sans Typewriter;--fontWeightMedium: 500;"
         >
-          Tekoäly
+          <span
+            data-astro-cid-marlabwr=""
+            style="--colorsBlack: rgb(0, 0, 0);--colorsEvening: rgb(0, 98, 114);--colorsSky: #bbdde6;--colorsWhite: rgb(255, 255, 255);--fontFamilyMono: "IBM Plex Mono", Lucida Sans Typewriter;--fontWeightMedium: 500;"
+          >
+            Tekoäly
+          </span>
         </a>
          
       </li>

--- a/tests/e2e/blogEnPage.spec.ts-snapshots/Blog-Page-in-English-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/blogEnPage.spec.ts-snapshots/Blog-Page-in-English-should-match-aria-snapshot-1.aria.yml
@@ -6,26 +6,22 @@
     - heading "What does it mean to live in the age of AI?" [level=2]
     - paragraph: I have over a decade of hands-on experience building secure software and banking systems. From that background I write about why AI does not merely speed up work but forces us to rethink the whole social safety net, why digital independence is a precondition for a free society, and how to ensure that the benefits of technology reach everyone — not only a few.
     - heading "By topic" [level=2]
-    - heading "Artificial intelligence" [level=2]:
-      - link "Artificial intelligence":
-        - /url: /en/category/artificial-intelligence/
-    - paragraph: I use AI tools professionally as a lead developer — I argue from hands-on experience, not theory. Finland must engage with AI actively and critically.
-    - heading "Economy" [level=2]:
-      - link "Economy":
-        - /url: /en/category/economy/
-    - paragraph: Keeping Finland’s economy working through the AI shift — new firms, new jobs and public services that use technology with judgement, not as a black box.
-    - heading "Learning" [level=2]:
-      - link "Learning":
-        - /url: /en/category/learning/
-    - paragraph: In the AI era learning must stay seamless from early childhood to working life — so AI productivity gains don’t leave most people behind.
-    - heading "Freedom" [level=2]:
-      - link "Freedom":
-        - /url: /en/category/freedom/
-    - paragraph: Freedom in the AI era is whether your data and communications remain yours when infrastructure scales surveillance to everyone, all the time.
-    - heading "Digital independence" [level=2]:
-      - link "Digital independence":
-        - /url: /en/category/digital-independence/
-    - paragraph: Finland and Europe must control their own digital infrastructure. I authored the citizens' initiative calling for reduced dependency on foreign cloud providers.
+    - list:
+      - listitem:
+        - link "Artificial intelligence":
+          - /url: /en/category/artificial-intelligence/
+      - listitem:
+        - link "Economy":
+          - /url: /en/category/economy/
+      - listitem:
+        - link "Learning":
+          - /url: /en/category/learning/
+      - listitem:
+        - link "Freedom":
+          - /url: /en/category/freedom/
+      - listitem:
+        - link "Digital independence":
+          - /url: /en/category/digital-independence/
     - heading "Featured" [level=2]
     - list:
       - listitem:
@@ -38,13 +34,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Privacy":
+                - link "Privacy":
                   - /url: /en/category/privacy/
               - listitem:
-                - link "#Technology":
+                - link "Technology":
                   - /url: /en/category/technology/
               - listitem:
-                - link "#Digitalisation":
+                - link "Digitalisation":
                   - /url: /en/category/digitalisation/
           - paragraph: The European Parliament rejected the extension of the chat control law. The police statistics are real, but parliament was still right — here is why.
       - listitem:
@@ -57,10 +53,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Digital independence":
+                - link "Digital independence":
                   - /url: /en/category/digital-independence/
               - listitem:
-                - link "#Digitalisation":
+                - link "Digitalisation":
                   - /url: /en/category/digitalisation/
           - paragraph: Finland's digital services depend on US platforms. As the US becomes unreliable, digital sovereignty is no longer optional — it is a necessity.
       - listitem:
@@ -73,10 +69,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Technology":
+                - link "Technology":
                   - /url: /en/category/technology/
               - listitem:
-                - link "#Privacy":
+                - link "Privacy":
                   - /url: /en/category/privacy/
           - paragraph: When fingerprints were added to passports, Finland created a national biometric register. Now the government wants to open it to police use.
       - listitem:
@@ -89,10 +85,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Digitalisation":
+                - link "Digitalisation":
                   - /url: /en/category/digitalisation/
               - listitem:
-                - link "#Artificial intelligence":
+                - link "Artificial intelligence":
                   - /url: /en/category/artificial-intelligence/
           - paragraph: AI is changing society — but perhaps not as you imagine. The biggest changes will be in private life and in the everyday lives of children.
     - heading "All posts" [level=2]
@@ -107,10 +103,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Artificial intelligence":
+                - link "Artificial intelligence":
                   - /url: /en/category/artificial-intelligence/
               - listitem:
-                - link "#Digitalisation":
+                - link "Digitalisation":
                   - /url: /en/category/digitalisation/
           - paragraph: AI does in two minutes what used to take a developer two weeks. The price of code is collapsing — but what will developers get paid for instead?
       - listitem:
@@ -123,10 +119,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Nature":
+                - link "Nature":
                   - /url: /en/category/nature/
           - paragraph: Kirkkonummi acquired Lähteelä, a coastal area. One of the few places on Kirkkonummi's coast accessible without a private boat — now permanently open to all.
       - listitem:
@@ -139,10 +135,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Equality & equity":
+                - link "Equality & equity":
                   - /url: /en/category/equality-and-non-discrimination/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
           - paragraph: /Bullying of rainbow youth is increasing\. Kirkkonummi voted \d+–\d+ for flag-flying — a small gesture with measurable effects on young people's wellbeing\./
       - listitem:
@@ -155,10 +151,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Digital independence":
+                - link "Digital independence":
                   - /url: /en/category/digital-independence/
               - listitem:
-                - link "#Digitalisation":
+                - link "Digitalisation":
                   - /url: /en/category/digitalisation/
           - paragraph: Digital independence is built in every procurement decision. Helsinki chose Finnish UpCloud as the platform for its core public services system.
       - listitem:
@@ -171,7 +167,7 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Equality & equity":
+                - link "Equality & equity":
                   - /url: /en/category/equality-and-non-discrimination/
           - paragraph: The municipal council of Kirkkonummi on 9.3. accepted my initiative for hoisting the Pride flag in Kirkkonummi, twice a year!
       - listitem:
@@ -184,13 +180,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infrastructure":
+                - link "Infrastructure":
                   - /url: /en/category/infrastructure/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Western railway":
+                - link "Western railway":
                   - /url: /en/category/west-railway/
           - paragraph: The West Railway decision revealed shortcomings in Kirkkonummi's strategic planning. The municipality risks bearing the costs without the benefits.
       - listitem:
@@ -203,10 +199,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Culture & education":
+                - link "Culture & education":
                   - /url: /en/category/culture-and-education/
           - paragraph: Kirkkonummi's renovation creates a culture cluster of Fyyri, Lyyra and Rovastinpuisto park. It sets conditions for growth for decades to come.
       - listitem:
@@ -219,13 +215,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infrastructure":
+                - link "Infrastructure":
                   - /url: /en/category/infrastructure/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Western railway":
+                - link "Western railway":
                   - /url: /en/category/west-railway/
           - paragraph: I voted for Kirkkonummi to join the Western Rail Link. The decision determines whether Northern Kirkkonummi gets a commuter rail station.
       - listitem:
@@ -238,10 +234,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Technology":
+                - link "Technology":
                   - /url: /en/category/technology/
               - listitem:
-                - link "#Privacy":
+                - link "Privacy":
                   - /url: /en/category/privacy/
           - paragraph: The government plans to extend intelligence methods to fight crime without individual suspicion — a serious threat to fundamental rights.
       - listitem:
@@ -254,10 +250,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Digitalisation":
+                - link "Digitalisation":
                   - /url: /en/category/digitalisation/
               - listitem:
-                - link "#Artificial intelligence":
+                - link "Artificial intelligence":
                   - /url: /en/category/artificial-intelligence/
           - paragraph: AI has been presented as a solution for improving public services. It may have a role, but cannot replace people or clear strategic planning.
       - listitem:
@@ -270,10 +266,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Social media":
+                - link "Social media":
                   - /url: /en/category/social-media/
               - listitem:
-                - link "#Technology":
+                - link "Technology":
                   - /url: /en/category/technology/
           - paragraph: Are we prepared for our conversations to be steered by foreign large corporations? There are no guarantees that algorithms would not be used deliberately.
       - listitem:
@@ -286,10 +282,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /en/category/immigration/
               - listitem:
-                - link "#Equality & equity":
+                - link "Equality & equity":
                   - /url: /en/category/equality-and-non-discrimination/
           - paragraph: Myths about immigration distort public debate. Ten common misconceptions are examined against what the facts actually show about immigration to Finland.
       - listitem:
@@ -302,13 +298,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infrastructure":
+                - link "Infrastructure":
                   - /url: /en/category/infrastructure/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Transport":
+                - link "Transport":
                   - /url: /en/category/transportation/
           - paragraph: HSL plans significant fare increases for buses and trains. This risks a downward spiral — fewer users means more pressure to raise prices further.
       - listitem:
@@ -321,7 +317,7 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Equality & equity":
+                - link "Equality & equity":
                   - /url: /en/category/equality-and-non-discrimination/
           - paragraph: Pride is about everyone's right to be proud of their existence. Gender and sexual minorities still face more discrimination than others.
       - listitem:
@@ -334,13 +330,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Equality & equity":
+                - link "Equality & equity":
                   - /url: /en/category/equality-and-non-discrimination/
               - listitem:
-                - link "#Council motion":
+                - link "Council motion":
                   - /url: /en/category/council-motion/
           - paragraph: Kirkkonummi's strategy promotes equality and equal treatment. Flying the Pride flag is an inexpensive and easy action to implement it.
       - listitem:
@@ -353,13 +349,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Education":
+                - link "Education":
                   - /url: /en/category/education/
               - listitem:
-                - link "#Early childhood education":
+                - link "Early childhood education":
                   - /url: /en/category/early-childhood-education/
           - paragraph: The government's mid-term session cut state subsidies and corporate tax. This significantly narrows the room for manoeuvre for local councils.
       - listitem:
@@ -372,16 +368,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Education":
+                - link "Education":
                   - /url: /en/category/education/
               - listitem:
-                - link "#Early childhood education":
+                - link "Early childhood education":
                   - /url: /en/category/early-childhood-education/
           - paragraph: Education is the municipality's most important task. Investment in education pays off far into the future — there are no quick wins.
       - listitem:
@@ -394,16 +390,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Western Uusimaa":
+                - link "Western Uusimaa":
                   - /url: /en/category/western-uusimaa/
           - paragraph: The government wants to place upper secondary students in unequal positions based on citizenship. Tuition fees must be opposed absolutely.
       - listitem:
@@ -416,16 +412,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Western Uusimaa":
+                - link "Western Uusimaa":
                   - /url: /en/category/western-uusimaa/
           - paragraph: Kirkkonummi's centre renovation is a golden opportunity. A vibrant centre attracts residents and businesses — and improves the municipality's finances.
       - listitem:
@@ -438,16 +434,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Western Uusimaa":
+                - link "Western Uusimaa":
                   - /url: /en/category/western-uusimaa/
           - paragraph: Parties market themselves with images and slogans. It pays to challenge candidates on what their claims are actually based on before casting your vote.
       - listitem:
@@ -460,10 +456,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
           - paragraph: "Municipal elections may seem complex, but they decide everyday matters: schools, daycare and transport connections. You have the power to influence them."
       - listitem:
@@ -476,16 +472,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /en/category/immigration/
           - paragraph: Growing polarisation and inequality-creating policies unnecessarily divide our small nation. History shows we fare best when we cooperate.
       - listitem:
@@ -498,16 +494,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /en/category/immigration/
           - paragraph: There are many misconceptions about asylum seekers. It is important to distinguish facts from myths — seekers do not live at taxpayers' expense.
       - listitem:
@@ -520,16 +516,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /en/category/immigration/
           - paragraph: Receiving asylum is not automatic — it is a carefully defined process. Too often we forget the actual people behind the applications.
       - listitem:
@@ -542,16 +538,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /en/category/immigration/
           - paragraph: Students who come to Finland from abroad bring skilled workers. Yet we still have major challenges with their employment after graduation.
       - listitem:
@@ -564,16 +560,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /en/category/immigration/
           - paragraph: Labour-based immigration helps solve Finland's labour shortage. However, better conditions for integration and employment are still needed.
       - listitem:
@@ -586,13 +582,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Education":
+                - link "Education":
                   - /url: /en/category/education/
           - paragraph: Education is being cut deeply, despite government claims to the contrary. Index increases and legal reforms do not cover hundreds of millions in cuts.
       - listitem:
@@ -605,16 +601,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /en/category/immigration/
           - paragraph: Those who immigrate on the basis of family ties are a diverse group. They are often further along in integration than other immigrant groups.
       - listitem:
@@ -627,10 +623,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Equality & equity":
+                - link "Equality & equity":
                   - /url: /en/category/equality-and-non-discrimination/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
           - paragraph: /Finland turns \d+\. It is time to rehabilitate patriotism — Finland is one of the world's finest countries, where everyone is equally valued\./
       - listitem:
@@ -643,16 +639,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /en/category/immigration/
           - paragraph: In immigration discussions, volumes are often left unmentioned. Finland's immigration is a fraction of comparable countries' levels.
       - listitem:
@@ -665,16 +661,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /en/category/immigration/
           - paragraph: The immigration debate has long been dominated by critical voices. It is time to examine the topic more evenhandedly, based on facts.
       - listitem:
@@ -687,13 +683,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Education":
+                - link "Education":
                   - /url: /en/category/education/
           - paragraph: /The government is making necessary reforms to upper secondary education, but they do not compensate for €\d+ million cuts to vocational education\./
       - listitem:
@@ -706,16 +702,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Western Uusimaa":
+                - link "Western Uusimaa":
                   - /url: /en/category/western-uusimaa/
           - paragraph: Young people are living through crisis after crisis. The responsibility for a better future lies with us adults, not with the young.
       - listitem:
@@ -728,16 +724,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Western Uusimaa":
+                - link "Western Uusimaa":
                   - /url: /en/category/western-uusimaa/
           - paragraph: /I am standing in both the municipal and regional elections in \d+\. My priority is securing good opportunities for children and young people\./
       - listitem:
@@ -750,10 +746,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Early childhood education":
+                - link "Early childhood education":
                   - /url: /en/category/early-childhood-education/
           - paragraph: The government plans to cut funding for early childhood education planning. In practice the costs will simply be transferred to municipalities.
       - listitem:
@@ -766,13 +762,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Urban planning":
+                - link "Urban planning":
                   - /url: /en/category/urban-planning/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Co-op elections":
+                - link "Co-op elections":
                   - /url: /en/category/coop-elections/
           - paragraph: The Varuboden-Osla co-op elections are now under way. By voting you influence people's jobs, consumer behaviour and local services.
       - listitem:
@@ -785,13 +781,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infrastructure":
+                - link "Infrastructure":
                   - /url: /en/category/infrastructure/
               - listitem:
-                - link "#Urban planning":
+                - link "Urban planning":
                   - /url: /en/category/urban-planning/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
           - paragraph: One of Kirkkonummi's greatest attractions is our nature. The participatory budgeting that has just begun has shown this once again.
       - listitem:
@@ -804,13 +800,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infrastructure":
+                - link "Infrastructure":
                   - /url: /en/category/infrastructure/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Transport":
+                - link "Transport":
                   - /url: /en/category/transportation/
           - paragraph: Kirkkonummi's winter maintenance has again proved as poor as in previous years. It does not have to be this way — we can choose to demand quality.
       - listitem:
@@ -823,13 +819,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Education":
+                - link "Education":
                   - /url: /en/category/education/
           - paragraph: Municipalities must plan for the long term. Short-sighted decisions lead to extra costs and poorer services for residents over time.
       - listitem:
@@ -842,7 +838,7 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
           - paragraph: The racism statement is an important step. Word choices matter — with words we shape reality and our relationship to difference.
       - listitem:
@@ -855,13 +851,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Transport":
+                - link "Transport":
                   - /url: /en/category/transportation/
               - listitem:
-                - link "#Infrastructure":
+                - link "Infrastructure":
                   - /url: /en/category/infrastructure/
           - paragraph: That is, for light traffic — pedestrians and cyclists. What if we stopped building society on the terms of private car use?
       - listitem:
@@ -874,16 +870,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Urban planning":
+                - link "Urban planning":
                   - /url: /en/category/urban-planning/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Education":
+                - link "Education":
                   - /url: /en/category/education/
               - listitem:
-                - link "#Early childhood education":
+                - link "Early childhood education":
                   - /url: /en/category/early-childhood-education/
           - paragraph: Not every forest needs to be felled. Local nature that is in active use in particular must be preserved, and it is an important part of our municipality.
       - listitem:
@@ -896,13 +892,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2022/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Social & health reform":
+                - link "Social & health reform":
                   - /url: /en/category/health-and-social-reform/
           - paragraph: Abolishing healthcare client fees saves bureaucracy, addresses problems before they grow, and ensures no one is left without care for financial reasons.
       - listitem:
@@ -915,13 +911,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2022/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Social & health reform":
+                - link "Social & health reform":
                   - /url: /en/category/health-and-social-reform/
           - paragraph: Social and healthcare is expensive, but essential. Without a functioning welfare system, can we still call Finland a welfare state?
       - listitem:
@@ -934,13 +930,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2022/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Social & health reform":
+                - link "Social & health reform":
                   - /url: /en/category/health-and-social-reform/
           - paragraph: What if Jorvi A&E were the only emergency service for all of Western Uusimaa? What if you always had to queue for hours at Jorvi?
       - listitem:
@@ -953,10 +949,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Basic welfare":
+                - link "Basic welfare":
                   - /url: /en/category/basic-welfare/
           - paragraph: The welfare committee handles residents' appeals on welfare matters. Although its meetings are confidential, the cases offer important lessons.
       - listitem:
@@ -969,13 +965,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2022/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Social & health reform":
+                - link "Social & health reform":
                   - /url: /en/category/health-and-social-reform/
           - paragraph: I am standing in the regional elections. My priorities are maintaining local services, keeping healthcare public, and supporting care workers.
       - listitem:
@@ -988,10 +984,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Early childhood education":
+                - link "Early childhood education":
                   - /url: /en/category/early-childhood-education/
           - paragraph: Kindergartens suffer from a severe shortage of early childhood education teachers. Kirkkonummi has an opportunity to build a new kind of workplace.
       - listitem:
@@ -1004,10 +1000,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Education":
+                - link "Education":
                   - /url: /en/category/education/
           - paragraph: The Gesterby school complex project plan has been returned for further preparation three times. Six years of planning, still no new building.
       - listitem:
@@ -1020,13 +1016,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Urban planning":
+                - link "Urban planning":
                   - /url: /en/category/urban-planning/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Early childhood education":
+                - link "Early childhood education":
                   - /url: /en/category/early-childhood-education/
           - paragraph: There is already a shortage of early childhood places in Kirkkonummi's centre. New plans will increase demand — adequate provision must be secured.
       - listitem:
@@ -1039,10 +1035,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Early childhood education":
+                - link "Early childhood education":
                   - /url: /en/category/early-childhood-education/
           - paragraph: Early childhood education club activities are cost-effective support for children and families. Their future in Kirkkonummi is, however, uncertain.
       - listitem:
@@ -1055,10 +1051,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Early childhood education":
+                - link "Early childhood education":
                   - /url: /en/category/early-childhood-education/
           - paragraph: The Kirkkonummi supplement benefits not just recipient families — it strengthens the whole municipality's vitality and appeal to young families.
       - listitem:
@@ -1071,9 +1067,9 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Early childhood education":
+                - link "Early childhood education":
                   - /url: /en/category/early-childhood-education/
           - paragraph: Kirkkonummi council abolished the home care allowance supplement. A small cost, but a significant benefit for families and the municipality's vitality.

--- a/tests/e2e/blogPage.spec.ts-snapshots/Blog-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/blogPage.spec.ts-snapshots/Blog-Page-should-match-aria-snapshot-1.aria.yml
@@ -6,26 +6,22 @@
     - heading "Mitä tarkoittaa elää tekoälyn aikakaudella?" [level=2]
     - paragraph: Käytännön kokemukseni on yli vuosikymmenen ajalta turvallisten ohjelmistojen ja pankkijärjestelmien rakentajana. Sitä taustaa vasten kirjoitan siitä, miksi tekoäly ei vain tehosta työtä vaan pakottaa miettimään uudelleen koko sosiaaliturvan, miksi digitaalinen itsenäisyys on välttämättömyys vapaan yhteiskunnan kannalta, ja miten varmistetaan, että teknologian hyödyt tulevat kaikille — ei vain harvoille.
     - heading "Aiheittain" [level=2]
-    - heading "Tekoäly" [level=2]:
-      - link "Tekoäly":
-        - /url: /fi/category/artificial-intelligence/
-    - paragraph: Olen käyttänyt tekoälytyökaluja ammatillisesti lead developer -roolissa — argumentoin käytännön kokemuksesta. Suomen on tartuttava tekoälyyn aktiivisesti.
-    - heading "Talous" [level=2]:
-      - link "Talous":
-        - /url: /fi/category/economy/
-    - paragraph: Suomen talous toimivaksi tekoälyn aikakaudella — uusia yrityksiä, uusia työpaikkoja ja julkisia palveluita, jotka käyttävät teknologiaa harkiten.
-    - heading "Sivistys" [level=2]:
-      - link "Sivistys":
-        - /url: /fi/category/learning/
-    - paragraph: Tekoälyn aikana sivistyksen on pysyttävä saumattomana varhaiskasvatuksesta työelämään — ettei tuottavuushyöty kasaannu pienelle ryhmälle.
-    - heading "Vapaus" [level=2]:
-      - link "Vapaus":
-        - /url: /fi/category/freedom/
-    - paragraph: Vapaus tekoälyn aikana on kysymys siitä, pysyykö data ja viestintä sinun omanasi, kun ympäröivä infrastruktuuri skaalaa valvontaa kaikille koko ajan.
-    - heading "Digitaalinen itsenäisyys" [level=2]:
-      - link "Digitaalinen itsenäisyys":
-        - /url: /fi/category/digital-independence/
-    - paragraph: Suomen ja Euroopan on hallittava omaa digitaalista infrastruktuuriaan — olen Digitaalinen itsenäisyys -kansalaisaloitteen alullepanija.
+    - list:
+      - listitem:
+        - link "Tekoäly":
+          - /url: /fi/category/artificial-intelligence/
+      - listitem:
+        - link "Talous":
+          - /url: /fi/category/economy/
+      - listitem:
+        - link "Sivistys":
+          - /url: /fi/category/learning/
+      - listitem:
+        - link "Vapaus":
+          - /url: /fi/category/freedom/
+      - listitem:
+        - link "Digitaalinen itsenäisyys":
+          - /url: /fi/category/digital-independence/
     - heading "Nostot" [level=2]
     - list:
       - listitem:
@@ -38,13 +34,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Yksityisyydensuoja":
+                - link "Yksityisyydensuoja":
                   - /url: /fi/category/privacy/
               - listitem:
-                - link "#Teknologia":
+                - link "Teknologia":
                   - /url: /fi/category/technology/
               - listitem:
-                - link "#Digitalisaatio":
+                - link "Digitalisaatio":
                   - /url: /fi/category/digitalisation/
           - paragraph: Chat control -lain jatkoaika kaatui Euroopan parlamentissa. KRP:n luvut ovat todellisia, mutta parlamentti toimi silti oikein — ja tässä syy, miksi.
       - listitem:
@@ -57,10 +53,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Digitaalinen itsenäisyys":
+                - link "Digitaalinen itsenäisyys":
                   - /url: /fi/category/digital-independence/
               - listitem:
-                - link "#Digitalisaatio":
+                - link "Digitalisaatio":
                   - /url: /fi/category/digitalisation/
           - paragraph: Venäjän naapurina Suomi on oppinut varautumaan. Kuitenkaan käsitteet huoltovarmuudesta ja suvereniteetista eivät ole levinneet digitaalisiin palveluihin.
       - listitem:
@@ -73,10 +69,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Teknologia":
+                - link "Teknologia":
                   - /url: /fi/category/technology/
               - listitem:
-                - link "#Yksityisyydensuoja":
+                - link "Yksityisyydensuoja":
                   - /url: /fi/category/privacy/
           - paragraph: Kun sormenjäljet tuotiin passeihin, Suomeen perustettiin kansallinen biometrinen rekisteri. Nyt hallitus haluaa avata sen poliisin käyttöön.
       - listitem:
@@ -89,10 +85,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Digitalisaatio":
+                - link "Digitalisaatio":
                   - /url: /fi/category/digitalisation/
               - listitem:
-                - link "#Tekoäly":
+                - link "Tekoäly":
                   - /url: /fi/category/artificial-intelligence/
           - paragraph: Tekoäly muuttaa yhteiskuntaamme – mutta et ehkä odottaisi, miten. Suurimmat muutokset näemme yksityiselämässä ja lasten arjessa.
     - heading "Kaikki kirjoitukset" [level=2]
@@ -107,10 +103,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Tekoäly":
+                - link "Tekoäly":
                   - /url: /fi/category/artificial-intelligence/
               - listitem:
-                - link "#Digitalisaatio":
+                - link "Digitalisaatio":
                   - /url: /fi/category/digitalisation/
           - paragraph: Tekoäly tekee kahdessa minuutissa sen, mihin kehittäjältä meni kaksi viikkoa. Koodin hinta romahtaa — mutta mistä kehittäjille sitten maksetaan?
       - listitem:
@@ -123,10 +119,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Luonto":
+                - link "Luonto":
                   - /url: /fi/category/nature/
           - paragraph: Kirkkonummi osti Lähteelän rannikkokohteen. Se on yksi harvoista paikoista, jonne pääsee myös ilman omaa venettä — nyt se on pysyvästi kaikkien saavutettavissa.
       - listitem:
@@ -139,10 +135,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Tasa-arvo ja yhdenvertaisuus":
+                - link "Tasa-arvo ja yhdenvertaisuus":
                   - /url: /fi/category/equality-and-non-discrimination/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
           - paragraph: /Sateenkaarinuorten kiusaaminen kasvaa\. Kirkkonummi äänesti \d+–\d+ liputuksen puolesta — pieni ele, jolla on mitattavia vaikutuksia nuorten hyvinvointiin\./
       - listitem:
@@ -155,10 +151,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Digitaalinen itsenäisyys":
+                - link "Digitaalinen itsenäisyys":
                   - /url: /fi/category/digital-independence/
               - listitem:
-                - link "#Digitalisaatio":
+                - link "Digitalisaatio":
                   - /url: /fi/category/digitalisation/
           - paragraph: Digitaalinen itsenäisyys rakentuu jokaisessa hankintapäätöksessä. Helsinki valitsi suomalaisen UpCloudin julkisten palveluiden ydinjärjestelmän alustaksi.
       - listitem:
@@ -171,7 +167,7 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Tasa-arvo ja yhdenvertaisuus":
+                - link "Tasa-arvo ja yhdenvertaisuus":
                   - /url: /fi/category/equality-and-non-discrimination/
           - paragraph: Kirkkonummen kunnnavaltuusto hyväksyi 9.3. aloitteeni Pride-liputuksen aloittamisesta Kirkkonummella, kahdesti vuodessa!
       - listitem:
@@ -184,13 +180,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infra":
+                - link "Infra":
                   - /url: /fi/category/infrastructure/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Länsirata":
+                - link "Länsirata":
                   - /url: /fi/category/west-railway/
           - paragraph: Länsirata-päätöstä tehdessä mitattiin päättäjien kykyä tehdä koko kunnalle strategisesti tärkeitä, tulevaisuuteen katsovia ratkaisuja.
       - listitem:
@@ -203,10 +199,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Sivistys":
+                - link "Sivistys":
                   - /url: /fi/category/culture-and-education/
           - paragraph: Kirkkonummen keskustan remontti rakentaa Fyyrin, Lyyran ja Rovastinpuiston sivistyksen keskittymän. Se luo edellytyksiä kasvulle vuosikymmeniksi.
       - listitem:
@@ -219,13 +215,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infra":
+                - link "Infra":
                   - /url: /fi/category/infrastructure/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Länsirata":
+                - link "Länsirata":
                   - /url: /fi/category/west-railway/
           - paragraph: Äänestin Kirkkonummen liittymisen Länsirataan puolesta. Päätös määrittää, saako Pohjois-Kirkkonummi lähijuna-aseman vai ei.
       - listitem:
@@ -238,10 +234,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Teknologia":
+                - link "Teknologia":
                   - /url: /fi/category/technology/
               - listitem:
-                - link "#Yksityisyydensuoja":
+                - link "Yksityisyydensuoja":
                   - /url: /fi/category/privacy/
           - paragraph: Hallitus suunnittelee tiedustelulainsäädännön laajentamista rikollisuuden torjuntaan ilman yksilöityä epäilyä – tämä uhkaa perusoikeuksia vakavasti.
       - listitem:
@@ -254,10 +250,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Digitalisaatio":
+                - link "Digitalisaatio":
                   - /url: /fi/category/digitalisation/
               - listitem:
-                - link "#Tekoäly":
+                - link "Tekoäly":
                   - /url: /fi/category/artificial-intelligence/
           - paragraph: Tekoälyä on esitetty ratkaisuna julkisten palveluiden kehittämiseen. Sillä voi olla roolinsa, mutta se ei korvaa ihmistä eikä selkeää suunnitelmaa.
       - listitem:
@@ -270,10 +266,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Sosiaalinen media":
+                - link "Sosiaalinen media":
                   - /url: /fi/category/social-media/
               - listitem:
-                - link "#Teknologia":
+                - link "Teknologia":
                   - /url: /fi/category/technology/
           - paragraph: Olemmeko valmiita siihen, että keskusteluamme ohjaavat ulkomaiset suuryritykset? Algoritmeja voidaan käyttää tarkoituksellisesti vaikuttamiseen.
       - listitem:
@@ -286,10 +282,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Maahanmuutto":
+                - link "Maahanmuutto":
                   - /url: /fi/category/immigration/
               - listitem:
-                - link "#Tasa-arvo ja yhdenvertaisuus":
+                - link "Tasa-arvo ja yhdenvertaisuus":
                   - /url: /fi/category/equality-and-non-discrimination/
           - paragraph: Maahanmuuttoon liittyy monia erittäin sitkeitä myyttejä. Erityisesti maahanmuuttoon kriittisesti tai vihamielisesti suhtautuvat tykkäävät vahvistaa niitä.
       - listitem:
@@ -302,13 +298,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infra":
+                - link "Infra":
                   - /url: /fi/category/infrastructure/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Liikenne":
+                - link "Liikenne":
                   - /url: /fi/category/transportation/
           - paragraph: Pääkaupunkiseudun joukkoliikenteestä vastaava HSL-kuntayhtymä suunnittelee lähivuosille tuntuvia korotuksia bussien ja junien lippujen hintoihin.
       - listitem:
@@ -321,7 +317,7 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Tasa-arvo ja yhdenvertaisuus":
+                - link "Tasa-arvo ja yhdenvertaisuus":
                   - /url: /fi/category/equality-and-non-discrimination/
           - paragraph: Pride tarkoittaa jokaisen oikeutta olla ylpeä olemassaolostaan. Sukupuoli- ja seksuaalivähemmistöt kohtaavat yhä enemmän syrjintää kuin muut.
       - listitem:
@@ -334,13 +330,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Tasa-arvo ja yhdenvertaisuus":
+                - link "Tasa-arvo ja yhdenvertaisuus":
                   - /url: /fi/category/equality-and-non-discrimination/
               - listitem:
-                - link "#Valtuustoaloite":
+                - link "Valtuustoaloite":
                   - /url: /fi/category/council-motion/
           - paragraph: Kirkkonummen strategia edistää tasa-arvoa ja yhdenvertaisuutta. Pride-liputus on edullinen ja helppo teko strategian toimeenpanemiseksi.
       - listitem:
@@ -353,13 +349,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Opetus":
+                - link "Opetus":
                   - /url: /fi/category/education/
               - listitem:
-                - link "#Varhaiskasvatus":
+                - link "Varhaiskasvatus":
                   - /url: /fi/category/early-childhood-education/
           - paragraph: Hallituksen puoliväliriihi toi leikkauksia valtionosuuksiin ja yhteisöveroon. Se kaventaa kunnanvaltuutettujen liikkumatilaa merkittävästi.
       - listitem:
@@ -372,16 +368,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Opetus":
+                - link "Opetus":
                   - /url: /fi/category/education/
               - listitem:
-                - link "#Varhaiskasvatus":
+                - link "Varhaiskasvatus":
                   - /url: /fi/category/early-childhood-education/
           - paragraph: Koulutus on kunnan tärkein tehtävä. Koulutusinvestoinnit näkyvät kauas tulevaisuuteen – eikä sieltä ole pikavoittoja saatavissa.
       - listitem:
@@ -394,16 +390,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Länsi-Uusimaa":
+                - link "Länsi-Uusimaa":
                   - /url: /fi/category/western-uusimaa/
           - paragraph: Hallitus haluaa asettaa toisen asteen opiskelijat eriarvoiseen asemaan kansalaisuuden perusteella. Lukukausimaksuille on sanottava ehdoton ei.
       - listitem:
@@ -416,16 +412,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Länsi-Uusimaa":
+                - link "Länsi-Uusimaa":
                   - /url: /fi/category/western-uusimaa/
           - paragraph: Kirkkonummen keskustan remontti on tuhannen taalan paikka. Elinvoimainen keskusta houkuttelee asukkaita ja yrityksiä – ja parantaa kunnan taloutta.
       - listitem:
@@ -438,16 +434,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Länsi-Uusimaa":
+                - link "Länsi-Uusimaa":
                   - /url: /fi/category/western-uusimaa/
           - paragraph: Puolueet markkinoivat itseään mielikuvilla. Kannattaa haastaa ehdokkaita ja kysyä, mihin väitteet perustuvat ja miten asiat oikeasti toimivat.
       - listitem:
@@ -460,10 +456,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
           - paragraph: "Kuntavaalit saattavat tuntua monimutkaisilta, mutta kyse on arjen asioista: kouluista, päiväkodeista ja liikenneyhteyksistä. Sinulla on vaikutusvaltaa."
       - listitem:
@@ -476,16 +472,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Maahanmuutto":
+                - link "Maahanmuutto":
                   - /url: /fi/category/immigration/
           - paragraph: Kasvava vastakkainasettelu ja eriarvoistava politiikka repivät kansaa osiin. Historiamme osoittaa, että yhteistyöllä pärjäämme paremmin.
       - listitem:
@@ -498,16 +494,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Maahanmuutto":
+                - link "Maahanmuutto":
                   - /url: /fi/category/immigration/
           - paragraph: Turvapaikanhakemiseen liittyy paljon väärinkäsityksiä. On tärkeää erottaa faktat myyteistä – hakijat eivät elä veronmaksajien rahoilla herroiksi.
       - listitem:
@@ -520,16 +516,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Maahanmuutto":
+                - link "Maahanmuutto":
                   - /url: /fi/category/immigration/
           - paragraph: Turvapaikan saaminen ei ole itsestäänselvyys, vaan tarkoin määritelty prosessi. Usein unohdetaan, keitä ihmiset ovat, jotka paikkaa hakevat.
       - listitem:
@@ -542,16 +538,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Maahanmuutto":
+                - link "Maahanmuutto":
                   - /url: /fi/category/immigration/
           - paragraph: Ulkomailta Suomeen opiskelemaan tulleet tuovat osaavaa työvoimaa. Silti heidän työllistymisessään on suuria haasteita, joihin ei ole puututtu riittävästi.
       - listitem:
@@ -564,16 +560,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Maahanmuutto":
+                - link "Maahanmuutto":
                   - /url: /fi/category/immigration/
           - paragraph: Työperäinen maahanmuutto auttaa ratkaisemaan Suomen työvoimapulaa. Tarvitaan kuitenkin paremmat edellytykset kotoutumiselle ja työllistymiselle.
       - listitem:
@@ -586,13 +582,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Opetus":
+                - link "Opetus":
                   - /url: /fi/category/education/
           - paragraph: Koulutuksesta leikataan reilusti, vaikka hallitus väittää muuta. Indeksikorotukset ja lakiuudistukset eivät paikkaa satoja miljoonia leikkauksia.
       - listitem:
@@ -605,16 +601,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Maahanmuutto":
+                - link "Maahanmuutto":
                   - /url: /fi/category/immigration/
           - paragraph: Perhesiteeseen perustuvasti maahan muuttavat ovat moninainen joukko. He ovat usein pidemmällä integraatiossa kuin muut maahanmuuttajaryhmät.
       - listitem:
@@ -627,10 +623,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Tasa-arvo ja yhdenvertaisuus":
+                - link "Tasa-arvo ja yhdenvertaisuus":
                   - /url: /fi/category/equality-and-non-discrimination/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
           - paragraph: /Suomi täyttää \d+ vuotta\. On aika tehdä isänmaallisuuden kunnianpalautus – Suomi on yksi maailman hienoimmista maista, jossa jokainen on yhtä arvokas\./
       - listitem:
@@ -643,16 +639,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Maahanmuutto":
+                - link "Maahanmuutto":
                   - /url: /fi/category/immigration/
           - paragraph: Maahanmuuttoa koskevassa keskustelussa määrät jäävät usein mainitsematta. Suomen maahanmuutto on murto-osa verrokimaiden tasosta.
       - listitem:
@@ -665,16 +661,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Maahanmuutto":
+                - link "Maahanmuutto":
                   - /url: /fi/category/immigration/
           - paragraph: Maahanmuutto on monimutkainen ilmiö, jota kriittiset äänet ovat pitkään dominoineet. On aika tarkastella aihetta tasapuolisemmin ja tietoon perustuen.
       - listitem:
@@ -687,13 +683,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Opetus":
+                - link "Opetus":
                   - /url: /fi/category/education/
           - paragraph: /Hallitus tekee tarpeellisia uudistuksia toiselle asteelle, mutta ne eivät korvaa ammatilliseen koulutukseen kohdistuvia \d+ miljoonan leikkauksia\./
       - listitem:
@@ -706,16 +702,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Länsi-Uusimaa":
+                - link "Länsi-Uusimaa":
                   - /url: /fi/category/western-uusimaa/
           - paragraph: Nuoret elävät kriisissä – ilmastonmuutos, pandemia, sodat. Vastuu paremmasta tulevaisuudesta on meillä aikuisilla, ei nuorilla.
       - listitem:
@@ -728,16 +724,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Länsi-Uusimaa":
+                - link "Länsi-Uusimaa":
                   - /url: /fi/category/western-uusimaa/
           - paragraph: /Olen ehdolla sekä kunta- että aluevaaleissa \d+\. Tärkeintä minulle on lasten ja nuorten mahdollisuuksista huolehtiminen kasvavassa Kirkkonummessa\./
       - listitem:
@@ -750,10 +746,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Varhaiskasvatus":
+                - link "Varhaiskasvatus":
                   - /url: /fi/category/early-childhood-education/
           - paragraph: Hallitus suunnittelee säästöjä varhaiskasvatuksen suunnittelutyöhön. Todellisuudessa nämä säästöt siirtyvät vain kunnille ja asukkaille maksettaviksi.
       - listitem:
@@ -766,13 +762,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kaavoitus":
+                - link "Kaavoitus":
                   - /url: /fi/category/urban-planning/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Osuuskauppavaalit":
+                - link "Osuuskauppavaalit":
                   - /url: /fi/category/coop-elections/
           - paragraph: Varuboden-Oslan osuuskauppavaalit ovat nyt käynnissä. Äänestämällä vaikutat ihmisten työpaikkoihin, kulutuskäyttäytymiseen sekä lähipalveluihin.
       - listitem:
@@ -785,13 +781,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infra":
+                - link "Infra":
                   - /url: /fi/category/infrastructure/
               - listitem:
-                - link "#Kaavoitus":
+                - link "Kaavoitus":
                   - /url: /fi/category/urban-planning/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
           - paragraph: Kirkkonummen tärkeimpiä vetovoimia on meidän luontomme. Nyt alkanut osallistava budjetointi on sen jälleen osoittanut – luonto kuuluu meille kaikille.
       - listitem:
@@ -804,13 +800,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infra":
+                - link "Infra":
                   - /url: /fi/category/infrastructure/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Liikenne":
+                - link "Liikenne":
                   - /url: /fi/category/transportation/
           - paragraph: Kirkkonummen talvikunnossapito on jälleen osoittautunut yhtä huonoksi kuin ennenkin. Asiat voisivat olla toisin, jos päättäisimme tavoitella laatua.
       - listitem:
@@ -823,13 +819,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Opetus":
+                - link "Opetus":
                   - /url: /fi/category/education/
           - paragraph: Kunnan on suunniteltava pitkäjänteisesti. Lyhytnäköiset päätökset johtavat lisäkustannuksiin ja heikompiin palveluihin asukkaille.
       - listitem:
@@ -842,7 +838,7 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
           - paragraph: Rasismitiedonanto on tärkeä askel. Sanavalinnoilla on merkitystä – puheella muovaamme todellisuutta ja suhtautumistamme erilaisuuteen.
       - listitem:
@@ -855,13 +851,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Liikenne":
+                - link "Liikenne":
                   - /url: /fi/category/transportation/
               - listitem:
-                - link "#Infra":
+                - link "Infra":
                   - /url: /fi/category/infrastructure/
           - paragraph: Siis kevyelle liikenteelle eli jalankulkijoille ja pyöräilijöille. Mitä jos emme rakentaisikaan yhteiskuntaa yksityisautoilun ehdolla?
       - listitem:
@@ -874,16 +870,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kaavoitus":
+                - link "Kaavoitus":
                   - /url: /fi/category/urban-planning/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Opetus":
+                - link "Opetus":
                   - /url: /fi/category/education/
               - listitem:
-                - link "#Varhaiskasvatus":
+                - link "Varhaiskasvatus":
                   - /url: /fi/category/early-childhood-education/
           - paragraph: Jokaista metsää ei tarvitse kaataa. Varsinkaan aktiivisessa käytössä oleva lähiluonto tulee säilyttää ja se on tärkeä osa kuntaamme.
       - listitem:
@@ -896,13 +892,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2022/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Sote-uudistus":
+                - link "Sote-uudistus":
                   - /url: /fi/category/health-and-social-reform/
           - paragraph: Poistamalla sote-asiakasmaksut säästetään byrokratiassa, hoidetaan ongelmat ennen kuin ne kasvavat ja varmistetaan, ettei kukaan jää hoidotta.
       - listitem:
@@ -915,13 +911,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2022/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Sote-uudistus":
+                - link "Sote-uudistus":
                   - /url: /fi/category/health-and-social-reform/
           - paragraph: Sosiaali- ja terveydenhuolto on kallista, mutta välttämätöntä. Ilman toimivaa sotea emme voi enää puhua Suomesta hyvinvointivaltiona.
       - listitem:
@@ -934,13 +930,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2022/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Sote-uudistus":
+                - link "Sote-uudistus":
                   - /url: /fi/category/health-and-social-reform/
           - paragraph: Mitä jos Jorvin ensiapu olisi koko läntisen Uudenmaan ainoa päivystys? Mitä jos Jorvissa pitäisi aina jonottaa monta tuntia?
       - listitem:
@@ -953,10 +949,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Perusturva":
+                - link "Perusturva":
                   - /url: /fi/category/basic-welfare/
           - paragraph: Perusturvajaosto vastaa asukkaiden oikaisuvaatimuksiin perusturvaan liittyvissä asioissa. Vaikka kokousten sisältö on salaista, niistä voi ottaa opiksi.
       - listitem:
@@ -969,13 +965,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2022/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Sote-uudistus":
+                - link "Sote-uudistus":
                   - /url: /fi/category/health-and-social-reform/
           - paragraph: Asetan itseni ehdolle aluevaaleihin. Tärkeintä on lähipalvelujen säilyminen, terveydenhuollon pitäminen julkisena ja hoitohenkilökunnan hyvinvointi.
       - listitem:
@@ -988,10 +984,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Varhaiskasvatus":
+                - link "Varhaiskasvatus":
                   - /url: /fi/category/early-childhood-education/
           - paragraph: Päiväkodeissa on pula varhaiskasvatuksen opettajista. Kirkkonummella on mahdollisuus rakentaa uudenlaista työympäristöä ja houkutella osaajia.
       - listitem:
@@ -1004,10 +1000,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Opetus":
+                - link "Opetus":
                   - /url: /fi/category/education/
           - paragraph: Gesterbyn koulukeskuksen hankesuunnitelmaa on palautettu lisävalmisteluun kolmesti. Hanketta on selvitetty kuusi vuotta ilman lopputulosta.
       - listitem:
@@ -1020,13 +1016,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kaavoitus":
+                - link "Kaavoitus":
                   - /url: /fi/category/urban-planning/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Varhaiskasvatus":
+                - link "Varhaiskasvatus":
                   - /url: /fi/category/early-childhood-education/
           - paragraph: Kirkkonummen keskustan alueella on jo pulaa päiväkotipaikoista. Uudet asemakaavat kasvattavat tarvetta – varhaiskasvatuspaikkoja on riitettävä.
       - listitem:
@@ -1039,10 +1035,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Varhaiskasvatus":
+                - link "Varhaiskasvatus":
                   - /url: /fi/category/early-childhood-education/
           - paragraph: Varhaiskasvatuksen kerhotoiminta on kustannustehokas tuki lapsille ja perheille. Kirkkonummella toiminnan jatkuminen on kuitenkin epävarmaa.
       - listitem:
@@ -1055,10 +1051,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Varhaiskasvatus":
+                - link "Varhaiskasvatus":
                   - /url: /fi/category/early-childhood-education/
           - paragraph: Kirkkonummi-lisä hyödyttää paitsi sitä saavia perheitä, myös koko kuntaa. Lapsiperhepalvelut ovat investointi Kirkkonummen elinvoimaan.
       - listitem:
@@ -1071,9 +1067,9 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Varhaiskasvatus":
+                - link "Varhaiskasvatus":
                   - /url: /fi/category/early-childhood-education/
           - paragraph: Kirkkonummen valtuusto lopetti kotihoidon tuen kuntalisän. Pieni kustannus, mutta suuri merkitys lapsiperheille ja kunnan elinvoimalle.

--- a/tests/e2e/blogPostPage.spec.ts-snapshots/Blog-Post-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/blogPostPage.spec.ts-snapshots/Blog-Post-Page-should-match-aria-snapshot-1.aria.yml
@@ -4,13 +4,13 @@
     - time: /\d+\.\d+\.\d+/
     - list:
       - listitem:
-        - link /#Aluevaalit \d+/:
+        - link /Aluevaalit \d+/:
           - /url: /fi/category/regional-elections-2022/
       - listitem:
-        - link "#Kirkkonummi":
+        - link "Kirkkonummi":
           - /url: /fi/category/kirkkonummi/
       - listitem:
-        - link "#Sote-uudistus":
+        - link "Sote-uudistus":
           - /url: /fi/category/health-and-social-reform/
   - img "Kuva Lauri Lavannista, taustalla näkyy metsää."
   - article:
@@ -105,13 +105,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2022/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Sote-uudistus":
+                - link "Sote-uudistus":
                   - /url: /fi/category/health-and-social-reform/
           - paragraph: Poistamalla sote-asiakasmaksut säästetään byrokratiassa, hoidetaan ongelmat ennen kuin ne kasvavat ja varmistetaan, ettei kukaan jää hoidotta.
       - listitem:
@@ -124,13 +124,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2022/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Sote-uudistus":
+                - link "Sote-uudistus":
                   - /url: /fi/category/health-and-social-reform/
           - paragraph: Mitä jos Jorvin ensiapu olisi koko läntisen Uudenmaan ainoa päivystys? Mitä jos Jorvissa pitäisi aina jonottaa monta tuntia?
       - listitem:
@@ -143,13 +143,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2022/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Sote-uudistus":
+                - link "Sote-uudistus":
                   - /url: /fi/category/health-and-social-reform/
           - paragraph: Asetan itseni ehdolle aluevaaleihin. Tärkeintä on lähipalvelujen säilyminen, terveydenhuollon pitäminen julkisena ja hoitohenkilökunnan hyvinvointi.
       - listitem:
@@ -162,9 +162,9 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Luonto":
+                - link "Luonto":
                   - /url: /fi/category/nature/
           - paragraph: Kirkkonummi osti Lähteelän rannikkokohteen. Se on yksi harvoista paikoista, jonne pääsee myös ilman omaa venettä — nyt se on pysyvästi kaikkien saavutettavissa.

--- a/tests/e2e/blogSwePage.spec.ts-snapshots/Blog-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/blogSwePage.spec.ts-snapshots/Blog-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
@@ -6,26 +6,22 @@
     - heading "Vad innebär det att leva i AI:s era?" [level=2]
     - paragraph: Jag har över ett årtiondes praktisk erfarenhet av att bygga säker programvara och banktjänster. Med den bakgrunden skriver jag om varför AI inte bara effektiviserar arbetet utan tvingar oss att tänka om hela det sociala skyddsnätet, varför digital självständighet är en förutsättning för ett fritt samhälle, och hur vi kan se till att teknikens vinster når alla — inte bara ett fåtal.
     - heading "Efter ämne" [level=2]
-    - heading "Artificiell intelligens" [level=2]:
-      - link "Artificiell intelligens":
-        - /url: /sv/category/artificial-intelligence/
-    - paragraph: Jag arbetar med AI-verktyg professionellt som lead developer — jag argumenterar utifrån praktisk erfarenhet. Finland måste engagera sig med AI aktivt.
-    - heading "Ekonomi" [level=2]:
-      - link "Ekonomi":
-        - /url: /sv/category/economy/
-    - paragraph: Finlands ekonomi måste fungera under AI-omställningen — nya företag, nya jobb och offentliga tjänster som använder teknik med omdöme.
-    - heading "Lärande" [level=2]:
-      - link "Lärande":
-        - /url: /sv/category/learning/
-    - paragraph: I AI-eran måste bildningen förbli sömlös från småbarnspedagogiken till arbetslivet — så att produktivitetsvinsterna inte samlas hos ett fåtal.
-    - heading "Frihet" [level=2]:
-      - link "Frihet":
-        - /url: /sv/category/freedom/
-    - paragraph: Frihet i AI-eran är frågan om dina data och din kommunikation förblir dina när infrastrukturen skalar övervakning till alla, hela tiden.
-    - heading "Digital självständighet" [level=2]:
-      - link "Digital självständighet":
-        - /url: /sv/category/digital-independence/
-    - paragraph: Finland och Europa måste kontrollera sin digitala infrastruktur — jag är huvudinitiativtagare till medborgarinitiativet om digital självständighet.
+    - list:
+      - listitem:
+        - link "Artificiell intelligens":
+          - /url: /sv/category/artificial-intelligence/
+      - listitem:
+        - link "Ekonomi":
+          - /url: /sv/category/economy/
+      - listitem:
+        - link "Lärande":
+          - /url: /sv/category/learning/
+      - listitem:
+        - link "Frihet":
+          - /url: /sv/category/freedom/
+      - listitem:
+        - link "Digital självständighet":
+          - /url: /sv/category/digital-independence/
     - heading "Utvalda" [level=2]
     - list:
       - listitem:
@@ -38,13 +34,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Integritetsskydd":
+                - link "Integritetsskydd":
                   - /url: /sv/category/privacy/
               - listitem:
-                - link "#Teknologi":
+                - link "Teknologi":
                   - /url: /sv/category/technology/
               - listitem:
-                - link "#Digitalisering":
+                - link "Digitalisering":
                   - /url: /sv/category/digitalisation/
           - paragraph: Chat control-lagens förlängning röstades ned i Europaparlamentet. KRP:s siffror är verkliga, men parlamentet handlade ändå rätt — och här är skälet.
       - listitem:
@@ -57,10 +53,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Digital självständighet":
+                - link "Digital självständighet":
                   - /url: /sv/category/digital-independence/
               - listitem:
-                - link "#Digitalisering":
+                - link "Digitalisering":
                   - /url: /sv/category/digitalisation/
           - paragraph: Som Rysslands granne har Finland lärt sig att vara beredd. Begreppen försörjningstrygghet och suveränitet har dock inte spridit sig till digitala tjänster.
       - listitem:
@@ -73,10 +69,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Teknologi":
+                - link "Teknologi":
                   - /url: /sv/category/technology/
               - listitem:
-                - link "#Integritetsskydd":
+                - link "Integritetsskydd":
                   - /url: /sv/category/privacy/
           - paragraph: När fingeravtryck infördes i pass skapades ett nationellt biometriskt register i Finland. Nu vill regeringen öppna det för polisens bruk.
       - listitem:
@@ -89,10 +85,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Digitalisering":
+                - link "Digitalisering":
                   - /url: /sv/category/digitalisation/
               - listitem:
-                - link "#Artificiell intelligens":
+                - link "Artificiell intelligens":
                   - /url: /sv/category/artificial-intelligence/
           - paragraph: AI förändrar samhället — men kanske inte som du tror. De största förändringarna ser vi i privatlivet och i barnens och ungdomarnas vardag.
     - heading "Alla inlägg" [level=2]
@@ -107,10 +103,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Artificiell intelligens":
+                - link "Artificiell intelligens":
                   - /url: /sv/category/artificial-intelligence/
               - listitem:
-                - link "#Digitalisering":
+                - link "Digitalisering":
                   - /url: /sv/category/digitalisation/
           - paragraph: AI gör på två minuter det som en utvecklare tidigare behövde två veckor på sig för. Priset på kod rasar — men vad ska utvecklare få betalt för i stället?
       - listitem:
@@ -123,10 +119,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Natur":
+                - link "Natur":
                   - /url: /sv/category/nature/
           - paragraph: Kyrksländ köpte Lähteelä som kustanläggning. En av få platser vid kusten dit man kan ta sig utan egen båt — nu permanent tillgängligt för alla invånare.
       - listitem:
@@ -139,10 +135,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Jämlikhet":
+                - link "Jämlikhet":
                   - /url: /sv/category/equality-and-non-discrimination/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
           - paragraph: /Mobbning av regnbågsungdomar ökar\. Kyrkslätt röstade \d+–\d+ för flaggning — en liten gest med mätbara effekter på ungas välmående\./
       - listitem:
@@ -155,10 +151,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Digital självständighet":
+                - link "Digital självständighet":
                   - /url: /sv/category/digital-independence/
               - listitem:
-                - link "#Digitalisering":
+                - link "Digitalisering":
                   - /url: /sv/category/digitalisation/
           - paragraph: Digital självständighet byggs i varje upphandlingsbeslut. Helsingfors valde finska UpCloud som plattform för kärnsystemet för stadens tjänster.
       - listitem:
@@ -171,7 +167,7 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Jämlikhet":
+                - link "Jämlikhet":
                   - /url: /sv/category/equality-and-non-discrimination/
           - paragraph: Den 9 mars godkände Kirkkonummis kommunfullmäktige mitt initiativ att börja hissa Pride-flaggor i Kirkkonummi två gånger om året!
       - listitem:
@@ -184,13 +180,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infrastruktur":
+                - link "Infrastruktur":
                   - /url: /sv/category/infrastructure/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Västbanan":
+                - link "Västbanan":
                   - /url: /sv/category/west-railway/
           - paragraph: Vid fattandet av Västbanans beslut mättes beslutsfattarnas förmåga att fatta strategiskt viktiga, framåtblickande beslut för hela kommunen.
       - listitem:
@@ -203,10 +199,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Bildning":
+                - link "Bildning":
                   - /url: /sv/category/culture-and-education/
           - paragraph: Renoveringen av Kyrkslätts centrum skapar ett bildningskluster av Fyyri, Lyyra och Provstparken. Det ger förutsättningar för tillväxt i decennier.
       - listitem:
@@ -219,13 +215,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infrastruktur":
+                - link "Infrastruktur":
                   - /url: /sv/category/infrastructure/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Västbanan":
+                - link "Västbanan":
                   - /url: /sv/category/west-railway/
           - paragraph: Jag röstade för att Kyrkslätt ansluter sig till Västernabanan. Beslutet avgör om norra Kyrkslätt får en närtågsstation eller inte.
       - listitem:
@@ -238,10 +234,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Teknologi":
+                - link "Teknologi":
                   - /url: /sv/category/technology/
               - listitem:
-                - link "#Integritetsskydd":
+                - link "Integritetsskydd":
                   - /url: /sv/category/privacy/
           - paragraph: Regeringen planerar att utvidga underrättelselagstiftningens metoder mot brottslighet utan individuell misstanke — ett allvarligt hot mot grundrättigheter.
       - listitem:
@@ -254,10 +250,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Digitalisering":
+                - link "Digitalisering":
                   - /url: /sv/category/digitalisation/
               - listitem:
-                - link "#Artificiell intelligens":
+                - link "Artificiell intelligens":
                   - /url: /sv/category/artificial-intelligence/
           - paragraph: AI har presenterats som ett sätt att göra Finlands offentliga tjänster till världens bästa. Det kan ha sin roll i det, men viktigast vore en helhetsbedömning.
       - listitem:
@@ -270,10 +266,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Sociala medier":
+                - link "Sociala medier":
                   - /url: /sv/category/social-media/
               - listitem:
-                - link "#Teknologi":
+                - link "Teknologi":
                   - /url: /sv/category/technology/
           - paragraph: Är vi beredda på att vår diskussion styrs av utländska storföretag? Det finns inga garantier för att algoritmer inte skulle användas avsiktligt.
       - listitem:
@@ -286,10 +282,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /sv/category/immigration/
               - listitem:
-                - link "#Jämlikhet":
+                - link "Jämlikhet":
                   - /url: /sv/category/equality-and-non-discrimination/
           - paragraph: Invandring omges av många extremt sega myter. De som ställer sig kritiska eller fientliga mot invandring brukar i synnerhet gärna förstärka dem.
       - listitem:
@@ -302,13 +298,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infrastruktur":
+                - link "Infrastruktur":
                   - /url: /sv/category/infrastructure/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Trafik":
+                - link "Trafik":
                   - /url: /sv/category/transportation/
           - paragraph: HSL, samkommunen som ansvarar för kollektivtrafiken i huvudstadsregionen, planerar avsevärda biljetthöjningar för bussar och tåg under de kommande åren.
       - listitem:
@@ -321,7 +317,7 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Jämlikhet":
+                - link "Jämlikhet":
                   - /url: /sv/category/equality-and-non-discrimination/
           - paragraph: Pride handlar om allas rätt att vara stolt över sin existens. Köns- och sexualminoriteter möter fortfarande mer diskriminering än andra.
       - listitem:
@@ -334,13 +330,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Jämlikhet":
+                - link "Jämlikhet":
                   - /url: /sv/category/equality-and-non-discrimination/
               - listitem:
-                - link "#Fullmäktigeinitiativ":
+                - link "Fullmäktigeinitiativ":
                   - /url: /sv/category/council-motion/
           - paragraph: Kyrkslätts strategi främjar jämlikhet och likabehandling. Att hissa Pride-flaggan är en enkel och kostnadseffektiv åtgärd för att omsätta strategin.
       - listitem:
@@ -353,13 +349,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Utbildning":
+                - link "Utbildning":
                   - /url: /sv/category/education/
               - listitem:
-                - link "#Småbarnspedagogik":
+                - link "Småbarnspedagogik":
                   - /url: /sv/category/early-childhood-education/
           - paragraph: Halvtidsöverläggningen innebar nedskärningar i statsandelar och samfundsskatt. Det inskränker kommunfullmäktiges handlingsutrymme avsevärt.
       - listitem:
@@ -372,16 +368,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Utbildning":
+                - link "Utbildning":
                   - /url: /sv/category/education/
               - listitem:
-                - link "#Småbarnspedagogik":
+                - link "Småbarnspedagogik":
                   - /url: /sv/category/early-childhood-education/
           - paragraph: Utbildning är kommunens viktigaste uppgift. Satsningar på utbildning är investeringar som syns långt in i framtiden, utan snabba vinster.
       - listitem:
@@ -394,16 +390,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Västra Nyland":
+                - link "Västra Nyland":
                   - /url: /sv/category/western-uusimaa/
           - paragraph: Regeringen anser att vi borde ställa unga som studerar på andra stadiet i en ojämlik ställning beroende på om de har EU-medborgarskap eller inte.
       - listitem:
@@ -416,16 +412,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Västra Nyland":
+                - link "Västra Nyland":
                   - /url: /sv/category/western-uusimaa/
           - paragraph: Renoveringen av Kyrkslätts centrum är ett gyllene tillfälle. Ett livskraftigt centrum lockar invånare och företag — och stärker kommunens ekonomi.
       - listitem:
@@ -438,16 +434,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Västra Nyland":
+                - link "Västra Nyland":
                   - /url: /sv/category/western-uusimaa/
           - paragraph: Partier marknadsför sig med hjälp av bilder. Det lönar sig att utmana kandidaterna och fråga vad påståenden grundar sig på i verkligheten.
       - listitem:
@@ -460,10 +456,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
           - paragraph: "Kommunalvalet kan verka komplicerat, men handlar om vardagsfrågor: skolor, daghem och kommunikationer. Du har makt att påverka."
       - listitem:
@@ -476,16 +472,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /sv/category/immigration/
           - paragraph: Ökad polarisering och ojämlikhetsskapande politik splittrar onödigt vårt folk. Historien visar att vi klarar oss bäst när vi samarbetar.
       - listitem:
@@ -498,16 +494,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /sv/category/immigration/
           - paragraph: Det finns många missuppfattningar om asylsökande. Det är viktigt att skilja fakta från myter — sökande lever inte på skattebetalarnas bekostnad.
       - listitem:
@@ -520,16 +516,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /sv/category/immigration/
           - paragraph: Att få asyl är ingen självklarhet, utan en noggrant definierad process. Alltför ofta glöms de faktiska människorna bakom ansökningarna bort.
       - listitem:
@@ -542,16 +538,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /sv/category/immigration/
           - paragraph: Studerande från utlandet tillför kompetent arbetskraft till Finland. Trots det har vi stora utmaningar med deras sysselsättning efter studierna.
       - listitem:
@@ -564,16 +560,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /sv/category/immigration/
           - paragraph: Arbetsbaserad invandring bidrar till att lösa Finlands arbetskraftsbrist. Det krävs dock bättre förutsättningar för integration och sysselsättning.
       - listitem:
@@ -586,13 +582,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Utbildning":
+                - link "Utbildning":
                   - /url: /sv/category/education/
           - paragraph: Utbildningen skärs ned kraftigt, trots att regeringen hävdar motsatsen. Indexhöjningar och lagreformer täcker inte hundratals miljoner i nedskärningar.
       - listitem:
@@ -605,16 +601,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /sv/category/immigration/
           - paragraph: De som invandrar på basis av familjeband är en mångfaldig grupp. De är ofta längre framme i integrationen än andra invandrargrupper.
       - listitem:
@@ -627,10 +623,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Jämlikhet":
+                - link "Jämlikhet":
                   - /url: /sv/category/equality-and-non-discrimination/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
           - paragraph: /Finland fyller \d+ år\. Det är dags att rehabilitera patriotismen — Finland är ett av världens bästa länder, där alla är lika värda\./
       - listitem:
@@ -643,16 +639,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /sv/category/immigration/
           - paragraph: I invandringsdebatten glöms volymen ofta bort. Finlands invandring är en bråkdel av jämförbara länders nivåer — fakta som sällan nämns.
       - listitem:
@@ -665,16 +661,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /sv/category/immigration/
           - paragraph: Invandringsdebatten domineras länge av kritiska röster. Det är dags att granska ämnet mer balanserat och faktabaserat — med fokus på vad forskning säger.
       - listitem:
@@ -687,13 +683,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Utbildning":
+                - link "Utbildning":
                   - /url: /sv/category/education/
           - paragraph: /Regeringen gör nödvändiga reformer för gymnasiet, men de kompenserar inte nedskärningarna på \d+ miljoner euro i yrkesutbildningen\./
       - listitem:
@@ -706,16 +702,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Västra Nyland":
+                - link "Västra Nyland":
                   - /url: /sv/category/western-uusimaa/
           - paragraph: Unga lever mitt i kriser — klimat, pandemi, krig. Ansvaret för en bättre framtid ligger hos oss vuxna, inte hos ungdomarna.
       - listitem:
@@ -728,16 +724,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Västra Nyland":
+                - link "Västra Nyland":
                   - /url: /sv/category/western-uusimaa/
           - paragraph: /Jag kandiderar i både kommunal- och välfärdsomradesvalet \d+\. Viktigast för mig är att säkra barn och ungdomars möjligheter i Kyrkslätt\./
       - listitem:
@@ -750,10 +746,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Småbarnspedagogik":
+                - link "Småbarnspedagogik":
                   - /url: /sv/category/early-childhood-education/
           - paragraph: Regeringen planerar att spara på planeringen av småbarnspedagogik. I praktiken övervältras kostnaderna på kommunerna och invånarna istället.
       - listitem:
@@ -766,13 +762,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Planläggning":
+                - link "Planläggning":
                   - /url: /sv/category/urban-planning/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Kooperativval":
+                - link "Kooperativval":
                   - /url: /sv/category/coop-elections/
           - paragraph: Varuboden-Oslas andelslagsval pågår nu. Genom att rösta påverkar du människors arbetsplatser, konsumtionsbeteende och lokala tjänster.
       - listitem:
@@ -785,13 +781,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infrastruktur":
+                - link "Infrastruktur":
                   - /url: /sv/category/infrastructure/
               - listitem:
-                - link "#Planläggning":
+                - link "Planläggning":
                   - /url: /sv/category/urban-planning/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
           - paragraph: En av Kirkkonummis viktigaste dragningskrafter är vår natur. Det deltagarbudgeterande som nyss inletts har återigen visat det.
       - listitem:
@@ -804,13 +800,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infrastruktur":
+                - link "Infrastruktur":
                   - /url: /sv/category/infrastructure/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Trafik":
+                - link "Trafik":
                   - /url: /sv/category/transportation/
           - paragraph: Kyrkslätts vinterväghållning har återigen visat sig lika bristfällig som tidigare år. Det behöver inte vara så — vi kan välja att kräva kvalitet.
       - listitem:
@@ -823,13 +819,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Utbildning":
+                - link "Utbildning":
                   - /url: /sv/category/education/
           - paragraph: Kommunen måste planera långsiktigt. Kortsiktiga beslut utan framförhållning leder till merkostnader och sämre service för invånarna på sikt.
       - listitem:
@@ -842,7 +838,7 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
           - paragraph: Rasismredogörelsen är ett viktigt steg. Ordval spelar roll — med ord formar vi verkligheten och vårt sätt att förhålla oss till olikhet.
       - listitem:
@@ -855,13 +851,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Trafik":
+                - link "Trafik":
                   - /url: /sv/category/transportation/
               - listitem:
-                - link "#Infrastruktur":
+                - link "Infrastruktur":
                   - /url: /sv/category/infrastructure/
           - paragraph: Det vill säga för lätttrafiken — fotgängare och cyklister. Tänk om vi slutade bygga samhället på privatbilismens villkor?
       - listitem:
@@ -874,16 +870,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Planläggning":
+                - link "Planläggning":
                   - /url: /sv/category/urban-planning/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Utbildning":
+                - link "Utbildning":
                   - /url: /sv/category/education/
               - listitem:
-                - link "#Småbarnspedagogik":
+                - link "Småbarnspedagogik":
                   - /url: /sv/category/early-childhood-education/
           - paragraph: Inte varje skog behöver fällas. Närnatur som är i aktivt bruk i synnerhet bör bevaras och är en viktig del av vår kommun.
       - listitem:
@@ -896,13 +892,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2022/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Vård- och servicereform":
+                - link "Vård- och servicereform":
                   - /url: /sv/category/health-and-social-reform/
           - paragraph: Att avskaffa sote-klientavgifter sparar byråkrati, åtgärdar problem innan de växer och säkerställer att ingen lämnas utan vård av ekonomiska skäl.
       - listitem:
@@ -915,13 +911,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2022/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Vård- och servicereform":
+                - link "Vård- och servicereform":
                   - /url: /sv/category/health-and-social-reform/
           - paragraph: Social- och hälsovård är dyr men nödvändig. Utan ett fungerande system kan vi inte längre kalla Finland en välfärdsstat.
       - listitem:
@@ -934,13 +930,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2022/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Vård- och servicereform":
+                - link "Vård- och servicereform":
                   - /url: /sv/category/health-and-social-reform/
           - paragraph: Vad om Jorvi akutmottagning vore den enda jouren för hela västra Nyland? Vad om man alltid behövde köa i timmar på Jorvi?
       - listitem:
@@ -953,10 +949,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Grundläggande":
+                - link "Grundläggande":
                   - /url: /sv/category/basic-welfare/
           - paragraph: Grundtrygghetsutskottet behandlar invånarnas rättelseyrkan i grundtrygghetsfrågor. Mötenas innehåll är sekretessbelagt, men fallen ger lärdomar.
       - listitem:
@@ -969,13 +965,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2022/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Vård- och servicereform":
+                - link "Vård- och servicereform":
                   - /url: /sv/category/health-and-social-reform/
           - paragraph: Jag ställer upp i välfärdsomradesvalet. Viktigast är att bevara närtjänster, hålla hälsovården offentlig och trygga vårdpersonalens välmående.
       - listitem:
@@ -988,10 +984,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Småbarnspedagogik":
+                - link "Småbarnspedagogik":
                   - /url: /sv/category/early-childhood-education/
           - paragraph: Daghemmen lider av brist på lärare inom småbarnspedagogiken. Kyrkslätt har möjlighet att bygga en ny sorts arbetsmiljö och locka kompetens.
       - listitem:
@@ -1004,10 +1000,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Utbildning":
+                - link "Utbildning":
                   - /url: /sv/category/education/
           - paragraph: Projektplanen för Gesterby skolkomplex har återremitterats tre gånger. Projektet har utretts i sex år utan att ett nytt skolhus har byggts.
       - listitem:
@@ -1020,13 +1016,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Planläggning":
+                - link "Planläggning":
                   - /url: /sv/category/urban-planning/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Småbarnspedagogik":
+                - link "Småbarnspedagogik":
                   - /url: /sv/category/early-childhood-education/
           - paragraph: I centrumområdet råder redan brist på daghemsplatser. Nya detaljplaner ökar behovet — tillräckliga platser för småbarnspedagogik måste tryggas.
       - listitem:
@@ -1039,10 +1035,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Småbarnspedagogik":
+                - link "Småbarnspedagogik":
                   - /url: /sv/category/early-childhood-education/
           - paragraph: Klubbverksamhet inom småbarnspedagogiken är ett kostnadseffektivt stöd för barn och familjer. Men verksamhetens framtid är osäker i Kyrkslätt.
       - listitem:
@@ -1055,10 +1051,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Småbarnspedagogik":
+                - link "Småbarnspedagogik":
                   - /url: /sv/category/early-childhood-education/
           - paragraph: Kyrkslätt-tillägget gynnar inte bara de familjer som får det — det stärker hela kommunens livskraft och attraktionskraft för barnfamiljer.
       - listitem:
@@ -1071,9 +1067,9 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Småbarnspedagogik":
+                - link "Småbarnspedagogik":
                   - /url: /sv/category/early-childhood-education/
           - paragraph: Kyrkslätts fullmäktige avskaffade hemvårdsstödets kommunalt tillägg. Liten kostnad, men stor betydelse för barnfamiljer och kommunens vitalitet.

--- a/tests/e2e/homeEnPage.spec.ts-snapshots/Home-Page-in-English-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/homeEnPage.spec.ts-snapshots/Home-Page-in-English-should-match-aria-snapshot-1.aria.yml
@@ -27,10 +27,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Artificial intelligence":
+                - link "Artificial intelligence":
                   - /url: /en/category/artificial-intelligence/
               - listitem:
-                - link "#Digitalisation":
+                - link "Digitalisation":
                   - /url: /en/category/digitalisation/
           - paragraph: AI does in two minutes what used to take a developer two weeks. The price of code is collapsing — but what will developers get paid for instead?
       - listitem:
@@ -43,10 +43,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Nature":
+                - link "Nature":
                   - /url: /en/category/nature/
           - paragraph: Kirkkonummi acquired Lähteelä, a coastal area. One of the few places on Kirkkonummi's coast accessible without a private boat — now permanently open to all.
       - listitem:
@@ -59,10 +59,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Equality & equity":
+                - link "Equality & equity":
                   - /url: /en/category/equality-and-non-discrimination/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
           - paragraph: /Bullying of rainbow youth is increasing\. Kirkkonummi voted \d+–\d+ for flag-flying — a small gesture with measurable effects on young people's wellbeing\./
       - listitem:
@@ -75,13 +75,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Privacy":
+                - link "Privacy":
                   - /url: /en/category/privacy/
               - listitem:
-                - link "#Technology":
+                - link "Technology":
                   - /url: /en/category/technology/
               - listitem:
-                - link "#Digitalisation":
+                - link "Digitalisation":
                   - /url: /en/category/digitalisation/
           - paragraph: The European Parliament rejected the extension of the chat control law. The police statistics are real, but parliament was still right — here is why.
       - listitem:
@@ -94,10 +94,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Digital independence":
+                - link "Digital independence":
                   - /url: /en/category/digital-independence/
               - listitem:
-                - link "#Digitalisation":
+                - link "Digitalisation":
                   - /url: /en/category/digitalisation/
           - paragraph: Digital independence is built in every procurement decision. Helsinki chose Finnish UpCloud as the platform for its core public services system.
       - listitem:
@@ -110,7 +110,7 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Equality & equity":
+                - link "Equality & equity":
                   - /url: /en/category/equality-and-non-discrimination/
           - paragraph: The municipal council of Kirkkonummi on 9.3. accepted my initiative for hoisting the Pride flag in Kirkkonummi, twice a year!
       - listitem:
@@ -123,10 +123,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Digital independence":
+                - link "Digital independence":
                   - /url: /en/category/digital-independence/
               - listitem:
-                - link "#Digitalisation":
+                - link "Digitalisation":
                   - /url: /en/category/digitalisation/
           - paragraph: Finland's digital services depend on US platforms. As the US becomes unreliable, digital sovereignty is no longer optional — it is a necessity.
       - listitem:
@@ -139,12 +139,12 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infrastructure":
+                - link "Infrastructure":
                   - /url: /en/category/infrastructure/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Western railway":
+                - link "Western railway":
                   - /url: /en/category/west-railway/
           - paragraph: The West Railway decision revealed shortcomings in Kirkkonummi's strategic planning. The municipality risks bearing the costs without the benefits.

--- a/tests/e2e/homePage.spec.ts-snapshots/Home-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/homePage.spec.ts-snapshots/Home-Page-should-match-aria-snapshot-1.aria.yml
@@ -27,10 +27,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Artificial intelligence":
+                - link "Artificial intelligence":
                   - /url: /en/category/artificial-intelligence/
               - listitem:
-                - link "#Digitalisation":
+                - link "Digitalisation":
                   - /url: /en/category/digitalisation/
           - paragraph: AI does in two minutes what used to take a developer two weeks. The price of code is collapsing — but what will developers get paid for instead?
       - listitem:
@@ -43,10 +43,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Nature":
+                - link "Nature":
                   - /url: /en/category/nature/
           - paragraph: Kirkkonummi acquired Lähteelä, a coastal area. One of the few places on Kirkkonummi's coast accessible without a private boat — now permanently open to all.
       - listitem:
@@ -59,10 +59,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Equality & equity":
+                - link "Equality & equity":
                   - /url: /en/category/equality-and-non-discrimination/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
           - paragraph: /Bullying of rainbow youth is increasing\. Kirkkonummi voted \d+–\d+ for flag-flying — a small gesture with measurable effects on young people's wellbeing\./
       - listitem:
@@ -75,13 +75,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Privacy":
+                - link "Privacy":
                   - /url: /en/category/privacy/
               - listitem:
-                - link "#Technology":
+                - link "Technology":
                   - /url: /en/category/technology/
               - listitem:
-                - link "#Digitalisation":
+                - link "Digitalisation":
                   - /url: /en/category/digitalisation/
           - paragraph: The European Parliament rejected the extension of the chat control law. The police statistics are real, but parliament was still right — here is why.
       - listitem:
@@ -94,10 +94,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Digital independence":
+                - link "Digital independence":
                   - /url: /en/category/digital-independence/
               - listitem:
-                - link "#Digitalisation":
+                - link "Digitalisation":
                   - /url: /en/category/digitalisation/
           - paragraph: Digital independence is built in every procurement decision. Helsinki chose Finnish UpCloud as the platform for its core public services system.
       - listitem:
@@ -110,7 +110,7 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Equality & equity":
+                - link "Equality & equity":
                   - /url: /en/category/equality-and-non-discrimination/
           - paragraph: The municipal council of Kirkkonummi on 9.3. accepted my initiative for hoisting the Pride flag in Kirkkonummi, twice a year!
       - listitem:
@@ -123,10 +123,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Digital independence":
+                - link "Digital independence":
                   - /url: /en/category/digital-independence/
               - listitem:
-                - link "#Digitalisation":
+                - link "Digitalisation":
                   - /url: /en/category/digitalisation/
           - paragraph: Finland's digital services depend on US platforms. As the US becomes unreliable, digital sovereignty is no longer optional — it is a necessity.
       - listitem:
@@ -139,12 +139,12 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infrastructure":
+                - link "Infrastructure":
                   - /url: /en/category/infrastructure/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Western railway":
+                - link "Western railway":
                   - /url: /en/category/west-railway/
           - paragraph: The West Railway decision revealed shortcomings in Kirkkonummi's strategic planning. The municipality risks bearing the costs without the benefits.

--- a/tests/e2e/homeSwePage.spec.ts-snapshots/Home-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/homeSwePage.spec.ts-snapshots/Home-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
@@ -28,10 +28,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Artificiell intelligens":
+                - link "Artificiell intelligens":
                   - /url: /sv/category/artificial-intelligence/
               - listitem:
-                - link "#Digitalisering":
+                - link "Digitalisering":
                   - /url: /sv/category/digitalisation/
           - paragraph: AI gör på två minuter det som en utvecklare tidigare behövde två veckor på sig för. Priset på kod rasar — men vad ska utvecklare få betalt för i stället?
       - listitem:
@@ -44,10 +44,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Natur":
+                - link "Natur":
                   - /url: /sv/category/nature/
           - paragraph: Kyrksländ köpte Lähteelä som kustanläggning. En av få platser vid kusten dit man kan ta sig utan egen båt — nu permanent tillgängligt för alla invånare.
       - listitem:
@@ -60,10 +60,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Jämlikhet":
+                - link "Jämlikhet":
                   - /url: /sv/category/equality-and-non-discrimination/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
           - paragraph: /Mobbning av regnbågsungdomar ökar\. Kyrkslätt röstade \d+–\d+ för flaggning — en liten gest med mätbara effekter på ungas välmående\./
       - listitem:
@@ -76,13 +76,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Integritetsskydd":
+                - link "Integritetsskydd":
                   - /url: /sv/category/privacy/
               - listitem:
-                - link "#Teknologi":
+                - link "Teknologi":
                   - /url: /sv/category/technology/
               - listitem:
-                - link "#Digitalisering":
+                - link "Digitalisering":
                   - /url: /sv/category/digitalisation/
           - paragraph: Chat control-lagens förlängning röstades ned i Europaparlamentet. KRP:s siffror är verkliga, men parlamentet handlade ändå rätt — och här är skälet.
       - listitem:
@@ -95,10 +95,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Digital självständighet":
+                - link "Digital självständighet":
                   - /url: /sv/category/digital-independence/
               - listitem:
-                - link "#Digitalisering":
+                - link "Digitalisering":
                   - /url: /sv/category/digitalisation/
           - paragraph: Digital självständighet byggs i varje upphandlingsbeslut. Helsingfors valde finska UpCloud som plattform för kärnsystemet för stadens tjänster.
       - listitem:
@@ -111,7 +111,7 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Jämlikhet":
+                - link "Jämlikhet":
                   - /url: /sv/category/equality-and-non-discrimination/
           - paragraph: Den 9 mars godkände Kirkkonummis kommunfullmäktige mitt initiativ att börja hissa Pride-flaggor i Kirkkonummi två gånger om året!
       - listitem:
@@ -124,10 +124,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Digital självständighet":
+                - link "Digital självständighet":
                   - /url: /sv/category/digital-independence/
               - listitem:
-                - link "#Digitalisering":
+                - link "Digitalisering":
                   - /url: /sv/category/digitalisation/
           - paragraph: Som Rysslands granne har Finland lärt sig att vara beredd. Begreppen försörjningstrygghet och suveränitet har dock inte spridit sig till digitala tjänster.
       - listitem:
@@ -140,12 +140,12 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infrastruktur":
+                - link "Infrastruktur":
                   - /url: /sv/category/infrastructure/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Västbanan":
+                - link "Västbanan":
                   - /url: /sv/category/west-railway/
           - paragraph: Vid fattandet av Västbanans beslut mättes beslutsfattarnas förmåga att fatta strategiskt viktiga, framåtblickande beslut för hela kommunen.

--- a/tests/e2e/notFoundPage.spec.ts-snapshots/404-Not-Found-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/notFoundPage.spec.ts-snapshots/404-Not-Found-Page-should-match-aria-snapshot-1.aria.yml
@@ -12,10 +12,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Tekoäly":
+                - link "Tekoäly":
                   - /url: /fi/category/artificial-intelligence/
               - listitem:
-                - link "#Digitalisaatio":
+                - link "Digitalisaatio":
                   - /url: /fi/category/digitalisation/
           - paragraph: Tekoäly tekee kahdessa minuutissa sen, mihin kehittäjältä meni kaksi viikkoa. Koodin hinta romahtaa — mutta mistä kehittäjille sitten maksetaan?
       - listitem:
@@ -28,10 +28,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Luonto":
+                - link "Luonto":
                   - /url: /fi/category/nature/
           - paragraph: Kirkkonummi osti Lähteelän rannikkokohteen. Se on yksi harvoista paikoista, jonne pääsee myös ilman omaa venettä — nyt se on pysyvästi kaikkien saavutettavissa.
       - listitem:
@@ -44,10 +44,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Tasa-arvo ja yhdenvertaisuus":
+                - link "Tasa-arvo ja yhdenvertaisuus":
                   - /url: /fi/category/equality-and-non-discrimination/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
           - paragraph: /Sateenkaarinuorten kiusaaminen kasvaa\. Kirkkonummi äänesti \d+–\d+ liputuksen puolesta — pieni ele, jolla on mitattavia vaikutuksia nuorten hyvinvointiin\./
       - listitem:
@@ -60,13 +60,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Yksityisyydensuoja":
+                - link "Yksityisyydensuoja":
                   - /url: /fi/category/privacy/
               - listitem:
-                - link "#Teknologia":
+                - link "Teknologia":
                   - /url: /fi/category/technology/
               - listitem:
-                - link "#Digitalisaatio":
+                - link "Digitalisaatio":
                   - /url: /fi/category/digitalisation/
           - paragraph: Chat control -lain jatkoaika kaatui Euroopan parlamentissa. KRP:n luvut ovat todellisia, mutta parlamentti toimi silti oikein — ja tässä syy, miksi.
       - listitem:
@@ -79,10 +79,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Digitaalinen itsenäisyys":
+                - link "Digitaalinen itsenäisyys":
                   - /url: /fi/category/digital-independence/
               - listitem:
-                - link "#Digitalisaatio":
+                - link "Digitalisaatio":
                   - /url: /fi/category/digitalisation/
           - paragraph: Digitaalinen itsenäisyys rakentuu jokaisessa hankintapäätöksessä. Helsinki valitsi suomalaisen UpCloudin julkisten palveluiden ydinjärjestelmän alustaksi.
       - listitem:
@@ -95,7 +95,7 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Tasa-arvo ja yhdenvertaisuus":
+                - link "Tasa-arvo ja yhdenvertaisuus":
                   - /url: /fi/category/equality-and-non-discrimination/
           - paragraph: Kirkkonummen kunnnavaltuusto hyväksyi 9.3. aloitteeni Pride-liputuksen aloittamisesta Kirkkonummella, kahdesti vuodessa!
       - listitem:
@@ -108,10 +108,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Digitaalinen itsenäisyys":
+                - link "Digitaalinen itsenäisyys":
                   - /url: /fi/category/digital-independence/
               - listitem:
-                - link "#Digitalisaatio":
+                - link "Digitalisaatio":
                   - /url: /fi/category/digitalisation/
           - paragraph: Venäjän naapurina Suomi on oppinut varautumaan. Kuitenkaan käsitteet huoltovarmuudesta ja suvereniteetista eivät ole levinneet digitaalisiin palveluihin.
       - listitem:
@@ -124,12 +124,12 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infra":
+                - link "Infra":
                   - /url: /fi/category/infrastructure/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Länsirata":
+                - link "Länsirata":
                   - /url: /fi/category/west-railway/
           - paragraph: Länsirata-päätöstä tehdessä mitattiin päättäjien kykyä tehdä koko kunnalle strategisesti tärkeitä, tulevaisuuteen katsovia ratkaisuja.

--- a/tests/e2e/tagEnPage.spec.ts-snapshots/Tag-Category-Page-in-English-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/tagEnPage.spec.ts-snapshots/Tag-Category-Page-in-English-should-match-aria-snapshot-1.aria.yml
@@ -14,10 +14,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Nature":
+                - link "Nature":
                   - /url: /en/category/nature/
           - paragraph: Kirkkonummi acquired Lähteelä, a coastal area. One of the few places on Kirkkonummi's coast accessible without a private boat — now permanently open to all.
       - listitem:
@@ -30,10 +30,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Equality & equity":
+                - link "Equality & equity":
                   - /url: /en/category/equality-and-non-discrimination/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
           - paragraph: /Bullying of rainbow youth is increasing\. Kirkkonummi voted \d+–\d+ for flag-flying — a small gesture with measurable effects on young people's wellbeing\./
       - listitem:
@@ -46,13 +46,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infrastructure":
+                - link "Infrastructure":
                   - /url: /en/category/infrastructure/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Western railway":
+                - link "Western railway":
                   - /url: /en/category/west-railway/
           - paragraph: The West Railway decision revealed shortcomings in Kirkkonummi's strategic planning. The municipality risks bearing the costs without the benefits.
       - listitem:
@@ -65,10 +65,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Culture & education":
+                - link "Culture & education":
                   - /url: /en/category/culture-and-education/
           - paragraph: Kirkkonummi's renovation creates a culture cluster of Fyyri, Lyyra and Rovastinpuisto park. It sets conditions for growth for decades to come.
       - listitem:
@@ -81,13 +81,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infrastructure":
+                - link "Infrastructure":
                   - /url: /en/category/infrastructure/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Western railway":
+                - link "Western railway":
                   - /url: /en/category/west-railway/
           - paragraph: I voted for Kirkkonummi to join the Western Rail Link. The decision determines whether Northern Kirkkonummi gets a commuter rail station.
       - listitem:
@@ -100,13 +100,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infrastructure":
+                - link "Infrastructure":
                   - /url: /en/category/infrastructure/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Transport":
+                - link "Transport":
                   - /url: /en/category/transportation/
           - paragraph: HSL plans significant fare increases for buses and trains. This risks a downward spiral — fewer users means more pressure to raise prices further.
       - listitem:
@@ -119,13 +119,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Equality & equity":
+                - link "Equality & equity":
                   - /url: /en/category/equality-and-non-discrimination/
               - listitem:
-                - link "#Council motion":
+                - link "Council motion":
                   - /url: /en/category/council-motion/
           - paragraph: Kirkkonummi's strategy promotes equality and equal treatment. Flying the Pride flag is an inexpensive and easy action to implement it.
       - listitem:
@@ -138,13 +138,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Education":
+                - link "Education":
                   - /url: /en/category/education/
               - listitem:
-                - link "#Early childhood education":
+                - link "Early childhood education":
                   - /url: /en/category/early-childhood-education/
           - paragraph: The government's mid-term session cut state subsidies and corporate tax. This significantly narrows the room for manoeuvre for local councils.
       - listitem:
@@ -157,16 +157,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Education":
+                - link "Education":
                   - /url: /en/category/education/
               - listitem:
-                - link "#Early childhood education":
+                - link "Early childhood education":
                   - /url: /en/category/early-childhood-education/
           - paragraph: Education is the municipality's most important task. Investment in education pays off far into the future — there are no quick wins.
       - listitem:
@@ -179,16 +179,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Western Uusimaa":
+                - link "Western Uusimaa":
                   - /url: /en/category/western-uusimaa/
           - paragraph: The government wants to place upper secondary students in unequal positions based on citizenship. Tuition fees must be opposed absolutely.
       - listitem:
@@ -201,16 +201,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Western Uusimaa":
+                - link "Western Uusimaa":
                   - /url: /en/category/western-uusimaa/
           - paragraph: Kirkkonummi's centre renovation is a golden opportunity. A vibrant centre attracts residents and businesses — and improves the municipality's finances.
       - listitem:
@@ -223,16 +223,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Western Uusimaa":
+                - link "Western Uusimaa":
                   - /url: /en/category/western-uusimaa/
           - paragraph: Parties market themselves with images and slogans. It pays to challenge candidates on what their claims are actually based on before casting your vote.
       - listitem:
@@ -245,10 +245,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
           - paragraph: "Municipal elections may seem complex, but they decide everyday matters: schools, daycare and transport connections. You have the power to influence them."
       - listitem:
@@ -261,16 +261,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /en/category/immigration/
           - paragraph: Growing polarisation and inequality-creating policies unnecessarily divide our small nation. History shows we fare best when we cooperate.
       - listitem:
@@ -283,16 +283,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /en/category/immigration/
           - paragraph: There are many misconceptions about asylum seekers. It is important to distinguish facts from myths — seekers do not live at taxpayers' expense.
       - listitem:
@@ -305,16 +305,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /en/category/immigration/
           - paragraph: Receiving asylum is not automatic — it is a carefully defined process. Too often we forget the actual people behind the applications.
       - listitem:
@@ -327,16 +327,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /en/category/immigration/
           - paragraph: Students who come to Finland from abroad bring skilled workers. Yet we still have major challenges with their employment after graduation.
       - listitem:
@@ -349,16 +349,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /en/category/immigration/
           - paragraph: Labour-based immigration helps solve Finland's labour shortage. However, better conditions for integration and employment are still needed.
       - listitem:
@@ -371,13 +371,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Education":
+                - link "Education":
                   - /url: /en/category/education/
           - paragraph: Education is being cut deeply, despite government claims to the contrary. Index increases and legal reforms do not cover hundreds of millions in cuts.
       - listitem:
@@ -390,16 +390,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /en/category/immigration/
           - paragraph: Those who immigrate on the basis of family ties are a diverse group. They are often further along in integration than other immigrant groups.
       - listitem:
@@ -412,10 +412,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Equality & equity":
+                - link "Equality & equity":
                   - /url: /en/category/equality-and-non-discrimination/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
           - paragraph: /Finland turns \d+\. It is time to rehabilitate patriotism — Finland is one of the world's finest countries, where everyone is equally valued\./
       - listitem:
@@ -428,16 +428,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /en/category/immigration/
           - paragraph: In immigration discussions, volumes are often left unmentioned. Finland's immigration is a fraction of comparable countries' levels.
       - listitem:
@@ -450,16 +450,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /en/category/immigration/
           - paragraph: The immigration debate has long been dominated by critical voices. It is time to examine the topic more evenhandedly, based on facts.
       - listitem:
@@ -472,13 +472,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Education":
+                - link "Education":
                   - /url: /en/category/education/
           - paragraph: /The government is making necessary reforms to upper secondary education, but they do not compensate for €\d+ million cuts to vocational education\./
       - listitem:
@@ -491,16 +491,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Western Uusimaa":
+                - link "Western Uusimaa":
                   - /url: /en/category/western-uusimaa/
           - paragraph: Young people are living through crisis after crisis. The responsibility for a better future lies with us adults, not with the young.
       - listitem:
@@ -513,16 +513,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Western Uusimaa":
+                - link "Western Uusimaa":
                   - /url: /en/category/western-uusimaa/
           - paragraph: /I am standing in both the municipal and regional elections in \d+\. My priority is securing good opportunities for children and young people\./
       - listitem:
@@ -535,10 +535,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Early childhood education":
+                - link "Early childhood education":
                   - /url: /en/category/early-childhood-education/
           - paragraph: The government plans to cut funding for early childhood education planning. In practice the costs will simply be transferred to municipalities.
       - listitem:
@@ -551,13 +551,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Urban planning":
+                - link "Urban planning":
                   - /url: /en/category/urban-planning/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Co-op elections":
+                - link "Co-op elections":
                   - /url: /en/category/coop-elections/
           - paragraph: The Varuboden-Osla co-op elections are now under way. By voting you influence people's jobs, consumer behaviour and local services.
       - listitem:
@@ -570,13 +570,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infrastructure":
+                - link "Infrastructure":
                   - /url: /en/category/infrastructure/
               - listitem:
-                - link "#Urban planning":
+                - link "Urban planning":
                   - /url: /en/category/urban-planning/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
           - paragraph: One of Kirkkonummi's greatest attractions is our nature. The participatory budgeting that has just begun has shown this once again.
       - listitem:
@@ -589,13 +589,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infrastructure":
+                - link "Infrastructure":
                   - /url: /en/category/infrastructure/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Transport":
+                - link "Transport":
                   - /url: /en/category/transportation/
           - paragraph: Kirkkonummi's winter maintenance has again proved as poor as in previous years. It does not have to be this way — we can choose to demand quality.
       - listitem:
@@ -608,13 +608,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link /#Municipal elections \d+/:
+                - link /Municipal elections \d+/:
                   - /url: /en/category/municipal-elections-2025/
               - listitem:
-                - link "#Education":
+                - link "Education":
                   - /url: /en/category/education/
           - paragraph: Municipalities must plan for the long term. Short-sighted decisions lead to extra costs and poorer services for residents over time.
       - listitem:
@@ -627,7 +627,7 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
           - paragraph: The racism statement is an important step. Word choices matter — with words we shape reality and our relationship to difference.
       - listitem:
@@ -640,13 +640,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Transport":
+                - link "Transport":
                   - /url: /en/category/transportation/
               - listitem:
-                - link "#Infrastructure":
+                - link "Infrastructure":
                   - /url: /en/category/infrastructure/
           - paragraph: That is, for light traffic — pedestrians and cyclists. What if we stopped building society on the terms of private car use?
       - listitem:
@@ -659,16 +659,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Urban planning":
+                - link "Urban planning":
                   - /url: /en/category/urban-planning/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Education":
+                - link "Education":
                   - /url: /en/category/education/
               - listitem:
-                - link "#Early childhood education":
+                - link "Early childhood education":
                   - /url: /en/category/early-childhood-education/
           - paragraph: Not every forest needs to be felled. Local nature that is in active use in particular must be preserved, and it is an important part of our municipality.
       - listitem:
@@ -681,13 +681,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2022/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Social & health reform":
+                - link "Social & health reform":
                   - /url: /en/category/health-and-social-reform/
           - paragraph: Abolishing healthcare client fees saves bureaucracy, addresses problems before they grow, and ensures no one is left without care for financial reasons.
       - listitem:
@@ -700,13 +700,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2022/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Social & health reform":
+                - link "Social & health reform":
                   - /url: /en/category/health-and-social-reform/
           - paragraph: Social and healthcare is expensive, but essential. Without a functioning welfare system, can we still call Finland a welfare state?
       - listitem:
@@ -719,13 +719,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2022/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Social & health reform":
+                - link "Social & health reform":
                   - /url: /en/category/health-and-social-reform/
           - paragraph: What if Jorvi A&E were the only emergency service for all of Western Uusimaa? What if you always had to queue for hours at Jorvi?
       - listitem:
@@ -738,10 +738,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Basic welfare":
+                - link "Basic welfare":
                   - /url: /en/category/basic-welfare/
           - paragraph: The welfare committee handles residents' appeals on welfare matters. Although its meetings are confidential, the cases offer important lessons.
       - listitem:
@@ -754,13 +754,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regional elections \d+/:
+                - link /Regional elections \d+/:
                   - /url: /en/category/regional-elections-2022/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Social & health reform":
+                - link "Social & health reform":
                   - /url: /en/category/health-and-social-reform/
           - paragraph: I am standing in the regional elections. My priorities are maintaining local services, keeping healthcare public, and supporting care workers.
       - listitem:
@@ -773,10 +773,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Early childhood education":
+                - link "Early childhood education":
                   - /url: /en/category/early-childhood-education/
           - paragraph: Kindergartens suffer from a severe shortage of early childhood education teachers. Kirkkonummi has an opportunity to build a new kind of workplace.
       - listitem:
@@ -789,10 +789,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Education":
+                - link "Education":
                   - /url: /en/category/education/
           - paragraph: The Gesterby school complex project plan has been returned for further preparation three times. Six years of planning, still no new building.
       - listitem:
@@ -805,13 +805,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Urban planning":
+                - link "Urban planning":
                   - /url: /en/category/urban-planning/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Early childhood education":
+                - link "Early childhood education":
                   - /url: /en/category/early-childhood-education/
           - paragraph: There is already a shortage of early childhood places in Kirkkonummi's centre. New plans will increase demand — adequate provision must be secured.
       - listitem:
@@ -824,10 +824,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Early childhood education":
+                - link "Early childhood education":
                   - /url: /en/category/early-childhood-education/
           - paragraph: Early childhood education club activities are cost-effective support for children and families. Their future in Kirkkonummi is, however, uncertain.
       - listitem:
@@ -840,10 +840,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Early childhood education":
+                - link "Early childhood education":
                   - /url: /en/category/early-childhood-education/
           - paragraph: The Kirkkonummi supplement benefits not just recipient families — it strengthens the whole municipality's vitality and appeal to young families.
       - listitem:
@@ -856,9 +856,9 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "#Early childhood education":
+                - link "Early childhood education":
                   - /url: /en/category/early-childhood-education/
           - paragraph: Kirkkonummi council abolished the home care allowance supplement. A small cost, but a significant benefit for families and the municipality's vitality.

--- a/tests/e2e/tagPage.spec.ts-snapshots/Tag-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/tagPage.spec.ts-snapshots/Tag-Page-should-match-aria-snapshot-1.aria.yml
@@ -14,10 +14,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Luonto":
+                - link "Luonto":
                   - /url: /fi/category/nature/
           - paragraph: Kirkkonummi osti Lähteelän rannikkokohteen. Se on yksi harvoista paikoista, jonne pääsee myös ilman omaa venettä — nyt se on pysyvästi kaikkien saavutettavissa.
       - listitem:
@@ -30,10 +30,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Tasa-arvo ja yhdenvertaisuus":
+                - link "Tasa-arvo ja yhdenvertaisuus":
                   - /url: /fi/category/equality-and-non-discrimination/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
           - paragraph: /Sateenkaarinuorten kiusaaminen kasvaa\. Kirkkonummi äänesti \d+–\d+ liputuksen puolesta — pieni ele, jolla on mitattavia vaikutuksia nuorten hyvinvointiin\./
       - listitem:
@@ -46,13 +46,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infra":
+                - link "Infra":
                   - /url: /fi/category/infrastructure/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Länsirata":
+                - link "Länsirata":
                   - /url: /fi/category/west-railway/
           - paragraph: Länsirata-päätöstä tehdessä mitattiin päättäjien kykyä tehdä koko kunnalle strategisesti tärkeitä, tulevaisuuteen katsovia ratkaisuja.
       - listitem:
@@ -65,10 +65,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Sivistys":
+                - link "Sivistys":
                   - /url: /fi/category/culture-and-education/
           - paragraph: Kirkkonummen keskustan remontti rakentaa Fyyrin, Lyyran ja Rovastinpuiston sivistyksen keskittymän. Se luo edellytyksiä kasvulle vuosikymmeniksi.
       - listitem:
@@ -81,13 +81,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infra":
+                - link "Infra":
                   - /url: /fi/category/infrastructure/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Länsirata":
+                - link "Länsirata":
                   - /url: /fi/category/west-railway/
           - paragraph: Äänestin Kirkkonummen liittymisen Länsirataan puolesta. Päätös määrittää, saako Pohjois-Kirkkonummi lähijuna-aseman vai ei.
       - listitem:
@@ -100,13 +100,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infra":
+                - link "Infra":
                   - /url: /fi/category/infrastructure/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Liikenne":
+                - link "Liikenne":
                   - /url: /fi/category/transportation/
           - paragraph: Pääkaupunkiseudun joukkoliikenteestä vastaava HSL-kuntayhtymä suunnittelee lähivuosille tuntuvia korotuksia bussien ja junien lippujen hintoihin.
       - listitem:
@@ -119,13 +119,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Tasa-arvo ja yhdenvertaisuus":
+                - link "Tasa-arvo ja yhdenvertaisuus":
                   - /url: /fi/category/equality-and-non-discrimination/
               - listitem:
-                - link "#Valtuustoaloite":
+                - link "Valtuustoaloite":
                   - /url: /fi/category/council-motion/
           - paragraph: Kirkkonummen strategia edistää tasa-arvoa ja yhdenvertaisuutta. Pride-liputus on edullinen ja helppo teko strategian toimeenpanemiseksi.
       - listitem:
@@ -138,13 +138,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Opetus":
+                - link "Opetus":
                   - /url: /fi/category/education/
               - listitem:
-                - link "#Varhaiskasvatus":
+                - link "Varhaiskasvatus":
                   - /url: /fi/category/early-childhood-education/
           - paragraph: Hallituksen puoliväliriihi toi leikkauksia valtionosuuksiin ja yhteisöveroon. Se kaventaa kunnanvaltuutettujen liikkumatilaa merkittävästi.
       - listitem:
@@ -157,16 +157,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Opetus":
+                - link "Opetus":
                   - /url: /fi/category/education/
               - listitem:
-                - link "#Varhaiskasvatus":
+                - link "Varhaiskasvatus":
                   - /url: /fi/category/early-childhood-education/
           - paragraph: Koulutus on kunnan tärkein tehtävä. Koulutusinvestoinnit näkyvät kauas tulevaisuuteen – eikä sieltä ole pikavoittoja saatavissa.
       - listitem:
@@ -179,16 +179,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Länsi-Uusimaa":
+                - link "Länsi-Uusimaa":
                   - /url: /fi/category/western-uusimaa/
           - paragraph: Hallitus haluaa asettaa toisen asteen opiskelijat eriarvoiseen asemaan kansalaisuuden perusteella. Lukukausimaksuille on sanottava ehdoton ei.
       - listitem:
@@ -201,16 +201,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Länsi-Uusimaa":
+                - link "Länsi-Uusimaa":
                   - /url: /fi/category/western-uusimaa/
           - paragraph: Kirkkonummen keskustan remontti on tuhannen taalan paikka. Elinvoimainen keskusta houkuttelee asukkaita ja yrityksiä – ja parantaa kunnan taloutta.
       - listitem:
@@ -223,16 +223,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Länsi-Uusimaa":
+                - link "Länsi-Uusimaa":
                   - /url: /fi/category/western-uusimaa/
           - paragraph: Puolueet markkinoivat itseään mielikuvilla. Kannattaa haastaa ehdokkaita ja kysyä, mihin väitteet perustuvat ja miten asiat oikeasti toimivat.
       - listitem:
@@ -245,10 +245,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
           - paragraph: "Kuntavaalit saattavat tuntua monimutkaisilta, mutta kyse on arjen asioista: kouluista, päiväkodeista ja liikenneyhteyksistä. Sinulla on vaikutusvaltaa."
       - listitem:
@@ -261,16 +261,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Maahanmuutto":
+                - link "Maahanmuutto":
                   - /url: /fi/category/immigration/
           - paragraph: Kasvava vastakkainasettelu ja eriarvoistava politiikka repivät kansaa osiin. Historiamme osoittaa, että yhteistyöllä pärjäämme paremmin.
       - listitem:
@@ -283,16 +283,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Maahanmuutto":
+                - link "Maahanmuutto":
                   - /url: /fi/category/immigration/
           - paragraph: Turvapaikanhakemiseen liittyy paljon väärinkäsityksiä. On tärkeää erottaa faktat myyteistä – hakijat eivät elä veronmaksajien rahoilla herroiksi.
       - listitem:
@@ -305,16 +305,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Maahanmuutto":
+                - link "Maahanmuutto":
                   - /url: /fi/category/immigration/
           - paragraph: Turvapaikan saaminen ei ole itsestäänselvyys, vaan tarkoin määritelty prosessi. Usein unohdetaan, keitä ihmiset ovat, jotka paikkaa hakevat.
       - listitem:
@@ -327,16 +327,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Maahanmuutto":
+                - link "Maahanmuutto":
                   - /url: /fi/category/immigration/
           - paragraph: Ulkomailta Suomeen opiskelemaan tulleet tuovat osaavaa työvoimaa. Silti heidän työllistymisessään on suuria haasteita, joihin ei ole puututtu riittävästi.
       - listitem:
@@ -349,16 +349,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Maahanmuutto":
+                - link "Maahanmuutto":
                   - /url: /fi/category/immigration/
           - paragraph: Työperäinen maahanmuutto auttaa ratkaisemaan Suomen työvoimapulaa. Tarvitaan kuitenkin paremmat edellytykset kotoutumiselle ja työllistymiselle.
       - listitem:
@@ -371,13 +371,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Opetus":
+                - link "Opetus":
                   - /url: /fi/category/education/
           - paragraph: Koulutuksesta leikataan reilusti, vaikka hallitus väittää muuta. Indeksikorotukset ja lakiuudistukset eivät paikkaa satoja miljoonia leikkauksia.
       - listitem:
@@ -390,16 +390,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Maahanmuutto":
+                - link "Maahanmuutto":
                   - /url: /fi/category/immigration/
           - paragraph: Perhesiteeseen perustuvasti maahan muuttavat ovat moninainen joukko. He ovat usein pidemmällä integraatiossa kuin muut maahanmuuttajaryhmät.
       - listitem:
@@ -412,10 +412,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Tasa-arvo ja yhdenvertaisuus":
+                - link "Tasa-arvo ja yhdenvertaisuus":
                   - /url: /fi/category/equality-and-non-discrimination/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
           - paragraph: /Suomi täyttää \d+ vuotta\. On aika tehdä isänmaallisuuden kunnianpalautus – Suomi on yksi maailman hienoimmista maista, jossa jokainen on yhtä arvokas\./
       - listitem:
@@ -428,16 +428,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Maahanmuutto":
+                - link "Maahanmuutto":
                   - /url: /fi/category/immigration/
           - paragraph: Maahanmuuttoa koskevassa keskustelussa määrät jäävät usein mainitsematta. Suomen maahanmuutto on murto-osa verrokimaiden tasosta.
       - listitem:
@@ -450,16 +450,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Maahanmuutto":
+                - link "Maahanmuutto":
                   - /url: /fi/category/immigration/
           - paragraph: Maahanmuutto on monimutkainen ilmiö, jota kriittiset äänet ovat pitkään dominoineet. On aika tarkastella aihetta tasapuolisemmin ja tietoon perustuen.
       - listitem:
@@ -472,13 +472,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Opetus":
+                - link "Opetus":
                   - /url: /fi/category/education/
           - paragraph: /Hallitus tekee tarpeellisia uudistuksia toiselle asteelle, mutta ne eivät korvaa ammatilliseen koulutukseen kohdistuvia \d+ miljoonan leikkauksia\./
       - listitem:
@@ -491,16 +491,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Länsi-Uusimaa":
+                - link "Länsi-Uusimaa":
                   - /url: /fi/category/western-uusimaa/
           - paragraph: Nuoret elävät kriisissä – ilmastonmuutos, pandemia, sodat. Vastuu paremmasta tulevaisuudesta on meillä aikuisilla, ei nuorilla.
       - listitem:
@@ -513,16 +513,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2025/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Länsi-Uusimaa":
+                - link "Länsi-Uusimaa":
                   - /url: /fi/category/western-uusimaa/
           - paragraph: /Olen ehdolla sekä kunta- että aluevaaleissa \d+\. Tärkeintä minulle on lasten ja nuorten mahdollisuuksista huolehtiminen kasvavassa Kirkkonummessa\./
       - listitem:
@@ -535,10 +535,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Varhaiskasvatus":
+                - link "Varhaiskasvatus":
                   - /url: /fi/category/early-childhood-education/
           - paragraph: Hallitus suunnittelee säästöjä varhaiskasvatuksen suunnittelutyöhön. Todellisuudessa nämä säästöt siirtyvät vain kunnille ja asukkaille maksettaviksi.
       - listitem:
@@ -551,13 +551,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kaavoitus":
+                - link "Kaavoitus":
                   - /url: /fi/category/urban-planning/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Osuuskauppavaalit":
+                - link "Osuuskauppavaalit":
                   - /url: /fi/category/coop-elections/
           - paragraph: Varuboden-Oslan osuuskauppavaalit ovat nyt käynnissä. Äänestämällä vaikutat ihmisten työpaikkoihin, kulutuskäyttäytymiseen sekä lähipalveluihin.
       - listitem:
@@ -570,13 +570,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infra":
+                - link "Infra":
                   - /url: /fi/category/infrastructure/
               - listitem:
-                - link "#Kaavoitus":
+                - link "Kaavoitus":
                   - /url: /fi/category/urban-planning/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
           - paragraph: Kirkkonummen tärkeimpiä vetovoimia on meidän luontomme. Nyt alkanut osallistava budjetointi on sen jälleen osoittanut – luonto kuuluu meille kaikille.
       - listitem:
@@ -589,13 +589,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infra":
+                - link "Infra":
                   - /url: /fi/category/infrastructure/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Liikenne":
+                - link "Liikenne":
                   - /url: /fi/category/transportation/
           - paragraph: Kirkkonummen talvikunnossapito on jälleen osoittautunut yhtä huonoksi kuin ennenkin. Asiat voisivat olla toisin, jos päättäisimme tavoitella laatua.
       - listitem:
@@ -608,13 +608,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link /#Kuntavaalit \d+/:
+                - link /Kuntavaalit \d+/:
                   - /url: /fi/category/municipal-elections-2025/
               - listitem:
-                - link "#Opetus":
+                - link "Opetus":
                   - /url: /fi/category/education/
           - paragraph: Kunnan on suunniteltava pitkäjänteisesti. Lyhytnäköiset päätökset johtavat lisäkustannuksiin ja heikompiin palveluihin asukkaille.
       - listitem:
@@ -627,7 +627,7 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
           - paragraph: Rasismitiedonanto on tärkeä askel. Sanavalinnoilla on merkitystä – puheella muovaamme todellisuutta ja suhtautumistamme erilaisuuteen.
       - listitem:
@@ -640,13 +640,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Liikenne":
+                - link "Liikenne":
                   - /url: /fi/category/transportation/
               - listitem:
-                - link "#Infra":
+                - link "Infra":
                   - /url: /fi/category/infrastructure/
           - paragraph: Siis kevyelle liikenteelle eli jalankulkijoille ja pyöräilijöille. Mitä jos emme rakentaisikaan yhteiskuntaa yksityisautoilun ehdolla?
       - listitem:
@@ -659,16 +659,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kaavoitus":
+                - link "Kaavoitus":
                   - /url: /fi/category/urban-planning/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Opetus":
+                - link "Opetus":
                   - /url: /fi/category/education/
               - listitem:
-                - link "#Varhaiskasvatus":
+                - link "Varhaiskasvatus":
                   - /url: /fi/category/early-childhood-education/
           - paragraph: Jokaista metsää ei tarvitse kaataa. Varsinkaan aktiivisessa käytössä oleva lähiluonto tulee säilyttää ja se on tärkeä osa kuntaamme.
       - listitem:
@@ -681,13 +681,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2022/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Sote-uudistus":
+                - link "Sote-uudistus":
                   - /url: /fi/category/health-and-social-reform/
           - paragraph: Poistamalla sote-asiakasmaksut säästetään byrokratiassa, hoidetaan ongelmat ennen kuin ne kasvavat ja varmistetaan, ettei kukaan jää hoidotta.
       - listitem:
@@ -700,13 +700,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2022/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Sote-uudistus":
+                - link "Sote-uudistus":
                   - /url: /fi/category/health-and-social-reform/
           - paragraph: Sosiaali- ja terveydenhuolto on kallista, mutta välttämätöntä. Ilman toimivaa sotea emme voi enää puhua Suomesta hyvinvointivaltiona.
       - listitem:
@@ -719,13 +719,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2022/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Sote-uudistus":
+                - link "Sote-uudistus":
                   - /url: /fi/category/health-and-social-reform/
           - paragraph: Mitä jos Jorvin ensiapu olisi koko läntisen Uudenmaan ainoa päivystys? Mitä jos Jorvissa pitäisi aina jonottaa monta tuntia?
       - listitem:
@@ -738,10 +738,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Perusturva":
+                - link "Perusturva":
                   - /url: /fi/category/basic-welfare/
           - paragraph: Perusturvajaosto vastaa asukkaiden oikaisuvaatimuksiin perusturvaan liittyvissä asioissa. Vaikka kokousten sisältö on salaista, niistä voi ottaa opiksi.
       - listitem:
@@ -754,13 +754,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Aluevaalit \d+/:
+                - link /Aluevaalit \d+/:
                   - /url: /fi/category/regional-elections-2022/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Sote-uudistus":
+                - link "Sote-uudistus":
                   - /url: /fi/category/health-and-social-reform/
           - paragraph: Asetan itseni ehdolle aluevaaleihin. Tärkeintä on lähipalvelujen säilyminen, terveydenhuollon pitäminen julkisena ja hoitohenkilökunnan hyvinvointi.
       - listitem:
@@ -773,10 +773,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Varhaiskasvatus":
+                - link "Varhaiskasvatus":
                   - /url: /fi/category/early-childhood-education/
           - paragraph: Päiväkodeissa on pula varhaiskasvatuksen opettajista. Kirkkonummella on mahdollisuus rakentaa uudenlaista työympäristöä ja houkutella osaajia.
       - listitem:
@@ -789,10 +789,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Opetus":
+                - link "Opetus":
                   - /url: /fi/category/education/
           - paragraph: Gesterbyn koulukeskuksen hankesuunnitelmaa on palautettu lisävalmisteluun kolmesti. Hanketta on selvitetty kuusi vuotta ilman lopputulosta.
       - listitem:
@@ -805,13 +805,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kaavoitus":
+                - link "Kaavoitus":
                   - /url: /fi/category/urban-planning/
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Varhaiskasvatus":
+                - link "Varhaiskasvatus":
                   - /url: /fi/category/early-childhood-education/
           - paragraph: Kirkkonummen keskustan alueella on jo pulaa päiväkotipaikoista. Uudet asemakaavat kasvattavat tarvetta – varhaiskasvatuspaikkoja on riitettävä.
       - listitem:
@@ -824,10 +824,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Varhaiskasvatus":
+                - link "Varhaiskasvatus":
                   - /url: /fi/category/early-childhood-education/
           - paragraph: Varhaiskasvatuksen kerhotoiminta on kustannustehokas tuki lapsille ja perheille. Kirkkonummella toiminnan jatkuminen on kuitenkin epävarmaa.
       - listitem:
@@ -840,10 +840,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Varhaiskasvatus":
+                - link "Varhaiskasvatus":
                   - /url: /fi/category/early-childhood-education/
           - paragraph: Kirkkonummi-lisä hyödyttää paitsi sitä saavia perheitä, myös koko kuntaa. Lapsiperhepalvelut ovat investointi Kirkkonummen elinvoimaan.
       - listitem:
@@ -856,9 +856,9 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kirkkonummi":
+                - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "#Varhaiskasvatus":
+                - link "Varhaiskasvatus":
                   - /url: /fi/category/early-childhood-education/
           - paragraph: Kirkkonummen valtuusto lopetti kotihoidon tuen kuntalisän. Pieni kustannus, mutta suuri merkitys lapsiperheille ja kunnan elinvoimalle.

--- a/tests/e2e/tagSwePage.spec.ts-snapshots/Tag-Category-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/tagSwePage.spec.ts-snapshots/Tag-Category-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
@@ -14,10 +14,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Natur":
+                - link "Natur":
                   - /url: /sv/category/nature/
           - paragraph: Kyrksländ köpte Lähteelä som kustanläggning. En av få platser vid kusten dit man kan ta sig utan egen båt — nu permanent tillgängligt för alla invånare.
       - listitem:
@@ -30,10 +30,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Jämlikhet":
+                - link "Jämlikhet":
                   - /url: /sv/category/equality-and-non-discrimination/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
           - paragraph: /Mobbning av regnbågsungdomar ökar\. Kyrkslätt röstade \d+–\d+ för flaggning — en liten gest med mätbara effekter på ungas välmående\./
       - listitem:
@@ -46,13 +46,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infrastruktur":
+                - link "Infrastruktur":
                   - /url: /sv/category/infrastructure/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Västbanan":
+                - link "Västbanan":
                   - /url: /sv/category/west-railway/
           - paragraph: Vid fattandet av Västbanans beslut mättes beslutsfattarnas förmåga att fatta strategiskt viktiga, framåtblickande beslut för hela kommunen.
       - listitem:
@@ -65,10 +65,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Bildning":
+                - link "Bildning":
                   - /url: /sv/category/culture-and-education/
           - paragraph: Renoveringen av Kyrkslätts centrum skapar ett bildningskluster av Fyyri, Lyyra och Provstparken. Det ger förutsättningar för tillväxt i decennier.
       - listitem:
@@ -81,13 +81,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infrastruktur":
+                - link "Infrastruktur":
                   - /url: /sv/category/infrastructure/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Västbanan":
+                - link "Västbanan":
                   - /url: /sv/category/west-railway/
           - paragraph: Jag röstade för att Kyrkslätt ansluter sig till Västernabanan. Beslutet avgör om norra Kyrkslätt får en närtågsstation eller inte.
       - listitem:
@@ -100,13 +100,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infrastruktur":
+                - link "Infrastruktur":
                   - /url: /sv/category/infrastructure/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Trafik":
+                - link "Trafik":
                   - /url: /sv/category/transportation/
           - paragraph: HSL, samkommunen som ansvarar för kollektivtrafiken i huvudstadsregionen, planerar avsevärda biljetthöjningar för bussar och tåg under de kommande åren.
       - listitem:
@@ -119,13 +119,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Jämlikhet":
+                - link "Jämlikhet":
                   - /url: /sv/category/equality-and-non-discrimination/
               - listitem:
-                - link "#Fullmäktigeinitiativ":
+                - link "Fullmäktigeinitiativ":
                   - /url: /sv/category/council-motion/
           - paragraph: Kyrkslätts strategi främjar jämlikhet och likabehandling. Att hissa Pride-flaggan är en enkel och kostnadseffektiv åtgärd för att omsätta strategin.
       - listitem:
@@ -138,13 +138,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Utbildning":
+                - link "Utbildning":
                   - /url: /sv/category/education/
               - listitem:
-                - link "#Småbarnspedagogik":
+                - link "Småbarnspedagogik":
                   - /url: /sv/category/early-childhood-education/
           - paragraph: Halvtidsöverläggningen innebar nedskärningar i statsandelar och samfundsskatt. Det inskränker kommunfullmäktiges handlingsutrymme avsevärt.
       - listitem:
@@ -157,16 +157,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Utbildning":
+                - link "Utbildning":
                   - /url: /sv/category/education/
               - listitem:
-                - link "#Småbarnspedagogik":
+                - link "Småbarnspedagogik":
                   - /url: /sv/category/early-childhood-education/
           - paragraph: Utbildning är kommunens viktigaste uppgift. Satsningar på utbildning är investeringar som syns långt in i framtiden, utan snabba vinster.
       - listitem:
@@ -179,16 +179,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Västra Nyland":
+                - link "Västra Nyland":
                   - /url: /sv/category/western-uusimaa/
           - paragraph: Regeringen anser att vi borde ställa unga som studerar på andra stadiet i en ojämlik ställning beroende på om de har EU-medborgarskap eller inte.
       - listitem:
@@ -201,16 +201,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Västra Nyland":
+                - link "Västra Nyland":
                   - /url: /sv/category/western-uusimaa/
           - paragraph: Renoveringen av Kyrkslätts centrum är ett gyllene tillfälle. Ett livskraftigt centrum lockar invånare och företag — och stärker kommunens ekonomi.
       - listitem:
@@ -223,16 +223,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Västra Nyland":
+                - link "Västra Nyland":
                   - /url: /sv/category/western-uusimaa/
           - paragraph: Partier marknadsför sig med hjälp av bilder. Det lönar sig att utmana kandidaterna och fråga vad påståenden grundar sig på i verkligheten.
       - listitem:
@@ -245,10 +245,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
           - paragraph: "Kommunalvalet kan verka komplicerat, men handlar om vardagsfrågor: skolor, daghem och kommunikationer. Du har makt att påverka."
       - listitem:
@@ -261,16 +261,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /sv/category/immigration/
           - paragraph: Ökad polarisering och ojämlikhetsskapande politik splittrar onödigt vårt folk. Historien visar att vi klarar oss bäst när vi samarbetar.
       - listitem:
@@ -283,16 +283,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /sv/category/immigration/
           - paragraph: Det finns många missuppfattningar om asylsökande. Det är viktigt att skilja fakta från myter — sökande lever inte på skattebetalarnas bekostnad.
       - listitem:
@@ -305,16 +305,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /sv/category/immigration/
           - paragraph: Att få asyl är ingen självklarhet, utan en noggrant definierad process. Alltför ofta glöms de faktiska människorna bakom ansökningarna bort.
       - listitem:
@@ -327,16 +327,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /sv/category/immigration/
           - paragraph: Studerande från utlandet tillför kompetent arbetskraft till Finland. Trots det har vi stora utmaningar med deras sysselsättning efter studierna.
       - listitem:
@@ -349,16 +349,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /sv/category/immigration/
           - paragraph: Arbetsbaserad invandring bidrar till att lösa Finlands arbetskraftsbrist. Det krävs dock bättre förutsättningar för integration och sysselsättning.
       - listitem:
@@ -371,13 +371,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Utbildning":
+                - link "Utbildning":
                   - /url: /sv/category/education/
           - paragraph: Utbildningen skärs ned kraftigt, trots att regeringen hävdar motsatsen. Indexhöjningar och lagreformer täcker inte hundratals miljoner i nedskärningar.
       - listitem:
@@ -390,16 +390,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /sv/category/immigration/
           - paragraph: De som invandrar på basis av familjeband är en mångfaldig grupp. De är ofta längre framme i integrationen än andra invandrargrupper.
       - listitem:
@@ -412,10 +412,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Jämlikhet":
+                - link "Jämlikhet":
                   - /url: /sv/category/equality-and-non-discrimination/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
           - paragraph: /Finland fyller \d+ år\. Det är dags att rehabilitera patriotismen — Finland är ett av världens bästa länder, där alla är lika värda\./
       - listitem:
@@ -428,16 +428,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /sv/category/immigration/
           - paragraph: I invandringsdebatten glöms volymen ofta bort. Finlands invandring är en bråkdel av jämförbara länders nivåer — fakta som sällan nämns.
       - listitem:
@@ -450,16 +450,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Immigration":
+                - link "Immigration":
                   - /url: /sv/category/immigration/
           - paragraph: Invandringsdebatten domineras länge av kritiska röster. Det är dags att granska ämnet mer balanserat och faktabaserat — med fokus på vad forskning säger.
       - listitem:
@@ -472,13 +472,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Utbildning":
+                - link "Utbildning":
                   - /url: /sv/category/education/
           - paragraph: /Regeringen gör nödvändiga reformer för gymnasiet, men de kompenserar inte nedskärningarna på \d+ miljoner euro i yrkesutbildningen\./
       - listitem:
@@ -491,16 +491,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Västra Nyland":
+                - link "Västra Nyland":
                   - /url: /sv/category/western-uusimaa/
           - paragraph: Unga lever mitt i kriser — klimat, pandemi, krig. Ansvaret för en bättre framtid ligger hos oss vuxna, inte hos ungdomarna.
       - listitem:
@@ -513,16 +513,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2025/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Västra Nyland":
+                - link "Västra Nyland":
                   - /url: /sv/category/western-uusimaa/
           - paragraph: /Jag kandiderar i både kommunal- och välfärdsomradesvalet \d+\. Viktigast för mig är att säkra barn och ungdomars möjligheter i Kyrkslätt\./
       - listitem:
@@ -535,10 +535,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Småbarnspedagogik":
+                - link "Småbarnspedagogik":
                   - /url: /sv/category/early-childhood-education/
           - paragraph: Regeringen planerar att spara på planeringen av småbarnspedagogik. I praktiken övervältras kostnaderna på kommunerna och invånarna istället.
       - listitem:
@@ -551,13 +551,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Planläggning":
+                - link "Planläggning":
                   - /url: /sv/category/urban-planning/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Kooperativval":
+                - link "Kooperativval":
                   - /url: /sv/category/coop-elections/
           - paragraph: Varuboden-Oslas andelslagsval pågår nu. Genom att rösta påverkar du människors arbetsplatser, konsumtionsbeteende och lokala tjänster.
       - listitem:
@@ -570,13 +570,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infrastruktur":
+                - link "Infrastruktur":
                   - /url: /sv/category/infrastructure/
               - listitem:
-                - link "#Planläggning":
+                - link "Planläggning":
                   - /url: /sv/category/urban-planning/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
           - paragraph: En av Kirkkonummis viktigaste dragningskrafter är vår natur. Det deltagarbudgeterande som nyss inletts har återigen visat det.
       - listitem:
@@ -589,13 +589,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Infrastruktur":
+                - link "Infrastruktur":
                   - /url: /sv/category/infrastructure/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Trafik":
+                - link "Trafik":
                   - /url: /sv/category/transportation/
           - paragraph: Kyrkslätts vinterväghållning har återigen visat sig lika bristfällig som tidigare år. Det behöver inte vara så — vi kan välja att kräva kvalitet.
       - listitem:
@@ -608,13 +608,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link /#Kommunalval \d+/:
+                - link /Kommunalval \d+/:
                   - /url: /sv/category/municipal-elections-2025/
               - listitem:
-                - link "#Utbildning":
+                - link "Utbildning":
                   - /url: /sv/category/education/
           - paragraph: Kommunen måste planera långsiktigt. Kortsiktiga beslut utan framförhållning leder till merkostnader och sämre service för invånarna på sikt.
       - listitem:
@@ -627,7 +627,7 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
           - paragraph: Rasismredogörelsen är ett viktigt steg. Ordval spelar roll — med ord formar vi verkligheten och vårt sätt att förhålla oss till olikhet.
       - listitem:
@@ -640,13 +640,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Trafik":
+                - link "Trafik":
                   - /url: /sv/category/transportation/
               - listitem:
-                - link "#Infrastruktur":
+                - link "Infrastruktur":
                   - /url: /sv/category/infrastructure/
           - paragraph: Det vill säga för lätttrafiken — fotgängare och cyklister. Tänk om vi slutade bygga samhället på privatbilismens villkor?
       - listitem:
@@ -659,16 +659,16 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Planläggning":
+                - link "Planläggning":
                   - /url: /sv/category/urban-planning/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Utbildning":
+                - link "Utbildning":
                   - /url: /sv/category/education/
               - listitem:
-                - link "#Småbarnspedagogik":
+                - link "Småbarnspedagogik":
                   - /url: /sv/category/early-childhood-education/
           - paragraph: Inte varje skog behöver fällas. Närnatur som är i aktivt bruk i synnerhet bör bevaras och är en viktig del av vår kommun.
       - listitem:
@@ -681,13 +681,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2022/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Vård- och servicereform":
+                - link "Vård- och servicereform":
                   - /url: /sv/category/health-and-social-reform/
           - paragraph: Att avskaffa sote-klientavgifter sparar byråkrati, åtgärdar problem innan de växer och säkerställer att ingen lämnas utan vård av ekonomiska skäl.
       - listitem:
@@ -700,13 +700,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2022/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Vård- och servicereform":
+                - link "Vård- och servicereform":
                   - /url: /sv/category/health-and-social-reform/
           - paragraph: Social- och hälsovård är dyr men nödvändig. Utan ett fungerande system kan vi inte längre kalla Finland en välfärdsstat.
       - listitem:
@@ -719,13 +719,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2022/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Vård- och servicereform":
+                - link "Vård- och servicereform":
                   - /url: /sv/category/health-and-social-reform/
           - paragraph: Vad om Jorvi akutmottagning vore den enda jouren för hela västra Nyland? Vad om man alltid behövde köa i timmar på Jorvi?
       - listitem:
@@ -738,10 +738,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Grundläggande":
+                - link "Grundläggande":
                   - /url: /sv/category/basic-welfare/
           - paragraph: Grundtrygghetsutskottet behandlar invånarnas rättelseyrkan i grundtrygghetsfrågor. Mötenas innehåll är sekretessbelagt, men fallen ger lärdomar.
       - listitem:
@@ -754,13 +754,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link /#Regionval \d+/:
+                - link /Regionval \d+/:
                   - /url: /sv/category/regional-elections-2022/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Vård- och servicereform":
+                - link "Vård- och servicereform":
                   - /url: /sv/category/health-and-social-reform/
           - paragraph: Jag ställer upp i välfärdsomradesvalet. Viktigast är att bevara närtjänster, hålla hälsovården offentlig och trygga vårdpersonalens välmående.
       - listitem:
@@ -773,10 +773,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Småbarnspedagogik":
+                - link "Småbarnspedagogik":
                   - /url: /sv/category/early-childhood-education/
           - paragraph: Daghemmen lider av brist på lärare inom småbarnspedagogiken. Kyrkslätt har möjlighet att bygga en ny sorts arbetsmiljö och locka kompetens.
       - listitem:
@@ -789,10 +789,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Utbildning":
+                - link "Utbildning":
                   - /url: /sv/category/education/
           - paragraph: Projektplanen för Gesterby skolkomplex har återremitterats tre gånger. Projektet har utretts i sex år utan att ett nytt skolhus har byggts.
       - listitem:
@@ -805,13 +805,13 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Planläggning":
+                - link "Planläggning":
                   - /url: /sv/category/urban-planning/
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Småbarnspedagogik":
+                - link "Småbarnspedagogik":
                   - /url: /sv/category/early-childhood-education/
           - paragraph: I centrumområdet råder redan brist på daghemsplatser. Nya detaljplaner ökar behovet — tillräckliga platser för småbarnspedagogik måste tryggas.
       - listitem:
@@ -824,10 +824,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Småbarnspedagogik":
+                - link "Småbarnspedagogik":
                   - /url: /sv/category/early-childhood-education/
           - paragraph: Klubbverksamhet inom småbarnspedagogiken är ett kostnadseffektivt stöd för barn och familjer. Men verksamhetens framtid är osäker i Kyrkslätt.
       - listitem:
@@ -840,10 +840,10 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Småbarnspedagogik":
+                - link "Småbarnspedagogik":
                   - /url: /sv/category/early-childhood-education/
           - paragraph: Kyrkslätt-tillägget gynnar inte bara de familjer som får det — det stärker hela kommunens livskraft och attraktionskraft för barnfamiljer.
       - listitem:
@@ -856,9 +856,9 @@
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "#Kyrkslätt":
+                - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "#Småbarnspedagogik":
+                - link "Småbarnspedagogik":
                   - /url: /sv/category/early-childhood-education/
           - paragraph: Kyrkslätts fullmäktige avskaffade hemvårdsstödets kommunalt tillägg. Liten kostnad, men stor betydelse för barnfamiljer och kommunens vitalitet.


### PR DESCRIPTION
> This PR containes AI-generated code. The author has reviewed and is responsible for all AI-generated content.

## Summary

- Replaces plain monospace tag links with compact sand-background pills (darkMoss border, 6px radius, IBM Plex Mono 12px) in `Meta.astro`
- New `TagPill.astro` component encapsulates the pill style; hover inverts colors (darkMoss bg, sand text)
- Blog index "by topic" section (`fi/en/sv`) now renders `TopicsTagList` (pills) instead of `TopicsList` (H2 + description cards)
- Topics pages (`/fi/topics/` etc.) are unchanged

## Test plan

- [ ] Visit a blog post — tags render as compact pills
- [ ] Visit `/fi/blog/` — "Aiheittain" section shows pills, not heading cards
- [ ] Visit `/fi/topics/` — still shows H2 + description layout
- [ ] All locales (`/en/blog/`, `/sv/blog/`) correct
- [ ] CI passes (type check, lint, unit tests, E2E)