### PR TITLE
feat(content): align blog tags and pinned posts with core-message pillars

### DIFF
--- a/src/pages/en/blog/15/the-municipality-must-plan-for-the-long-term/index.mdx
+++ b/src/pages/en/blog/15/the-municipality-must-plan-for-the-long-term/index.mdx
@@ -11,6 +11,7 @@ tags:
   - kirkkonummi
   - municipal-elections-2025
   - education
+  - learning
 heroImage: 'laajakallion-koulu'
 alt: 'Laajakallio school building in Kirkkonummi'
 ---

--- a/src/pages/en/blog/22/one-step-forward-two-steps-back/index.mdx
+++ b/src/pages/en/blog/22/one-step-forward-two-steps-back/index.mdx
@@ -11,6 +11,7 @@ tags:
   - kirkkonummi
   - municipal-elections-2025
   - education
+  - learning
 heroImage: 'Lauri-Lavanti-ja-lapsi-kävelyllä'
 alt: 'Lauri Lavanti pushing a pram on a gravel path, a child walking beside him and houses in the background.'
 ---

--- a/src/pages/en/blog/27/is-education-under-special-protection/index.mdx
+++ b/src/pages/en/blog/27/is-education-under-special-protection/index.mdx
@@ -11,6 +11,7 @@ tags:
   - kirkkonummi
   - municipal-elections-2025
   - education
+  - learning
 faq:
   - q: "Are the government's value choices right?"
     a: "We agree with the Minister that public finances must be strengthened and the economy balanced. However, we do not agree on which services should be cut and what amounts should be cut from education."

--- a/src/pages/en/blog/37/education-is-the-municipalitys-most-important-task/index.mdx
+++ b/src/pages/en/blog/37/education-is-the-municipalitys-most-important-task/index.mdx
@@ -12,6 +12,7 @@ tags:
   - municipal-elections-2025
   - education
   - early-childhood-education
+  - learning
 heroImage: 'laajakallion-koulu'
 alt: 'A photograph of Laajakallio school.'
 ---

--- a/src/pages/en/blog/38/a-cold-harvest-for-kirkkonummi/index.mdx
+++ b/src/pages/en/blog/38/a-cold-harvest-for-kirkkonummi/index.mdx
@@ -11,6 +11,7 @@ tags:
   - kirkkonummi
   - education
   - early-childhood-education
+  - learning
 heroImage: Kirkkonummen-keskusta
 alt: "Kirkkonummi's town centre from a high vantage point, with the sun low in the background."
 ---

--- a/src/pages/en/blog/43/who-decides-what-we-talk-about/index.mdx
+++ b/src/pages/en/blog/43/who-decides-what-we-talk-about/index.mdx
@@ -10,6 +10,7 @@ updatedDate: '2025-12-19'
 tags:
   - social-media
   - technology
+  - freedom
 faq:
   - q: "How does social media guide public debate?"
     a: "A significant portion of all public and political discussion has now shifted into the sphere of influence of foreign social media giants."

--- a/src/pages/en/blog/44/ai-cannot-do-everything/index.mdx
+++ b/src/pages/en/blog/44/ai-cannot-do-everything/index.mdx
@@ -10,6 +10,7 @@ updatedDate: '2025-12-19'
 tags:
   - digitalisation
   - artificial-intelligence
+  - learning
 faq:
   - q: "What can AI do in public services?"
     a: "AI is a tool that can be used to solve well-understood problems. The slowness of recording a doctor's observations is a good example of such a problem."

--- a/src/pages/en/blog/45/fundamental-rights-must-not-be-dismantled-without-justification/index.mdx
+++ b/src/pages/en/blog/45/fundamental-rights-must-not-be-dismantled-without-justification/index.mdx
@@ -10,6 +10,7 @@ updatedDate: '2025-12-22'
 tags:
   - technology
   - privacy
+  - freedom
 heroImage: Poliisiauto
 alt: 'An image of the lights on the roof of a police car.'
 ---

--- a/src/pages/en/blog/47/2026-is-the-year-of-ai/index.mdx
+++ b/src/pages/en/blog/47/2026-is-the-year-of-ai/index.mdx
@@ -10,6 +10,7 @@ updatedDate: '2026-05-03'
 tags:
   - digitalisation
   - artificial-intelligence
+  - learning
 heroImage: 'Lauri-Lavanti-Helsingin-yliopistolla'
 alt: 'Lauri Lavanti standing in front of a mirror with a phone in his hand, taking a selfie. Wearing a black jacket, white shirt and green tie. In the background, the light corridor of the main building of the University of Helsinki.'
 ---

--- a/src/pages/en/blog/48/the-use-of-biometric-identifiers-in-passports-must-not-be-expanded/index.mdx
+++ b/src/pages/en/blog/48/the-use-of-biometric-identifiers-in-passports-must-not-be-expanded/index.mdx
@@ -10,6 +10,7 @@ updatedDate: '2026-05-03'
 tags:
   - technology
   - privacy
+  - freedom
 heroImage: 'Atte-Harjanne-ja-Lauri-Lavanti'
 alt: 'A photo of Atte Harjanne and Lauri Lavanti. Both are wearing a black jacket and shirt.'
 ---

--- a/src/pages/en/blog/5/well-planned-is-half-done-but/index.mdx
+++ b/src/pages/en/blog/5/well-planned-is-half-done-but/index.mdx
@@ -10,6 +10,7 @@ updatedDate: '2026-03-01'
 tags:
   - kirkkonummi
   - education
+  - learning
 heroImage: winellska-skolan
 alt: 'Winellska skolan building in Kirkkonummi.'
 ---

--- a/src/pages/en/blog/54/chat-control-parliament-was-right/index.mdx
+++ b/src/pages/en/blog/54/chat-control-parliament-was-right/index.mdx
@@ -10,6 +10,7 @@ tags:
   - privacy
   - technology
   - digitalisation
+  - freedom
 heroImage: sermi-jonka-takana-huone
 alt: 'A Japanese-style screen behind which a room is visible in soft focus.'
 ---

--- a/src/pages/en/blog/57/ai-changes-what-developers-get-paid-for/index.mdx
+++ b/src/pages/en/blog/57/ai-changes-what-developers-get-paid-for/index.mdx
@@ -9,6 +9,8 @@ publishDate: '2026-04-22'
 tags:
   - artificial-intelligence
   - digitalisation
+  - learning
+  - economy
 heroImage: koodia-tietokoneella
 alt: 'A computer screen showing code.'
 faq:

--- a/src/pages/en/blog/60/ai-helps-secure-municipal-services-but-it-isnt-free/index.mdx
+++ b/src/pages/en/blog/60/ai-helps-secure-municipal-services-but-it-isnt-free/index.mdx
@@ -10,6 +10,7 @@ tags:
   - artificial-intelligence
   - kirkkonummi
   - digitalisation
+  - learning
 heroImage: Lauri-Lavanti-seisoo-kukkapaita-päällään-valkoinen-tausta-vaaka
 alt: 'Lauri Lavanti stands in a floral shirt against a white background.'
 faq:

--- a/src/pages/en/blog/index.mdx
+++ b/src/pages/en/blog/index.mdx
@@ -31,8 +31,8 @@ I have over a decade of hands-on experience building secure software and banking
 
 ## Featured
 
-<ExcerptList lang="en" onlyIds={[47, 48, 51, 54]} />
+<ExcerptList lang="en" onlyIds={[60, 57, 54, 51]} />
 
 ## All posts
 
-<ExcerptList lang="en" excludeIds={[47, 48, 51, 54]} />
+<ExcerptList lang="en" excludeIds={[60, 57, 54, 51]} />

--- a/src/pages/fi/blog/15/kunnan-pitaa-suunnitella-pitkajanteisesti/index.mdx
+++ b/src/pages/fi/blog/15/kunnan-pitaa-suunnitella-pitkajanteisesti/index.mdx
@@ -11,6 +11,7 @@ tags:
   - kirkkonummi
   - municipal-elections-2025
   - education
+  - learning
 heroImage: laajakallion-koulu
 alt: 'Kuva Laajakallion koulusta'
 ---

--- a/src/pages/fi/blog/22/yksi-askel-eteen-kaksi-taakse/index.mdx
+++ b/src/pages/fi/blog/22/yksi-askel-eteen-kaksi-taakse/index.mdx
@@ -11,6 +11,7 @@ tags:
   - kirkkonummi
   - municipal-elections-2025
   - education
+  - learning
 heroImage: Lauri-Lavanti-ja-lapsi-kävelyllä
 alt: 'Lauri Lavanti työntämässä rattaita hiekkatietä, vieressä lapsi kävelee ja taustalla on taloja.'
 ---

--- a/src/pages/fi/blog/27/koulutusko-erityissuojelussa/index.mdx
+++ b/src/pages/fi/blog/27/koulutusko-erityissuojelussa/index.mdx
@@ -11,6 +11,7 @@ tags:
   - kirkkonummi
   - municipal-elections-2025
   - education
+  - learning
 faq:
   - q: "Ovatko hallituksen arvovalinnat kunnossa?"
     a: "Olemme yhtä mieltä opetusministerin kanssa siitä, että julkista taloutta tulee vahvistaa ja taloutta tasapainottaa. Emme kuitenkaan ole samaa mieltä siitä, mistä palveluista tulisi leikata ja kuinka paljon koulutuksesta tulisi leikata."

--- a/src/pages/fi/blog/37/koulutus-on-kunnan-tarkein-tehtava/index.mdx
+++ b/src/pages/fi/blog/37/koulutus-on-kunnan-tarkein-tehtava/index.mdx
@@ -12,6 +12,7 @@ tags:
   - municipal-elections-2025
   - education
   - early-childhood-education
+  - learning
 heroImage: laajakallion-koulu
 alt: 'Kuva Laajakallion koulusta'
 ---

--- a/src/pages/fi/blog/38/kylma-riihi-kirkkonummelle/index.mdx
+++ b/src/pages/fi/blog/38/kylma-riihi-kirkkonummelle/index.mdx
@@ -11,6 +11,7 @@ tags:
   - kirkkonummi
   - education
   - early-childhood-education
+  - learning
 heroImage: Kirkkonummen-keskusta
 alt: 'Kuva Kirkkonummen keskustasta korkealta, taustalla aurinko matalalla'
 ---

--- a/src/pages/fi/blog/43/kuka-paattaa-mista-puhumma/index.mdx
+++ b/src/pages/fi/blog/43/kuka-paattaa-mista-puhumma/index.mdx
@@ -10,6 +10,7 @@ updatedDate: '2025-12-19'
 tags:
   - social-media
   - technology
+  - freedom
 faq:
   - q: "Miten sosiaalinen media ohjaa yhteiskunnallista keskustelua?"
     a: "Merkittävä osa kaikesta yhteiskunnallisesta ja poliittisesta keskustelusta onkin nykyään siirtynyt ulkomaisten sosiaalisen median suuryhtiöiden vaikutuspiiriin."

--- a/src/pages/fi/blog/44/tekoaly-ei-pysty-mihin-tahansa/index.mdx
+++ b/src/pages/fi/blog/44/tekoaly-ei-pysty-mihin-tahansa/index.mdx
@@ -10,6 +10,7 @@ updatedDate: '2025-12-19'
 tags:
   - digitalisation
   - artificial-intelligence
+  - learning
 faq:
   - q: "Mitä tekoäly voi tehdä julkisissa palveluissa?"
     a: "Tekoäly on työkalu, jota voi hyödyntää hyvin ymmärrettyjen ongelmien ratkomiseen. Lääkärin havaintojen kirjaamisen hitaus on hyvä esimerkki tällaisesta ongelmasta."

--- a/src/pages/fi/blog/45/perusoikeuksia-ei-pida-purkaa-perusteettomasti/index.mdx
+++ b/src/pages/fi/blog/45/perusoikeuksia-ei-pida-purkaa-perusteettomasti/index.mdx
@@ -10,6 +10,7 @@ updatedDate: '2025-12-22'
 tags:
   - technology
   - privacy
+  - freedom
 heroImage: Poliisiauto
 alt: 'Kuva poliisiauton katolla olevista valoista'
 ---

--- a/src/pages/fi/blog/47/vuosi-2026-on-tekoalyn/index.mdx
+++ b/src/pages/fi/blog/47/vuosi-2026-on-tekoalyn/index.mdx
@@ -10,6 +10,7 @@ updatedDate: '2026-05-03'
 tags:
   - digitalisation
   - artificial-intelligence
+  - learning
 heroImage: Lauri-Lavanti-Helsingin-yliopistolla
 alt: 'Lauri Lavanti seisomassa peilin edessä puhelin kädessä, ottamassa itsestään kuvaa. Päällä musta takki, valkoinen kauluspaita ja kaulassa vihreä kravatti. Taustalla Helsingin Yliopiston päärakennuksen vaalea käytävä.'
 ---

--- a/src/pages/fi/blog/48/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/index.mdx
+++ b/src/pages/fi/blog/48/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/index.mdx
@@ -10,6 +10,7 @@ updatedDate: '2026-05-03'
 tags:
   - technology
   - privacy
+  - freedom
 heroImage: Atte-Harjanne-ja-Lauri-Lavanti
 alt: 'Kuva Atte Harjanteesta ja Lauri Lavannista. Kummallakin musta takki ja kauluspaita.'
 ---

--- a/src/pages/fi/blog/5/hyvin-suunniteltu-on-puoliksi-tehty-mutta/index.mdx
+++ b/src/pages/fi/blog/5/hyvin-suunniteltu-on-puoliksi-tehty-mutta/index.mdx
@@ -10,6 +10,7 @@ updatedDate: '2025-12-19'
 tags:
   - kirkkonummi
   - education
+  - learning
 heroImage: winellska-skolan
 alt: 'Kuva Winellska skolanista.'
 ---

--- a/src/pages/fi/blog/54/chat-control-parlamentti-toimi-oikein/index.mdx
+++ b/src/pages/fi/blog/54/chat-control-parlamentti-toimi-oikein/index.mdx
@@ -10,6 +10,7 @@ tags:
   - privacy
   - technology
   - digitalisation
+  - freedom
 heroImage: sermi-jonka-takana-huone
 alt: 'Kuva japanilaistyylisestä sermistä, jonka takana näkyy sumeasti huone.'
 ---

--- a/src/pages/fi/blog/57/tekoaly-ei-korvaa-koodareita-vaan-muuttaa-sen-mista-heille-maksetaan/index.mdx
+++ b/src/pages/fi/blog/57/tekoaly-ei-korvaa-koodareita-vaan-muuttaa-sen-mista-heille-maksetaan/index.mdx
@@ -9,6 +9,8 @@ publishDate: '2026-04-22'
 tags:
   - artificial-intelligence
   - digitalisation
+  - learning
+  - economy
 heroImage: koodia-tietokoneella
 alt: 'Kuvassa tietokoneen näyttö, jossa näkyy koodia.'
 faq:

--- a/src/pages/fi/blog/60/tekoaly-auttaa-palvelujen-turvaamisessa-mutta-se-ei-ole-ilmaista/index.mdx
+++ b/src/pages/fi/blog/60/tekoaly-auttaa-palvelujen-turvaamisessa-mutta-se-ei-ole-ilmaista/index.mdx
@@ -10,6 +10,7 @@ tags:
   - artificial-intelligence
   - kirkkonummi
   - digitalisation
+  - learning
 heroImage: Lauri-Lavanti-seisoo-kukkapaita-päällään-valkoinen-tausta-vaaka
 alt: 'Lauri Lavanti seisoo kukkapaita päällään valkoisella taustalla.'
 faq:

--- a/src/pages/fi/blog/index.mdx
+++ b/src/pages/fi/blog/index.mdx
@@ -31,8 +31,8 @@ Käytännön kokemukseni on yli vuosikymmenen ajalta turvallisten ohjelmistojen 
 
 ## Nostot
 
-<ExcerptList lang="fi" onlyIds={[47, 48, 51, 54]} />
+<ExcerptList lang="fi" onlyIds={[60, 57, 54, 51]} />
 
 ## Kaikki kirjoitukset
 
-<ExcerptList lang="fi" excludeIds={[47, 48, 51, 54]} />
+<ExcerptList lang="fi" excludeIds={[60, 57, 54, 51]} />

--- a/src/pages/sv/blog/15/kommunen-maste-planera-langsiktigt/index.mdx
+++ b/src/pages/sv/blog/15/kommunen-maste-planera-langsiktigt/index.mdx
@@ -11,6 +11,7 @@ tags:
   - kirkkonummi
   - municipal-elections-2025
   - education
+  - learning
 heroImage: 'laajakallion-koulu'
 alt: 'Laajakallio skolbyggnad i Kyrkslätt'
 ---

--- a/src/pages/sv/blog/22/ett-steg-fram-tva-steg-tillbaka/index.mdx
+++ b/src/pages/sv/blog/22/ett-steg-fram-tva-steg-tillbaka/index.mdx
@@ -11,6 +11,7 @@ tags:
   - kirkkonummi
   - municipal-elections-2025
   - education
+  - learning
 heroImage: 'Lauri-Lavanti-ja-lapsi-kävelyllä'
 alt: 'Lauri Lavanti knuffar en barnvagn på en grusväg, ett barn går bredvid och hus syns i bakgrunden.'
 ---

--- a/src/pages/sv/blog/27/ar-utbildningen-under-sarskilt-skydd/index.mdx
+++ b/src/pages/sv/blog/27/ar-utbildningen-under-sarskilt-skydd/index.mdx
@@ -11,6 +11,7 @@ tags:
   - kirkkonummi
   - municipal-elections-2025
   - education
+  - learning
 faq:
   - q: "Är regeringens värdeval rätt?"
     a: "Vi håller med ministern om att de offentliga finanserna måste stärkas och ekonomin balanseras. Vi är dock inte eniga om vilka tjänster som bör skäras ned och hur mycket som bör skäras från utbildningen."

--- a/src/pages/sv/blog/37/utbildning-ar-kommunens-viktigaste-uppgift/index.mdx
+++ b/src/pages/sv/blog/37/utbildning-ar-kommunens-viktigaste-uppgift/index.mdx
@@ -12,6 +12,7 @@ tags:
   - municipal-elections-2025
   - education
   - early-childhood-education
+  - learning
 heroImage: 'laajakallion-koulu'
 alt: 'Ett fotografi av Laajakallio skola.'
 ---

--- a/src/pages/sv/blog/38/en-kall-skord-for-kyrkslätt/index.mdx
+++ b/src/pages/sv/blog/38/en-kall-skord-for-kyrkslätt/index.mdx
@@ -11,6 +11,7 @@ tags:
   - kirkkonummi
   - education
   - early-childhood-education
+  - learning
 heroImage: Kirkkonummen-keskusta
 alt: 'Kyrkslätts centrum sett från en hög utsiktspunkt, med solen lågt i bakgrunden.'
 ---

--- a/src/pages/sv/blog/43/vem-bestammer-vad-vi-pratar-om/index.mdx
+++ b/src/pages/sv/blog/43/vem-bestammer-vad-vi-pratar-om/index.mdx
@@ -10,6 +10,7 @@ updatedDate: '2025-12-19'
 tags:
   - social-media
   - technology
+  - freedom
 faq:
   - q: "Hur styr sociala medier den samhälleliga diskussionen?"
     a: "En betydande del av all samhällelig och politisk diskussion har nu förflyttats till utländska sociala mediegiganternas inflytandesfär."

--- a/src/pages/sv/blog/44/ai-kan-inte-allt/index.mdx
+++ b/src/pages/sv/blog/44/ai-kan-inte-allt/index.mdx
@@ -10,6 +10,7 @@ updatedDate: '2025-12-19'
 tags:
   - digitalisation
   - artificial-intelligence
+  - learning
 faq:
   - q: "Vad kan AI göra i offentliga tjänster?"
     a: "AI är ett verktyg som kan användas för att lösa väl förstådda problem. Långsamheten i att dokumentera en läkares observationer är ett bra exempel på ett sådant problem."

--- a/src/pages/sv/blog/45/grundlaggande-rattigheter-far-inte-rivas-utan-grund/index.mdx
+++ b/src/pages/sv/blog/45/grundlaggande-rattigheter-far-inte-rivas-utan-grund/index.mdx
@@ -10,6 +10,7 @@ updatedDate: '2025-12-22'
 tags:
   - technology
   - privacy
+  - freedom
 heroImage: Poliisiauto
 alt: 'En bild av lamporna på taket av en polisbil.'
 ---

--- a/src/pages/sv/blog/47/ar-2026-ar-ai-aret/index.mdx
+++ b/src/pages/sv/blog/47/ar-2026-ar-ai-aret/index.mdx
@@ -10,6 +10,7 @@ updatedDate: '2026-05-03'
 tags:
   - digitalisation
   - artificial-intelligence
+  - learning
 heroImage: 'Lauri-Lavanti-Helsingin-yliopistolla'
 alt: 'Lauri Lavanti stående framför en spegel med en telefon i handen och tar en selfie. Klädd i svart jacka, vit skjorta och grön slips. I bakgrunden den ljusa korridoren i Helsingfors universitets huvudbyggnad.'
 ---

--- a/src/pages/sv/blog/48/anvandningen-av-biometriska-identifierare-i-pass-far-inte-utvidgas/index.mdx
+++ b/src/pages/sv/blog/48/anvandningen-av-biometriska-identifierare-i-pass-far-inte-utvidgas/index.mdx
@@ -10,6 +10,7 @@ updatedDate: '2026-05-03'
 tags:
   - technology
   - privacy
+  - freedom
 heroImage: 'Atte-Harjanne-ja-Lauri-Lavanti'
 alt: 'Ett foto av Atte Harjanne och Lauri Lavanti. Båda bär svart jacka och skjorta.'
 ---

--- a/src/pages/sv/blog/5/valplanerat-ar-halvt-gjort-men/index.mdx
+++ b/src/pages/sv/blog/5/valplanerat-ar-halvt-gjort-men/index.mdx
@@ -10,6 +10,7 @@ updatedDate: '2026-03-01'
 tags:
   - kirkkonummi
   - education
+  - learning
 heroImage: winellska-skolan
 alt: 'Winellska skolan i Kyrkslätt.'
 ---

--- a/src/pages/sv/blog/54/chat-control-parlamentet-handlade-ratt/index.mdx
+++ b/src/pages/sv/blog/54/chat-control-parlamentet-handlade-ratt/index.mdx
@@ -10,6 +10,7 @@ tags:
   - privacy
   - technology
   - digitalisation
+  - freedom
 heroImage: sermi-jonka-takana-huone
 alt: 'Bild på en japansk skärm bakom vilken ett rum skymtar suddigt.'
 ---

--- a/src/pages/sv/blog/57/ai-forandrar-vad-utvecklare-far-betalt-for/index.mdx
+++ b/src/pages/sv/blog/57/ai-forandrar-vad-utvecklare-far-betalt-for/index.mdx
@@ -9,6 +9,8 @@ publishDate: '2026-04-22'
 tags:
   - artificial-intelligence
   - digitalisation
+  - learning
+  - economy
 heroImage: koodia-tietokoneella
 alt: 'En datorskärm med kod.'
 faq:

--- a/src/pages/sv/blog/60/ai-hjalper-till-att-sakra-kommunala-tjanster-men-det-kostar/index.mdx
+++ b/src/pages/sv/blog/60/ai-hjalper-till-att-sakra-kommunala-tjanster-men-det-kostar/index.mdx
@@ -10,6 +10,7 @@ tags:
   - artificial-intelligence
   - kirkkonummi
   - digitalisation
+  - learning
 heroImage: Lauri-Lavanti-seisoo-kukkapaita-päällään-valkoinen-tausta-vaaka
 alt: 'Lauri Lavanti står i en blommig skjorta mot vit bakgrund.'
 faq:

--- a/src/pages/sv/blog/index.mdx
+++ b/src/pages/sv/blog/index.mdx
@@ -31,8 +31,8 @@ Jag har över ett årtiondes praktisk erfarenhet av att bygga säker programvara
 
 ## Utvalda
 
-<ExcerptList lang="sv" onlyIds={[47, 48, 51, 54]} />
+<ExcerptList lang="sv" onlyIds={[60, 57, 54, 51]} />
 
 ## Alla inlägg
 
-<ExcerptList lang="sv" excludeIds={[47, 48, 51, 54]} />
+<ExcerptList lang="sv" excludeIds={[60, 57, 54, 51]} />

--- a/tests/e2e/blogEnPage.spec.ts-snapshots/Blog-Page-in-English-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/blogEnPage.spec.ts-snapshots/Blog-Page-in-English-should-match-aria-snapshot-1.aria.yml
@@ -22,8 +22,55 @@
       - listitem:
         - link "Digital independence":
           - /url: /en/category/digital-independence/
+      - listitem:
+        - link "Kirkkonummi":
+          - /url: /en/category/kirkkonummi/
     - heading "Featured" [level=2]
     - list:
+      - listitem:
+        - 'article "AI in municipalities: benefits and costs"':
+          - 'link "Lauri Lavanti stands in a floral shirt against a white background. AI in municipalities: benefits and costs"':
+            - /url: /en/blog/60/ai-helps-secure-municipal-services-but-it-isnt-free/
+            - img "Lauri Lavanti stands in a floral shirt against a white background."
+            - 'heading "AI in municipalities: benefits and costs" [level=2]'
+          - 'complementary "Meta information for post \"AI in municipalities: benefits and costs\""':
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Artificial intelligence":
+                  - /url: /en/category/artificial-intelligence/
+              - listitem:
+                - link "Kirkkonummi":
+                  - /url: /en/category/kirkkonummi/
+              - listitem:
+                - link "Digitalisation":
+                  - /url: /en/category/digitalisation/
+              - listitem:
+                - link "Learning":
+                  - /url: /en/category/learning/
+          - paragraph: In Konnevesi, AI cut processing time for road grants from two months to days. Kirkkonummi is too small to act alone — but collaboration makes change possible.
+      - listitem:
+        - article "AI changes what developers get paid for":
+          - link "A computer screen showing code. AI changes what developers get paid for":
+            - /url: /en/blog/57/ai-changes-what-developers-get-paid-for/
+            - img "A computer screen showing code."
+            - heading "AI changes what developers get paid for" [level=2]
+          - complementary "Meta information for post \"AI changes what developers get paid for\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Artificial intelligence":
+                  - /url: /en/category/artificial-intelligence/
+              - listitem:
+                - link "Digitalisation":
+                  - /url: /en/category/digitalisation/
+              - listitem:
+                - link "Learning":
+                  - /url: /en/category/learning/
+              - listitem:
+                - link "Economy":
+                  - /url: /en/category/economy/
+          - paragraph: AI does in two minutes what used to take a developer two weeks. The price of code is collapsing — but what will developers get paid for instead?
       - listitem:
         - 'article "Chat control: parliament was right"':
           - 'link "A Japanese-style screen behind which a room is visible in soft focus. Chat control: parliament was right"':
@@ -42,6 +89,9 @@
               - listitem:
                 - link "Digitalisation":
                   - /url: /en/category/digitalisation/
+              - listitem:
+                - link "Freedom":
+                  - /url: /en/category/freedom/
           - paragraph: The European Parliament rejected the extension of the chat control law. The police statistics are real, but parliament was still right — here is why.
       - listitem:
         - article "Digital independence is a necessity":
@@ -59,56 +109,46 @@
                 - link "Digitalisation":
                   - /url: /en/category/digitalisation/
           - paragraph: Finland's digital services depend on US platforms. As the US becomes unreliable, digital sovereignty is no longer optional — it is a necessity.
-      - listitem:
-        - article "Passport biometrics must stay protected":
-          - link "A photo of Atte Harjanne and Lauri Lavanti. Both are wearing a black jacket and shirt. Passport biometrics must stay protected":
-            - /url: /en/blog/48/the-use-of-biometric-identifiers-in-passports-must-not-be-expanded/
-            - img "A photo of Atte Harjanne and Lauri Lavanti. Both are wearing a black jacket and shirt."
-            - heading "Passport biometrics must stay protected" [level=2]
-          - complementary "Meta information for post \"Passport biometrics must stay protected\"":
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Technology":
-                  - /url: /en/category/technology/
-              - listitem:
-                - link "Privacy":
-                  - /url: /en/category/privacy/
-          - paragraph: When fingerprints were added to passports, Finland created a national biometric register. Now the government wants to open it to police use.
-      - listitem:
-        - article /\d+ is the year of AI — not as you think/:
-          - link /Lauri Lavanti standing in front of a mirror with a phone in his hand, taking a selfie\. Wearing a black jacket, white shirt and green tie\. In the background, the light corridor of the main building of the University of Helsinki\. \d+ is the year of AI — not as you think/:
-            - /url: /en/blog/47/2026-is-the-year-of-ai/
-            - img "Lauri Lavanti standing in front of a mirror with a phone in his hand, taking a selfie. Wearing a black jacket, white shirt and green tie. In the background, the light corridor of the main building of the University of Helsinki."
-            - heading /\d+ is the year of AI — not as you think/ [level=2]
-          - complementary /Meta information for post "\d+ is the year of AI — not as you think"/:
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Digitalisation":
-                  - /url: /en/category/digitalisation/
-              - listitem:
-                - link "Artificial intelligence":
-                  - /url: /en/category/artificial-intelligence/
-          - paragraph: AI is changing society — but perhaps not as you imagine. The biggest changes will be in private life and in the everyday lives of children.
     - heading "All posts" [level=2]
     - list:
       - listitem:
-        - article "AI changes what developers get paid for":
-          - link "A computer screen showing code. AI changes what developers get paid for":
-            - /url: /en/blog/57/ai-changes-what-developers-get-paid-for/
-            - img "A computer screen showing code."
-            - heading "AI changes what developers get paid for" [level=2]
-          - complementary "Meta information for post \"AI changes what developers get paid for\"":
+        - 'article "Council initiative: digital resilience"':
+          - 'link "Lauri Lavanti smiling and looking at the camera. He is wearing a white t-shirt that reads Digitaalinen itsenäisyys (Digital independence) with a lion motif above it, and a blazer. Photo by Erkki Laine. Council initiative: digital resilience"':
+            - /url: /en/blog/59/council-initiative-strengthening-kirkkonummis-digital-resilience/
+            - img "Lauri Lavanti smiling and looking at the camera. He is wearing a white t-shirt that reads Digitaalinen itsenäisyys (Digital independence) with a lion motif above it, and a blazer. Photo by Erkki Laine."
+            - 'heading "Council initiative: digital resilience" [level=2]'
+          - 'complementary "Meta information for post \"Council initiative: digital resilience\""':
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "Artificial intelligence":
-                  - /url: /en/category/artificial-intelligence/
+                - link "Kirkkonummi":
+                  - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "Digitalisation":
-                  - /url: /en/category/digitalisation/
-          - paragraph: AI does in two minutes what used to take a developer two weeks. The price of code is collapsing — but what will developers get paid for instead?
+                - link "Digital independence":
+                  - /url: /en/category/digital-independence/
+              - listitem:
+                - link "Council motion":
+                  - /url: /en/category/council-motion/
+          - paragraph: Kirkkonummi relies on digital systems for nearly all its operations. This initiative calls for mapping dependencies and switching to open file formats.
+      - listitem:
+        - article "I voted against Västra – here is why":
+          - link "Three stacks of coins at different heights on a white background. The image illustrates municipal financial decision-making. I voted against Västra – here is why":
+            - /url: /en/blog/58/i-voted-against-vastra/
+            - img "Three stacks of coins at different heights on a white background. The image illustrates municipal financial decision-making."
+            - heading "I voted against Västra – here is why" [level=2]
+          - complementary "Meta information for post \"I voted against Västra – here is why\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Economy":
+                  - /url: /en/category/economy/
+              - listitem:
+                - link "Kirkkonummi":
+                  - /url: /en/category/kirkkonummi/
+              - listitem:
+                - link "Western Uusimaa":
+                  - /url: /en/category/western-uusimaa/
+          - paragraph: "I voted against Kirkkonummi joining the Västra cooperation. The council decided otherwise. My case: the money belongs in education, not a locked-in agreement."
       - listitem:
         - article "Lähteelä — a gem on Kirkkonummi coast":
           - link "Lauri Lavanti and Miisa Jeremejew, municipal councillors (Greens), Kirkkonummi Lähteelä — a gem on Kirkkonummi coast":
@@ -206,6 +246,44 @@
                   - /url: /en/category/culture-and-education/
           - paragraph: Kirkkonummi's renovation creates a culture cluster of Fyyri, Lyyra and Rovastinpuisto park. It sets conditions for growth for decades to come.
       - listitem:
+        - article "Passport biometrics must stay protected":
+          - link "A photo of Atte Harjanne and Lauri Lavanti. Both are wearing a black jacket and shirt. Passport biometrics must stay protected":
+            - /url: /en/blog/48/the-use-of-biometric-identifiers-in-passports-must-not-be-expanded/
+            - img "A photo of Atte Harjanne and Lauri Lavanti. Both are wearing a black jacket and shirt."
+            - heading "Passport biometrics must stay protected" [level=2]
+          - complementary "Meta information for post \"Passport biometrics must stay protected\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Technology":
+                  - /url: /en/category/technology/
+              - listitem:
+                - link "Privacy":
+                  - /url: /en/category/privacy/
+              - listitem:
+                - link "Freedom":
+                  - /url: /en/category/freedom/
+          - paragraph: When fingerprints were added to passports, Finland created a national biometric register. Now the government wants to open it to police use.
+      - listitem:
+        - article /\d+ is the year of AI — not as you think/:
+          - link /Lauri Lavanti standing in front of a mirror with a phone in his hand, taking a selfie\. Wearing a black jacket, white shirt and green tie\. In the background, the light corridor of the main building of the University of Helsinki\. \d+ is the year of AI — not as you think/:
+            - /url: /en/blog/47/2026-is-the-year-of-ai/
+            - img "Lauri Lavanti standing in front of a mirror with a phone in his hand, taking a selfie. Wearing a black jacket, white shirt and green tie. In the background, the light corridor of the main building of the University of Helsinki."
+            - heading /\d+ is the year of AI — not as you think/ [level=2]
+          - complementary /Meta information for post "\d+ is the year of AI — not as you think"/:
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Digitalisation":
+                  - /url: /en/category/digitalisation/
+              - listitem:
+                - link "Artificial intelligence":
+                  - /url: /en/category/artificial-intelligence/
+              - listitem:
+                - link "Learning":
+                  - /url: /en/category/learning/
+          - paragraph: AI is changing society — but perhaps not as you imagine. The biggest changes will be in private life and in the everyday lives of children.
+      - listitem:
         - article "I voted yes for the Western Rail Link":
           - link /A visualisation by Länsirata Oy of what the Veikkola railway station could look like\. The image shows tracks, platforms and a pedestrian overpass\. Taken from https:\/\/lansirata\.sitowise\.com\/\?link=Pysm6# on 8 December \d+\. I voted yes for the Western Rail Link/:
             - /url: /en/blog/46/i-voted-for-the-western-rail-link/
@@ -239,6 +317,9 @@
               - listitem:
                 - link "Privacy":
                   - /url: /en/category/privacy/
+              - listitem:
+                - link "Freedom":
+                  - /url: /en/category/freedom/
           - paragraph: The government plans to extend intelligence methods to fight crime without individual suspicion — a serious threat to fundamental rights.
       - listitem:
         - article "AI cannot do everything — know the limits":
@@ -255,6 +336,9 @@
               - listitem:
                 - link "Artificial intelligence":
                   - /url: /en/category/artificial-intelligence/
+              - listitem:
+                - link "Learning":
+                  - /url: /en/category/learning/
           - paragraph: AI has been presented as a solution for improving public services. It may have a role, but cannot replace people or clear strategic planning.
       - listitem:
         - article "Who decides what we talk about? Algorithms":
@@ -271,6 +355,9 @@
               - listitem:
                 - link "Technology":
                   - /url: /en/category/technology/
+              - listitem:
+                - link "Freedom":
+                  - /url: /en/category/freedom/
           - paragraph: Are we prepared for our conversations to be steered by foreign large corporations? There are no guarantees that algorithms would not be used deliberately.
       - listitem:
         - 'article "Essays on immigration: the persistent myths"':
@@ -357,6 +444,9 @@
               - listitem:
                 - link "Early childhood education":
                   - /url: /en/category/early-childhood-education/
+              - listitem:
+                - link "Learning":
+                  - /url: /en/category/learning/
           - paragraph: The government's mid-term session cut state subsidies and corporate tax. This significantly narrows the room for manoeuvre for local councils.
       - listitem:
         - article "Education is the municipality's main task":
@@ -379,6 +469,9 @@
               - listitem:
                 - link "Early childhood education":
                   - /url: /en/category/early-childhood-education/
+              - listitem:
+                - link "Learning":
+                  - /url: /en/category/learning/
           - paragraph: Education is the municipality's most important task. Investment in education pays off far into the future — there are no quick wins.
       - listitem:
         - article "No to upper secondary tuition fees":
@@ -590,6 +683,9 @@
               - listitem:
                 - link "Education":
                   - /url: /en/category/education/
+              - listitem:
+                - link "Learning":
+                  - /url: /en/category/learning/
           - paragraph: Education is being cut deeply, despite government claims to the contrary. Index increases and legal reforms do not cover hundreds of millions in cuts.
       - listitem:
         - 'article "Essays on immigration: family-based"':
@@ -691,6 +787,9 @@
               - listitem:
                 - link "Education":
                   - /url: /en/category/education/
+              - listitem:
+                - link "Learning":
+                  - /url: /en/category/learning/
           - paragraph: /The government is making necessary reforms to upper secondary education, but they do not compensate for €\d+ million cuts to vocational education\./
       - listitem:
         - 'article "A better future: responsibility lies with us"':
@@ -827,6 +926,9 @@
               - listitem:
                 - link "Education":
                   - /url: /en/category/education/
+              - listitem:
+                - link "Learning":
+                  - /url: /en/category/learning/
           - paragraph: Municipalities must plan for the long term. Short-sighted decisions lead to extra costs and poorer services for residents over time.
       - listitem:
         - article "With our words we shape our shared reality":
@@ -1005,6 +1107,9 @@
               - listitem:
                 - link "Education":
                   - /url: /en/category/education/
+              - listitem:
+                - link "Learning":
+                  - /url: /en/category/learning/
           - paragraph: The Gesterby school complex project plan has been returned for further preparation three times. Six years of planning, still no new building.
       - listitem:
         - article "Early childhood education standards to hold":

--- a/tests/e2e/blogPage.spec.ts-snapshots/Blog-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/blogPage.spec.ts-snapshots/Blog-Page-should-match-aria-snapshot-1.aria.yml
@@ -22,8 +22,55 @@
       - listitem:
         - link "Digitaalinen itsenäisyys":
           - /url: /fi/category/digital-independence/
+      - listitem:
+        - link "Kirkkonummi":
+          - /url: /fi/category/kirkkonummi/
     - heading "Nostot" [level=2]
     - list:
+      - listitem:
+        - 'article "Tekoäly kunnassa: mahdollisuudet ja hinta"':
+          - 'link "Lauri Lavanti seisoo kukkapaita päällään valkoisella taustalla. Tekoäly kunnassa: mahdollisuudet ja hinta"':
+            - /url: /fi/blog/60/tekoaly-auttaa-palvelujen-turvaamisessa-mutta-se-ei-ole-ilmaista/
+            - img "Lauri Lavanti seisoo kukkapaita päällään valkoisella taustalla."
+            - 'heading "Tekoäly kunnassa: mahdollisuudet ja hinta" [level=2]'
+          - 'complementary "Kirjoituksen \"Tekoäly kunnassa: mahdollisuudet ja hinta\" meta-tiedot"':
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Tekoäly":
+                  - /url: /fi/category/artificial-intelligence/
+              - listitem:
+                - link "Kirkkonummi":
+                  - /url: /fi/category/kirkkonummi/
+              - listitem:
+                - link "Digitalisaatio":
+                  - /url: /fi/category/digitalisation/
+              - listitem:
+                - link "Sivistys":
+                  - /url: /fi/category/learning/
+          - paragraph: Konnevedellä tekoäly lyhensi käsittelyajan kahdesta kuukaudesta päiviin. Kirkkonummi on liian pieni yksin — mutta yhteistyöllä muutos on mahdollinen.
+      - listitem:
+        - article "Tekoäly muuttaa kehittäjän palkan perustan":
+          - link "Kuvassa tietokoneen näyttö, jossa näkyy koodia. Tekoäly muuttaa kehittäjän palkan perustan":
+            - /url: /fi/blog/57/tekoaly-ei-korvaa-koodareita-vaan-muuttaa-sen-mista-heille-maksetaan/
+            - img "Kuvassa tietokoneen näyttö, jossa näkyy koodia."
+            - heading "Tekoäly muuttaa kehittäjän palkan perustan" [level=2]
+          - complementary "Kirjoituksen \"Tekoäly muuttaa kehittäjän palkan perustan\" meta-tiedot":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Tekoäly":
+                  - /url: /fi/category/artificial-intelligence/
+              - listitem:
+                - link "Digitalisaatio":
+                  - /url: /fi/category/digitalisation/
+              - listitem:
+                - link "Sivistys":
+                  - /url: /fi/category/learning/
+              - listitem:
+                - link "Talous":
+                  - /url: /fi/category/economy/
+          - paragraph: Tekoäly tekee kahdessa minuutissa sen, mihin kehittäjältä meni kaksi viikkoa. Koodin hinta romahtaa — mutta mistä kehittäjille sitten maksetaan?
       - listitem:
         - 'article "Chat control: parlamentti toimi oikein"':
           - 'link "Kuva japanilaistyylisestä sermistä, jonka takana näkyy sumeasti huone. Chat control: parlamentti toimi oikein"':
@@ -42,6 +89,9 @@
               - listitem:
                 - link "Digitalisaatio":
                   - /url: /fi/category/digitalisation/
+              - listitem:
+                - link "Vapaus":
+                  - /url: /fi/category/freedom/
           - paragraph: Chat control -lain jatkoaika kaatui Euroopan parlamentissa. KRP:n luvut ovat todellisia, mutta parlamentti toimi silti oikein — ja tässä syy, miksi.
       - listitem:
         - article "Digitaalinen itsenäisyys on välttämättömyys":
@@ -59,56 +109,46 @@
                 - link "Digitalisaatio":
                   - /url: /fi/category/digitalisation/
           - paragraph: Venäjän naapurina Suomi on oppinut varautumaan. Kuitenkaan käsitteet huoltovarmuudesta ja suvereniteetista eivät ole levinneet digitaalisiin palveluihin.
-      - listitem:
-        - article "Passitunnisteiden käyttöä ei saa laajentaa":
-          - link "Kuva Atte Harjanteesta ja Lauri Lavannista. Kummallakin musta takki ja kauluspaita. Passitunnisteiden käyttöä ei saa laajentaa":
-            - /url: /fi/blog/48/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/
-            - img "Kuva Atte Harjanteesta ja Lauri Lavannista. Kummallakin musta takki ja kauluspaita."
-            - heading "Passitunnisteiden käyttöä ei saa laajentaa" [level=2]
-          - complementary "Kirjoituksen \"Passitunnisteiden käyttöä ei saa laajentaa\" meta-tiedot":
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Teknologia":
-                  - /url: /fi/category/technology/
-              - listitem:
-                - link "Yksityisyydensuoja":
-                  - /url: /fi/category/privacy/
-          - paragraph: Kun sormenjäljet tuotiin passeihin, Suomeen perustettiin kansallinen biometrinen rekisteri. Nyt hallitus haluaa avata sen poliisin käyttöön.
-      - listitem:
-        - article /Vuosi \d+ on tekoälyn – yllättävä totuus/:
-          - link /Lauri Lavanti seisomassa peilin edessä puhelin kädessä, ottamassa itsestään kuvaa\. Päällä musta takki, valkoinen kauluspaita ja kaulassa vihreä kravatti\. Taustalla Helsingin Yliopiston päärakennuksen vaalea käytävä\. Vuosi \d+ on tekoälyn – yllättävä totuus/:
-            - /url: /fi/blog/47/vuosi-2026-on-tekoalyn/
-            - img "Lauri Lavanti seisomassa peilin edessä puhelin kädessä, ottamassa itsestään kuvaa. Päällä musta takki, valkoinen kauluspaita ja kaulassa vihreä kravatti. Taustalla Helsingin Yliopiston päärakennuksen vaalea käytävä."
-            - heading /Vuosi \d+ on tekoälyn – yllättävä totuus/ [level=2]
-          - complementary /Kirjoituksen "Vuosi \d+ on tekoälyn – yllättävä totuus" meta-tiedot/:
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Digitalisaatio":
-                  - /url: /fi/category/digitalisation/
-              - listitem:
-                - link "Tekoäly":
-                  - /url: /fi/category/artificial-intelligence/
-          - paragraph: Tekoäly muuttaa yhteiskuntaamme – mutta et ehkä odottaisi, miten. Suurimmat muutokset näemme yksityiselämässä ja lasten arjessa.
     - heading "Kaikki kirjoitukset" [level=2]
     - list:
       - listitem:
-        - article "Tekoäly muuttaa kehittäjän palkan perustan":
-          - link "Kuvassa tietokoneen näyttö, jossa näkyy koodia. Tekoäly muuttaa kehittäjän palkan perustan":
-            - /url: /fi/blog/57/tekoaly-ei-korvaa-koodareita-vaan-muuttaa-sen-mista-heille-maksetaan/
-            - img "Kuvassa tietokoneen näyttö, jossa näkyy koodia."
-            - heading "Tekoäly muuttaa kehittäjän palkan perustan" [level=2]
-          - complementary "Kirjoituksen \"Tekoäly muuttaa kehittäjän palkan perustan\" meta-tiedot":
+        - 'article "Valtuustoaloite: digitaalinen huoltovarmuus"':
+          - 'link "Lauri Lavanti hymyilemässä ja katsomassa kameraan. Päällään hänellä on valkoinen t-paita, jossa lukee Digitaalinen itsenäisyys, jonka yllä on leijonakuvio. Lisäksi pikkutakki. Kuvan ottanut Erkki Laine. Valtuustoaloite: digitaalinen huoltovarmuus"':
+            - /url: /fi/blog/59/valtuustoaloite-kirkkonummen-digitaalisen-huoltovarmuuden-vahvistaminen/
+            - img "Lauri Lavanti hymyilemässä ja katsomassa kameraan. Päällään hänellä on valkoinen t-paita, jossa lukee Digitaalinen itsenäisyys, jonka yllä on leijonakuvio. Lisäksi pikkutakki. Kuvan ottanut Erkki Laine."
+            - 'heading "Valtuustoaloite: digitaalinen huoltovarmuus" [level=2]'
+          - 'complementary "Kirjoituksen \"Valtuustoaloite: digitaalinen huoltovarmuus\" meta-tiedot"':
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "Tekoäly":
-                  - /url: /fi/category/artificial-intelligence/
+                - link "Kirkkonummi":
+                  - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "Digitalisaatio":
-                  - /url: /fi/category/digitalisation/
-          - paragraph: Tekoäly tekee kahdessa minuutissa sen, mihin kehittäjältä meni kaksi viikkoa. Koodin hinta romahtaa — mutta mistä kehittäjille sitten maksetaan?
+                - link "Digitaalinen itsenäisyys":
+                  - /url: /fi/category/digital-independence/
+              - listitem:
+                - link "Valtuustoaloite":
+                  - /url: /fi/category/council-motion/
+          - paragraph: Kirkkonummi nojaa lähes kaikessa toiminnassaan digitaalisiin järjestelmiin. Aloite esittää riippuvuuksien kartoitusta ja siirtymistä avoimiin tiedostomuotoihin.
+      - listitem:
+        - article "Äänestin Västraa vastaan – perusteluni":
+          - link "Kolme kolikkopinoa eri korkeuksilla valkoisella taustalla. Kuva havainnollistaa kunnan taloudellista päätöksentekoa. Äänestin Västraa vastaan – perusteluni":
+            - /url: /fi/blog/58/aanestin-vastraa-vastaan/
+            - img "Kolme kolikkopinoa eri korkeuksilla valkoisella taustalla. Kuva havainnollistaa kunnan taloudellista päätöksentekoa."
+            - heading "Äänestin Västraa vastaan – perusteluni" [level=2]
+          - complementary "Kirjoituksen \"Äänestin Västraa vastaan – perusteluni\" meta-tiedot":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Talous":
+                  - /url: /fi/category/economy/
+              - listitem:
+                - link "Kirkkonummi":
+                  - /url: /fi/category/kirkkonummi/
+              - listitem:
+                - link "Länsi-Uusimaa":
+                  - /url: /fi/category/western-uusimaa/
+          - paragraph: "Äänestin Västra-rannikkoyhteistyötä vastaan. Valtuusto päätti liittyä. Perusteluni: rahat kuuluvat sivistyspalveluihin, ei sopimukseen josta ei pääse irti."
       - listitem:
         - article "Lähteelä — helmi Kirkkonummen rannikolla":
           - link "Lauri Lavanti ja Miisa Jeremejew, kunnanvaltuutettuja (vihr.), Kirkkonummi Lähteelä — helmi Kirkkonummen rannikolla":
@@ -206,6 +246,44 @@
                   - /url: /fi/category/culture-and-education/
           - paragraph: Kirkkonummen keskustan remontti rakentaa Fyyrin, Lyyran ja Rovastinpuiston sivistyksen keskittymän. Se luo edellytyksiä kasvulle vuosikymmeniksi.
       - listitem:
+        - article "Passitunnisteiden käyttöä ei saa laajentaa":
+          - link "Kuva Atte Harjanteesta ja Lauri Lavannista. Kummallakin musta takki ja kauluspaita. Passitunnisteiden käyttöä ei saa laajentaa":
+            - /url: /fi/blog/48/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/
+            - img "Kuva Atte Harjanteesta ja Lauri Lavannista. Kummallakin musta takki ja kauluspaita."
+            - heading "Passitunnisteiden käyttöä ei saa laajentaa" [level=2]
+          - complementary "Kirjoituksen \"Passitunnisteiden käyttöä ei saa laajentaa\" meta-tiedot":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Teknologia":
+                  - /url: /fi/category/technology/
+              - listitem:
+                - link "Yksityisyydensuoja":
+                  - /url: /fi/category/privacy/
+              - listitem:
+                - link "Vapaus":
+                  - /url: /fi/category/freedom/
+          - paragraph: Kun sormenjäljet tuotiin passeihin, Suomeen perustettiin kansallinen biometrinen rekisteri. Nyt hallitus haluaa avata sen poliisin käyttöön.
+      - listitem:
+        - article /Vuosi \d+ on tekoälyn – yllättävä totuus/:
+          - link /Lauri Lavanti seisomassa peilin edessä puhelin kädessä, ottamassa itsestään kuvaa\. Päällä musta takki, valkoinen kauluspaita ja kaulassa vihreä kravatti\. Taustalla Helsingin Yliopiston päärakennuksen vaalea käytävä\. Vuosi \d+ on tekoälyn – yllättävä totuus/:
+            - /url: /fi/blog/47/vuosi-2026-on-tekoalyn/
+            - img "Lauri Lavanti seisomassa peilin edessä puhelin kädessä, ottamassa itsestään kuvaa. Päällä musta takki, valkoinen kauluspaita ja kaulassa vihreä kravatti. Taustalla Helsingin Yliopiston päärakennuksen vaalea käytävä."
+            - heading /Vuosi \d+ on tekoälyn – yllättävä totuus/ [level=2]
+          - complementary /Kirjoituksen "Vuosi \d+ on tekoälyn – yllättävä totuus" meta-tiedot/:
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Digitalisaatio":
+                  - /url: /fi/category/digitalisation/
+              - listitem:
+                - link "Tekoäly":
+                  - /url: /fi/category/artificial-intelligence/
+              - listitem:
+                - link "Sivistys":
+                  - /url: /fi/category/learning/
+          - paragraph: Tekoäly muuttaa yhteiskuntaamme – mutta et ehkä odottaisi, miten. Suurimmat muutokset näemme yksityiselämässä ja lasten arjessa.
+      - listitem:
         - article "Äänestin Länsiradan puolesta – ratapäätös":
           - link /Länsirata Oyn havainnekuva siitä, millainen Veikkolan juna-asema voisi olla\. Kuvassa näkyy raiteet, laiturit ja ylikulkukävelysilta\. Otettu osoitteesta https:\/\/lansirata\.sitowise\.com\/\?link=Pysm6# \d+\.\d+\.\d+\. Äänestin Länsiradan puolesta – ratapäätös/:
             - /url: /fi/blog/46/aanestin-lansiradan-puolesta/
@@ -239,6 +317,9 @@
               - listitem:
                 - link "Yksityisyydensuoja":
                   - /url: /fi/category/privacy/
+              - listitem:
+                - link "Vapaus":
+                  - /url: /fi/category/freedom/
           - paragraph: Hallitus suunnittelee tiedustelulainsäädännön laajentamista rikollisuuden torjuntaan ilman yksilöityä epäilyä – tämä uhkaa perusoikeuksia vakavasti.
       - listitem:
         - article "Tekoäly ei pysty mihin tahansa – riskit":
@@ -255,6 +336,9 @@
               - listitem:
                 - link "Tekoäly":
                   - /url: /fi/category/artificial-intelligence/
+              - listitem:
+                - link "Sivistys":
+                  - /url: /fi/category/learning/
           - paragraph: Tekoälyä on esitetty ratkaisuna julkisten palveluiden kehittämiseen. Sillä voi olla roolinsa, mutta se ei korvaa ihmistä eikä selkeää suunnitelmaa.
       - listitem:
         - article "Kuka päättää mistä puhumme? Algoritmit":
@@ -271,6 +355,9 @@
               - listitem:
                 - link "Teknologia":
                   - /url: /fi/category/technology/
+              - listitem:
+                - link "Vapaus":
+                  - /url: /fi/category/freedom/
           - paragraph: Olemmeko valmiita siihen, että keskusteluamme ohjaavat ulkomaiset suuryritykset? Algoritmeja voidaan käyttää tarkoituksellisesti vaikuttamiseen.
       - listitem:
         - 'article "Esseitä maahanmuutosta: maahanmuuton myytit"':
@@ -357,6 +444,9 @@
               - listitem:
                 - link "Varhaiskasvatus":
                   - /url: /fi/category/early-childhood-education/
+              - listitem:
+                - link "Sivistys":
+                  - /url: /fi/category/learning/
           - paragraph: Hallituksen puoliväliriihi toi leikkauksia valtionosuuksiin ja yhteisöveroon. Se kaventaa kunnanvaltuutettujen liikkumatilaa merkittävästi.
       - listitem:
         - article "Koulutus on kunnan tärkein tehtävä":
@@ -379,6 +469,9 @@
               - listitem:
                 - link "Varhaiskasvatus":
                   - /url: /fi/category/early-childhood-education/
+              - listitem:
+                - link "Sivistys":
+                  - /url: /fi/category/learning/
           - paragraph: Koulutus on kunnan tärkein tehtävä. Koulutusinvestoinnit näkyvät kauas tulevaisuuteen – eikä sieltä ole pikavoittoja saatavissa.
       - listitem:
         - article "Ehdoton ei toisen asteen lukukausimaksuille":
@@ -590,6 +683,9 @@
               - listitem:
                 - link "Opetus":
                   - /url: /fi/category/education/
+              - listitem:
+                - link "Sivistys":
+                  - /url: /fi/category/learning/
           - paragraph: Koulutuksesta leikataan reilusti, vaikka hallitus väittää muuta. Indeksikorotukset ja lakiuudistukset eivät paikkaa satoja miljoonia leikkauksia.
       - listitem:
         - 'article "Esseitä maahanmuutosta: perhesiteet"':
@@ -691,6 +787,9 @@
               - listitem:
                 - link "Opetus":
                   - /url: /fi/category/education/
+              - listitem:
+                - link "Sivistys":
+                  - /url: /fi/category/learning/
           - paragraph: /Hallitus tekee tarpeellisia uudistuksia toiselle asteelle, mutta ne eivät korvaa ammatilliseen koulutukseen kohdistuvia \d+ miljoonan leikkauksia\./
       - listitem:
         - article "Vastuu paremmasta tulevaisuudesta on meidän":
@@ -827,6 +926,9 @@
               - listitem:
                 - link "Opetus":
                   - /url: /fi/category/education/
+              - listitem:
+                - link "Sivistys":
+                  - /url: /fi/category/learning/
           - paragraph: Kunnan on suunniteltava pitkäjänteisesti. Lyhytnäköiset päätökset johtavat lisäkustannuksiin ja heikompiin palveluihin asukkaille.
       - listitem:
         - article "Sanat ja puhe muovaavat todellisuuttamme":
@@ -1005,6 +1107,9 @@
               - listitem:
                 - link "Opetus":
                   - /url: /fi/category/education/
+              - listitem:
+                - link "Sivistys":
+                  - /url: /fi/category/learning/
           - paragraph: Gesterbyn koulukeskuksen hankesuunnitelmaa on palautettu lisävalmisteluun kolmesti. Hanketta on selvitetty kuusi vuotta ilman lopputulosta.
       - listitem:
         - article "Varhaiskasvatuksen laadusta ei saa tinkiä":

--- a/tests/e2e/blogSwePage.spec.ts-snapshots/Blog-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/blogSwePage.spec.ts-snapshots/Blog-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
@@ -22,8 +22,55 @@
       - listitem:
         - link "Digital självständighet":
           - /url: /sv/category/digital-independence/
+      - listitem:
+        - link "Kyrkslätt":
+          - /url: /sv/category/kirkkonummi/
     - heading "Utvalda" [level=2]
     - list:
+      - listitem:
+        - 'article "AI i kommunen: möjligheter och kostnad"':
+          - 'link "Lauri Lavanti står i en blommig skjorta mot vit bakgrund. AI i kommunen: möjligheter och kostnad"':
+            - /url: /sv/blog/60/ai-hjalper-till-att-sakra-kommunala-tjanster-men-det-kostar/
+            - img "Lauri Lavanti står i en blommig skjorta mot vit bakgrund."
+            - 'heading "AI i kommunen: möjligheter och kostnad" [level=2]'
+          - 'complementary "Metainformation för inlägget \"AI i kommunen: möjligheter och kostnad\""':
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Artificiell intelligens":
+                  - /url: /sv/category/artificial-intelligence/
+              - listitem:
+                - link "Kyrkslätt":
+                  - /url: /sv/category/kirkkonummi/
+              - listitem:
+                - link "Digitalisering":
+                  - /url: /sv/category/digitalisation/
+              - listitem:
+                - link "Lärande":
+                  - /url: /sv/category/learning/
+          - paragraph: I Konnevesi kortade AI handläggningstiden från två månader till dagar. Kyrkslätt är för litet att agera ensamt — men samarbete gör förändring möjlig.
+      - listitem:
+        - article "AI förändrar vad utvecklare får betalt för":
+          - link "En datorskärm med kod. AI förändrar vad utvecklare får betalt för":
+            - /url: /sv/blog/57/ai-forandrar-vad-utvecklare-far-betalt-for/
+            - img "En datorskärm med kod."
+            - heading "AI förändrar vad utvecklare får betalt för" [level=2]
+          - complementary "Metainformation för inlägget \"AI förändrar vad utvecklare får betalt för\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Artificiell intelligens":
+                  - /url: /sv/category/artificial-intelligence/
+              - listitem:
+                - link "Digitalisering":
+                  - /url: /sv/category/digitalisation/
+              - listitem:
+                - link "Lärande":
+                  - /url: /sv/category/learning/
+              - listitem:
+                - link "Ekonomi":
+                  - /url: /sv/category/economy/
+          - paragraph: AI gör på två minuter det som en utvecklare tidigare behövde två veckor på sig för. Priset på kod rasar — men vad ska utvecklare få betalt för i stället?
       - listitem:
         - 'article "Chat control: parlamentet handlade rätt"':
           - 'link "Bild på en japansk skärm bakom vilken ett rum skymtar suddigt. Chat control: parlamentet handlade rätt"':
@@ -42,6 +89,9 @@
               - listitem:
                 - link "Digitalisering":
                   - /url: /sv/category/digitalisation/
+              - listitem:
+                - link "Frihet":
+                  - /url: /sv/category/freedom/
           - paragraph: Chat control-lagens förlängning röstades ned i Europaparlamentet. KRP:s siffror är verkliga, men parlamentet handlade ändå rätt — och här är skälet.
       - listitem:
         - article "Digital självständighet är en nödvändighet":
@@ -59,56 +109,46 @@
                 - link "Digitalisering":
                   - /url: /sv/category/digitalisation/
           - paragraph: Som Rysslands granne har Finland lärt sig att vara beredd. Begreppen försörjningstrygghet och suveränitet har dock inte spridit sig till digitala tjänster.
-      - listitem:
-        - article "Biometriska identifierare i pass – motstånd":
-          - link "Ett foto av Atte Harjanne och Lauri Lavanti. Båda bär svart jacka och skjorta. Biometriska identifierare i pass – motstånd":
-            - /url: /sv/blog/48/anvandningen-av-biometriska-identifierare-i-pass-far-inte-utvidgas/
-            - img "Ett foto av Atte Harjanne och Lauri Lavanti. Båda bär svart jacka och skjorta."
-            - heading "Biometriska identifierare i pass – motstånd" [level=2]
-          - complementary "Metainformation för inlägget \"Biometriska identifierare i pass – motstånd\"":
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Teknologi":
-                  - /url: /sv/category/technology/
-              - listitem:
-                - link "Integritetsskydd":
-                  - /url: /sv/category/privacy/
-          - paragraph: När fingeravtryck infördes i pass skapades ett nationellt biometriskt register i Finland. Nu vill regeringen öppna det för polisens bruk.
-      - listitem:
-        - article /År \d+ är AI-året — en överraskande sanning/:
-          - link /Lauri Lavanti stående framför en spegel med en telefon i handen och tar en selfie\. Klädd i svart jacka, vit skjorta och grön slips\. I bakgrunden den ljusa korridoren i Helsingfors universitets huvudbyggnad\. År \d+ är AI-året — en överraskande sanning/:
-            - /url: /sv/blog/47/ar-2026-ar-ai-aret/
-            - img "Lauri Lavanti stående framför en spegel med en telefon i handen och tar en selfie. Klädd i svart jacka, vit skjorta och grön slips. I bakgrunden den ljusa korridoren i Helsingfors universitets huvudbyggnad."
-            - heading /År \d+ är AI-året — en överraskande sanning/ [level=2]
-          - complementary /Metainformation för inlägget "År \d+ är AI-året — en överraskande sanning"/:
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Digitalisering":
-                  - /url: /sv/category/digitalisation/
-              - listitem:
-                - link "Artificiell intelligens":
-                  - /url: /sv/category/artificial-intelligence/
-          - paragraph: AI förändrar samhället — men kanske inte som du tror. De största förändringarna ser vi i privatlivet och i barnens och ungdomarnas vardag.
     - heading "Alla inlägg" [level=2]
     - list:
       - listitem:
-        - article "AI förändrar vad utvecklare får betalt för":
-          - link "En datorskärm med kod. AI förändrar vad utvecklare får betalt för":
-            - /url: /sv/blog/57/ai-forandrar-vad-utvecklare-far-betalt-for/
-            - img "En datorskärm med kod."
-            - heading "AI förändrar vad utvecklare får betalt för" [level=2]
-          - complementary "Metainformation för inlägget \"AI förändrar vad utvecklare får betalt för\"":
+        - 'article "Fullmäktigemotion: digital beredskap"':
+          - 'link "Lauri Lavanti ler och tittar in i kameran. Han bär en vit t-shirt med texten Digitaalinen itsenäisyys (Digital självständighet) och ett lejonmotiv ovanför, samt en kavaj. Foto av Erkki Laine. Fullmäktigemotion: digital beredskap"':
+            - /url: /sv/blog/59/fullmaktigemotion-starka-kyrkslatt-digital-forsorjningsberedskap/
+            - img "Lauri Lavanti ler och tittar in i kameran. Han bär en vit t-shirt med texten Digitaalinen itsenäisyys (Digital självständighet) och ett lejonmotiv ovanför, samt en kavaj. Foto av Erkki Laine."
+            - 'heading "Fullmäktigemotion: digital beredskap" [level=2]'
+          - 'complementary "Metainformation för inlägget \"Fullmäktigemotion: digital beredskap\""':
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "Artificiell intelligens":
-                  - /url: /sv/category/artificial-intelligence/
+                - link "Kyrkslätt":
+                  - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "Digitalisering":
-                  - /url: /sv/category/digitalisation/
-          - paragraph: AI gör på två minuter det som en utvecklare tidigare behövde två veckor på sig för. Priset på kod rasar — men vad ska utvecklare få betalt för i stället?
+                - link "Digital självständighet":
+                  - /url: /sv/category/digital-independence/
+              - listitem:
+                - link "Fullmäktigeinitiativ":
+                  - /url: /sv/category/council-motion/
+          - paragraph: Kyrkslätt förlitar sig på digitala system i nästan all sin verksamhet. Motionen föreslår kartläggning av beroenden och övergång till öppna filformat.
+      - listitem:
+        - article "Jag röstade mot Västra – mina skäl":
+          - link "Tre myntstaplar i olika höjder på vit bakgrund. Bilden illustrerar kommunalt ekonomiskt beslutsfattande. Jag röstade mot Västra – mina skäl":
+            - /url: /sv/blog/58/jag-rostade-mot-vastra/
+            - img "Tre myntstaplar i olika höjder på vit bakgrund. Bilden illustrerar kommunalt ekonomiskt beslutsfattande."
+            - heading "Jag röstade mot Västra – mina skäl" [level=2]
+          - complementary "Metainformation för inlägget \"Jag röstade mot Västra – mina skäl\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Ekonomi":
+                  - /url: /sv/category/economy/
+              - listitem:
+                - link "Kyrkslätt":
+                  - /url: /sv/category/kirkkonummi/
+              - listitem:
+                - link "Västra Nyland":
+                  - /url: /sv/category/western-uusimaa/
+          - paragraph: Jag röstade mot Västra kustsamarbetet. Fullmäktige beslutade annorlunda. Pengarna hör till bildningsservicen, inte ett avtal man inte kan lämna.
       - listitem:
         - article "Lähteelä — en gem vid Kyrksländets kust":
           - link "Lauri Lavanti och Miisa Jeremejew, kommunfullmäktigeledamöter (gröna), Kyrksländ Lähteelä — en gem vid Kyrksländets kust":
@@ -206,6 +246,44 @@
                   - /url: /sv/category/culture-and-education/
           - paragraph: Renoveringen av Kyrkslätts centrum skapar ett bildningskluster av Fyyri, Lyyra och Provstparken. Det ger förutsättningar för tillväxt i decennier.
       - listitem:
+        - article "Biometriska identifierare i pass – motstånd":
+          - link "Ett foto av Atte Harjanne och Lauri Lavanti. Båda bär svart jacka och skjorta. Biometriska identifierare i pass – motstånd":
+            - /url: /sv/blog/48/anvandningen-av-biometriska-identifierare-i-pass-far-inte-utvidgas/
+            - img "Ett foto av Atte Harjanne och Lauri Lavanti. Båda bär svart jacka och skjorta."
+            - heading "Biometriska identifierare i pass – motstånd" [level=2]
+          - complementary "Metainformation för inlägget \"Biometriska identifierare i pass – motstånd\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Teknologi":
+                  - /url: /sv/category/technology/
+              - listitem:
+                - link "Integritetsskydd":
+                  - /url: /sv/category/privacy/
+              - listitem:
+                - link "Frihet":
+                  - /url: /sv/category/freedom/
+          - paragraph: När fingeravtryck infördes i pass skapades ett nationellt biometriskt register i Finland. Nu vill regeringen öppna det för polisens bruk.
+      - listitem:
+        - article /År \d+ är AI-året — en överraskande sanning/:
+          - link /Lauri Lavanti stående framför en spegel med en telefon i handen och tar en selfie\. Klädd i svart jacka, vit skjorta och grön slips\. I bakgrunden den ljusa korridoren i Helsingfors universitets huvudbyggnad\. År \d+ är AI-året — en överraskande sanning/:
+            - /url: /sv/blog/47/ar-2026-ar-ai-aret/
+            - img "Lauri Lavanti stående framför en spegel med en telefon i handen och tar en selfie. Klädd i svart jacka, vit skjorta och grön slips. I bakgrunden den ljusa korridoren i Helsingfors universitets huvudbyggnad."
+            - heading /År \d+ är AI-året — en överraskande sanning/ [level=2]
+          - complementary /Metainformation för inlägget "År \d+ är AI-året — en överraskande sanning"/:
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Digitalisering":
+                  - /url: /sv/category/digitalisation/
+              - listitem:
+                - link "Artificiell intelligens":
+                  - /url: /sv/category/artificial-intelligence/
+              - listitem:
+                - link "Lärande":
+                  - /url: /sv/category/learning/
+          - paragraph: AI förändrar samhället — men kanske inte som du tror. De största förändringarna ser vi i privatlivet och i barnens och ungdomarnas vardag.
+      - listitem:
         - article "Jag röstade för Västernabanan – varför":
           - link /En visualisering av Länsirata Oy om hur Veikkola järnvägsstation skulle kunna se ut\. Bilden visar spår, plattformar och en gångbro\. Tagen från https:\/\/lansirata\.sitowise\.com\/\?link=Pysm6# den 8 december \d+\. Jag röstade för Västernabanan – varför/:
             - /url: /sv/blog/46/jag-rostade-for-vasternabanan/
@@ -239,6 +317,9 @@
               - listitem:
                 - link "Integritetsskydd":
                   - /url: /sv/category/privacy/
+              - listitem:
+                - link "Frihet":
+                  - /url: /sv/category/freedom/
           - paragraph: Regeringen planerar att utvidga underrättelselagstiftningens metoder mot brottslighet utan individuell misstanke — ett allvarligt hot mot grundrättigheter.
       - listitem:
         - article "AI kan inte allt — gränserna för AI":
@@ -255,6 +336,9 @@
               - listitem:
                 - link "Artificiell intelligens":
                   - /url: /sv/category/artificial-intelligence/
+              - listitem:
+                - link "Lärande":
+                  - /url: /sv/category/learning/
           - paragraph: AI har presenterats som ett sätt att göra Finlands offentliga tjänster till världens bästa. Det kan ha sin roll i det, men viktigast vore en helhetsbedömning.
       - listitem:
         - article "Vem bestämmer vad vi pratar om? Algoritmer":
@@ -271,6 +355,9 @@
               - listitem:
                 - link "Teknologi":
                   - /url: /sv/category/technology/
+              - listitem:
+                - link "Frihet":
+                  - /url: /sv/category/freedom/
           - paragraph: Är vi beredda på att vår diskussion styrs av utländska storföretag? Det finns inga garantier för att algoritmer inte skulle användas avsiktligt.
       - listitem:
         - 'article "Essäer om invandring: segaste myterna"':
@@ -357,6 +444,9 @@
               - listitem:
                 - link "Småbarnspedagogik":
                   - /url: /sv/category/early-childhood-education/
+              - listitem:
+                - link "Lärande":
+                  - /url: /sv/category/learning/
           - paragraph: Halvtidsöverläggningen innebar nedskärningar i statsandelar och samfundsskatt. Det inskränker kommunfullmäktiges handlingsutrymme avsevärt.
       - listitem:
         - article "Utbildning är kommunens viktigaste uppgift":
@@ -379,6 +469,9 @@
               - listitem:
                 - link "Småbarnspedagogik":
                   - /url: /sv/category/early-childhood-education/
+              - listitem:
+                - link "Lärande":
+                  - /url: /sv/category/learning/
           - paragraph: Utbildning är kommunens viktigaste uppgift. Satsningar på utbildning är investeringar som syns långt in i framtiden, utan snabba vinster.
       - listitem:
         - article "Ett absolut nej till terminsavgifter":
@@ -590,6 +683,9 @@
               - listitem:
                 - link "Utbildning":
                   - /url: /sv/category/education/
+              - listitem:
+                - link "Lärande":
+                  - /url: /sv/category/learning/
           - paragraph: Utbildningen skärs ned kraftigt, trots att regeringen hävdar motsatsen. Indexhöjningar och lagreformer täcker inte hundratals miljoner i nedskärningar.
       - listitem:
         - 'article "Essäer om invandring: familiebaserad"':
@@ -691,6 +787,9 @@
               - listitem:
                 - link "Utbildning":
                   - /url: /sv/category/education/
+              - listitem:
+                - link "Lärande":
+                  - /url: /sv/category/learning/
           - paragraph: /Regeringen gör nödvändiga reformer för gymnasiet, men de kompenserar inte nedskärningarna på \d+ miljoner euro i yrkesutbildningen\./
       - listitem:
         - 'article "En bättre framtid: ansvaret ligger hos oss"':
@@ -827,6 +926,9 @@
               - listitem:
                 - link "Utbildning":
                   - /url: /sv/category/education/
+              - listitem:
+                - link "Lärande":
+                  - /url: /sv/category/learning/
           - paragraph: Kommunen måste planera långsiktigt. Kortsiktiga beslut utan framförhållning leder till merkostnader och sämre service för invånarna på sikt.
       - listitem:
         - article "Med ord formar vi verkligheten – språk":
@@ -1005,6 +1107,9 @@
               - listitem:
                 - link "Utbildning":
                   - /url: /sv/category/education/
+              - listitem:
+                - link "Lärande":
+                  - /url: /sv/category/learning/
           - paragraph: Projektplanen för Gesterby skolkomplex har återremitterats tre gånger. Projektet har utretts i sex år utan att ett nytt skolhus har byggts.
       - listitem:
         - article "Tillräcklig förskola är barnets rätt":


### PR DESCRIPTION
> This PR contains AI-generated code. The author has reviewed and is responsible for all AI-generated content.

## Summary

- Add `learning` tag (Sivistys saumattomaksi pillar) to 10 posts (5, 15, 22, 27, 37, 38, 44, 47, 57, 60)
- Add `freedom` tag (Vapaus varmaksi pillar) to 4 posts (43, 45, 48, 54)
- Add `economy` tag (Talous toimivaksi pillar) to post 57
- Update pinned posts on blog index from [47, 48, 51, 54] to [60, 57, 54, 51] — balances all three pillars and replaces outdated AI-critical post 47 with newer constructive post 60

## Motivation

Tags `freedom`, `learning`, and `economy` are the three core-message pillar tags in lavanti-2027 but had near-zero blog coverage. This backfill ensures each pillar has supporting posts on the site.

## Test plan

- [ ] `npm run test` passes (tag validation)
- [ ] `npm run build` succeeds
- [ ] Tag pages for `freedom`, `learning`, `economy` list the expected posts
- [ ] Blog index shows posts 60, 57, 54, 51 as pinned