### PR TITLE
feat(content): add FAQ metadata to Tier 1 campaign blog posts (#1169)

### DIFF
--- a/src/pages/en/blog/47/2026-is-the-year-of-ai/index.mdx
+++ b/src/pages/en/blog/47/2026-is-the-year-of-ai/index.mdx
@@ -12,6 +12,11 @@ tags:
   - digitalisation
   - artificial-intelligence
   - learning
+faq:
+  - q: "How is AI changing children's everyday lives in 2026?"
+    a: "AI is becoming part of children's daily life: in some situations it replaces therapists and friends, produces entertainment, and guides learning. This is a bigger change than AI adoption in business."
+  - q: "Why is AI literacy a new civic skill?"
+    a: "AI literacy means understanding how AI works, what it can do, and what it cannot. Without this skill, children and adults cannot critically evaluate AI-generated content."
 heroImage: 'Lauri-Lavanti-Helsingin-yliopistolla'
 alt: 'Lauri Lavanti standing in front of a mirror with a phone in his hand, taking a selfie. Wearing a black jacket, white shirt and green tie. In the background, the light corridor of the main building of the University of Helsinki.'
 ---

--- a/src/pages/en/blog/47/2026-is-the-year-of-ai/index.mdx
+++ b/src/pages/en/blog/47/2026-is-the-year-of-ai/index.mdx
@@ -7,7 +7,7 @@ pageTitle: '2026 is the year of AI — not as you think'
 title: '2026 is the year of AI'
 description: 'AI is changing society — but perhaps not as you imagine. The biggest changes will be in private life and in the everyday lives of children.'
 publishDate: '2026-01-10'
-updatedDate: '2026-05-03'
+updatedDate: '2026-05-15'
 tags:
   - digitalisation
   - artificial-intelligence

--- a/src/pages/en/blog/48/the-use-of-biometric-identifiers-in-passports-must-not-be-expanded/index.mdx
+++ b/src/pages/en/blog/48/the-use-of-biometric-identifiers-in-passports-must-not-be-expanded/index.mdx
@@ -12,6 +12,11 @@ tags:
   - technology
   - privacy
   - freedom
+faq:
+  - q: "Why is Finland's biometric passport register exceptional in the EU?"
+    a: "Finland is one of the few EU countries that stores biometric passport data in a permanent national register. In most EU countries, data is stored only on the passport chip and destroyed after the passport is issued."
+  - q: "What risks does expanding biometric data to police use carry?"
+    a: "Biometric identifiers are permanent — they cannot be changed like a password. Once a database exists, expanding its purpose is historically likely. Germany destroys the data immediately after issuing the passport as a model for data protection."
 heroImage: 'Atte-Harjanne-ja-Lauri-Lavanti'
 alt: 'A photo of Atte Harjanne and Lauri Lavanti. Both are wearing a black jacket and shirt.'
 ---

--- a/src/pages/en/blog/48/the-use-of-biometric-identifiers-in-passports-must-not-be-expanded/index.mdx
+++ b/src/pages/en/blog/48/the-use-of-biometric-identifiers-in-passports-must-not-be-expanded/index.mdx
@@ -7,7 +7,7 @@ pageTitle: 'Passport biometrics must stay protected'
 title: 'The use of biometric identifiers in passports must not be expanded'
 description: 'When fingerprints were added to passports, Finland created a national biometric register. Now the government wants to open it to police use.'
 publishDate: '2026-01-23'
-updatedDate: '2026-05-03'
+updatedDate: '2026-05-15'
 tags:
   - technology
   - privacy

--- a/src/pages/en/blog/51/digital-independence-is-a-necessity/index.mdx
+++ b/src/pages/en/blog/51/digital-independence-is-a-necessity/index.mdx
@@ -7,9 +7,15 @@ pageTitle: 'Digital independence is a necessity'
 title: 'Digital inde­pendence is a necessity'
 description: "Finland's digital services depend on US platforms. As the US becomes unreliable, digital sovereignty is no longer optional — it is a necessity."
 publishDate: '2026-03-05'
+updatedDate: '2026-05-15'
 tags:
   - digital-independence
   - digitalisation
+faq:
+  - q: "Why is Finland's digital independence under threat?"
+    a: "Finland's public administration is almost entirely dependent on US cloud services such as Amazon, Microsoft, Google, and Oracle. The political risk has grown as the United States is no longer a predictable partner."
+  - q: "What alternatives exist to US cloud services?"
+    a: "European and Finnish alternatives exist for most public administration needs. For example, Helsinki chose Finnish UpCloud for its core systems. Germany and Estonia are also actively investing in digital sovereignty."
 heroImage: Suomi-neito-suojaa-Suomea-valkopaamerikotkalta
 alt: "A cartoon image showing a blonde woman holding a laptop computer. The Finnish flag is displayed on the computer screen. A bald eagle is attempting to snatch the computer from the woman. The image is surrounded by text that reads 'Digital independence', 'Digitaalinen itsenäisyys' and 'Digital självständighet'. Copyright for the image belongs to the Digital Independence citizens' initiative."
 ---

--- a/src/pages/en/blog/53/digital-independence-is-built-one-step-at-a-time/index.mdx
+++ b/src/pages/en/blog/53/digital-independence-is-built-one-step-at-a-time/index.mdx
@@ -7,9 +7,15 @@ pageTitle: 'Digital independence: one step at a time'
 title: 'Digital inde­pendence is built one step at a time'
 description: 'Digital independence is built in every procurement decision. Helsinki chose Finnish UpCloud as the platform for its core public services system.'
 publishDate: '2026-03-28'
+updatedDate: '2026-05-15'
 tags:
   - digital-independence
   - digitalisation
+faq:
+  - q: "How does Helsinki advance digital independence through procurement?"
+    a: "Helsinki chose Finnish UpCloud as the cloud provider for its core systems. Every procurement decision builds or erodes digital sovereignty, because vendor lock-in makes switching increasingly costly over time."
+  - q: "Why is vendor lock-in a problem for digital independence?"
+    a: "When public administration migrates its systems to a single vendor's platform, switching becomes more expensive and difficult over the years. European alternatives are technically sufficient for most needs."
 heroImage: Lauri-Lavanti-digitaalinen-itsenaisyys-paidassa
 alt: 'Lauri Lavanti smiling and looking at the camera. He is wearing a white t-shirt reading Digitaalinen itsenäisyys with a lion emblem above it, and a blazer. Photo by Erkki Laine.'
 ---

--- a/src/pages/en/blog/54/chat-control-parliament-was-right/index.mdx
+++ b/src/pages/en/blog/54/chat-control-parliament-was-right/index.mdx
@@ -7,11 +7,17 @@ pageTitle: 'Chat control: parliament was right'
 title: 'Chat control: parliament was right'
 description: 'The European Parliament rejected the extension of the chat control law. The police statistics are real, but parliament was still right — here is why.'
 publishDate: '2026-04-04'
+updatedDate: '2026-05-15'
 tags:
   - privacy
   - technology
   - digitalisation
   - freedom
+faq:
+  - q: "Why did the EU Parliament reject the chat control regulation?"
+    a: "The EU Parliament rejected the extension of the chat control regulation by 331–228 votes in March 2026. Mass surveillance that automatically scans all messages violates the rule of law and does not target only criminals."
+  - q: "How can children's safety be improved without mass surveillance?"
+    a: "Concrete suspicion before surveillance and a court order are minimum requirements of the rule of law — not a privacy privilege. Targeted investigation is also more effective than mass scanning, because organised crime can circumvent encryption-based filters."
 heroImage: sermi-jonka-takana-huone
 alt: 'A Japanese-style screen behind which a room is visible in soft focus.'
 ---

--- a/src/pages/fi/blog/47/vuosi-2026-on-tekoalyn/index.mdx
+++ b/src/pages/fi/blog/47/vuosi-2026-on-tekoalyn/index.mdx
@@ -7,7 +7,7 @@ pageTitle: 'Vuosi 2026 on tekoälyn – yllättävä totuus'
 title: 'Vuosi 2026 on tekoälyn'
 description: 'Tekoäly muuttaa yhteiskuntaamme – mutta et ehkä odottaisi, miten. Suurimmat muutokset näemme yksityiselämässä ja lasten arjessa.'
 publishDate: '2026-01-10'
-updatedDate: '2026-05-03'
+updatedDate: '2026-05-15'
 tags:
   - digitalisation
   - artificial-intelligence

--- a/src/pages/fi/blog/47/vuosi-2026-on-tekoalyn/index.mdx
+++ b/src/pages/fi/blog/47/vuosi-2026-on-tekoalyn/index.mdx
@@ -12,6 +12,11 @@ tags:
   - digitalisation
   - artificial-intelligence
   - learning
+faq:
+  - q: "Miten tekoäly muuttaa lasten arkea vuonna 2026?"
+    a: "Tekoäly on siirtymässä osaksi lasten jokapäiväistä elämää: se korvaa joissain tilanteissa terapeutit ja ystävät, tuottaa viihdettä ja ohjaa oppimista. Tämä on suurempi muutos kuin tekoälyn käyttöönotto yrityksissä."
+  - q: "Miksi tekoälylukutaito on uusi kansalaistaito?"
+    a: "Tekoälylukutaito tarkoittaa kykyä ymmärtää, miten tekoäly toimii, mitä se osaa ja mitä se ei osaa. Ilman tätä taitoa lapset ja aikuiset eivät pysty arvioimaan tekoälyn tuottamaa sisältöä kriittisesti."
 heroImage: Lauri-Lavanti-Helsingin-yliopistolla
 alt: 'Lauri Lavanti seisomassa peilin edessä puhelin kädessä, ottamassa itsestään kuvaa. Päällä musta takki, valkoinen kauluspaita ja kaulassa vihreä kravatti. Taustalla Helsingin Yliopiston päärakennuksen vaalea käytävä.'
 ---

--- a/src/pages/fi/blog/48/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/index.mdx
+++ b/src/pages/fi/blog/48/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/index.mdx
@@ -7,7 +7,7 @@ pageTitle: 'Passitunnisteiden käyttöä ei saa laajentaa'
 title: 'Passien bio­metristen tunnisteiden käyttöä ei pidä laajentaa'
 description: 'Kun sormenjäljet tuotiin passeihin, Suomeen perustettiin kansallinen biometrinen rekisteri. Nyt hallitus haluaa avata sen poliisin käyttöön.'
 publishDate: '2026-01-23'
-updatedDate: '2026-05-03'
+updatedDate: '2026-05-15'
 tags:
   - technology
   - privacy

--- a/src/pages/fi/blog/48/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/index.mdx
+++ b/src/pages/fi/blog/48/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/index.mdx
@@ -12,6 +12,11 @@ tags:
   - technology
   - privacy
   - freedom
+faq:
+  - q: "Miksi Suomen biometrinen passitietorekisteri on poikkeuksellinen EU:ssa?"
+    a: "Suomi on yksi harvoista EU-maista, joka tallentaa passien biometriset tiedot pysyvään kansalliseen rekisteriin. Suurimmassa osassa EU-maita tiedot tallennetaan vain passisirulle ja hävitetään passin myöntämisen jälkeen."
+  - q: "Mitä riskejä biometristen tietojen laajentaminen poliisin käyttöön sisältää?"
+    a: "Biometriset tunnisteet ovat pysyviä – niitä ei voi vaihtaa kuten salasanan. Kun kerran perustettu tietokanta on olemassa, käyttötarkoituksen laajentaminen on historiallisesti todennäköistä. Saksassa data hävitetään heti passin myöntämisen jälkeen malliesimerkkinä tietosuojasta."
 heroImage: Atte-Harjanne-ja-Lauri-Lavanti
 alt: 'Kuva Atte Harjanteesta ja Lauri Lavannista. Kummallakin musta takki ja kauluspaita.'
 ---

--- a/src/pages/fi/blog/51/digitaalinen-itsenaisyys-on-valttamattomyys/index.mdx
+++ b/src/pages/fi/blog/51/digitaalinen-itsenaisyys-on-valttamattomyys/index.mdx
@@ -7,9 +7,15 @@ pageTitle: 'Digitaalinen itsenäisyys on välttämättömyys'
 title: 'Digitaalinen itsenäisyys on välttä­mättömyys'
 description: 'Venäjän naapurina Suomi on oppinut varautumaan. Kuitenkaan käsitteet huoltovarmuudesta ja suvereniteetista eivät ole levinneet digitaalisiin palveluihin.'
 publishDate: '2026-03-05'
+updatedDate: '2026-05-15'
 tags:
   - digital-independence
   - digitalisation
+faq:
+  - q: "Miksi Suomen digitaalinen riippumattomuus on uhattuna?"
+    a: "Suomen julkishallinto on lähes kokonaan riippuvainen yhdysvaltalaisista pilvipalveluista kuten Amazonista, Microsoftista, Googlesta ja Oraclesta. Poliittinen riski on kasvanut, kun Yhdysvallat ei ole enää ennustettava kumppani."
+  - q: "Mitä vaihtoehtoja yhdysvaltalaisille pilvipalveluille on?"
+    a: "Eurooppalaisia ja suomalaisia vaihtoehtoja on olemassa useimpiin julkishallinnon tarpeisiin. Esimerkiksi Helsinki valitsi suomalaisen UpCloudin ydinjärjestelmiinsä. Myös Saksa ja Viro investoivat aktiivisesti digitaaliseen itsemääräämisoikeuteen."
 heroImage: Suomi-neito-suojaa-Suomea-valkopaamerikotkalta
 alt: 'Piirretty kuva, jossa vaaleahiuksinen nainen pitää käsissään kannettavaa tietokonetta. Tietokoneen ruudussa on Suomen lippu. Tietokonetta yrittää riistää naiselta valkopäämerikotka. Kuvan ympärillä lukee "Digital independence", "Digitaalinen itsenäisyys" ja "Digital självständighet". Tekijänoikeudet kuvaan ovat Digitaalinen itsenäisyys -kansalaisaloitteella.'
 ---

--- a/src/pages/fi/blog/53/digitaalinen-itsenaisyys-rakennetaan-askel-kerrallaan/index.mdx
+++ b/src/pages/fi/blog/53/digitaalinen-itsenaisyys-rakennetaan-askel-kerrallaan/index.mdx
@@ -7,9 +7,15 @@ pageTitle: 'Digitaalinen itsenäisyys: askel kerrallaan'
 title: 'Digitaalinen itsenäisyys rakennetaan askel kerrallaan'
 description: 'Digitaalinen itsenäisyys rakentuu jokaisessa hankintapäätöksessä. Helsinki valitsi suomalaisen UpCloudin julkisten palveluiden ydinjärjestelmän alustaksi.'
 publishDate: '2026-03-28'
+updatedDate: '2026-05-15'
 tags:
   - digital-independence
   - digitalisation
+faq:
+  - q: "Miten Helsinki edistää digitaalista itsenäisyyttä hankintapäätöksillään?"
+    a: "Helsinki valitsi suomalaisen UpCloudin ydinjärjestelmiensä pilvipalveluksi. Jokainen hankintapäätös rakentaa tai murentaa digitaalista itsemääräämisoikeutta, koska toimittajalukkiutuminen tekee vaihtamisesta myöhemmin kallista."
+  - q: "Miksi toimittajalukkiutuminen on digitaalisen itsenäisyyden ongelma?"
+    a: "Kun julkishallinto siirtää järjestelmänsä yhden toimittajan alustalle, vaihtaminen muuttuu vuosien kuluessa yhä kalliimmaksi ja vaikeammaksi. Eurooppalaiset vaihtoehdot ovat teknisesti riittäviä useimpiin tarpeisiin."
 heroImage: Lauri-Lavanti-digitaalinen-itsenaisyys-paidassa
 alt: 'Lauri Lavanti hymyilemässä ja katsomassa kameraan. Päällään hänellä on valkoinen t-paita, jossa lukee Digitaalinen itsenäisyys, jonka yllä on leijonakuvio. Lisäksi pikkutakki. Kuvan ottanut Erkki Laine.'
 ---

--- a/src/pages/fi/blog/54/chat-control-parlamentti-toimi-oikein/index.mdx
+++ b/src/pages/fi/blog/54/chat-control-parlamentti-toimi-oikein/index.mdx
@@ -7,11 +7,17 @@ pageTitle: 'Chat control: parlamentti toimi oikein'
 title: 'Chat control: parlamentti toimi oikein'
 description: 'Chat control -lain jatkoaika kaatui Euroopan parlamentissa. KRP:n luvut ovat todellisia, mutta parlamentti toimi silti oikein — ja tässä syy, miksi.'
 publishDate: '2026-04-04'
+updatedDate: '2026-05-15'
 tags:
   - privacy
   - technology
   - digitalisation
   - freedom
+faq:
+  - q: "Miksi EU-parlamentti hylkäsi chat control -asetuksen?"
+    a: "EU-parlamentti hylkäsi chat control -asetuksen laajentamisen äänin 331–228 maaliskuussa 2026. Massavalvonta, jossa kaikki viestit skannataan automaattisesti, loukkaa oikeusvaltioperiaatetta eikä kohdistu vain rikollisiin."
+  - q: "Miten lasten turvallisuutta voidaan parantaa ilman massavalvontaa?"
+    a: "Konkreettinen epäily ennen valvontaa ja tuomioistuimen lupa ovat oikeusvaltion minimivaatimuksia – eivät yksityisyyttä suojaava etuoikeus. Kohdennettu tutkinta on myös tehokkaampi kuin massaskannaus, koska järjestäytynyt rikollisuus voi kiertää salakirjoitukseen perustuvat suodattimet."
 heroImage: sermi-jonka-takana-huone
 alt: 'Kuva japanilaistyylisestä sermistä, jonka takana näkyy sumeasti huone.'
 ---

--- a/src/pages/sv/blog/47/ar-2026-ar-ai-aret/index.mdx
+++ b/src/pages/sv/blog/47/ar-2026-ar-ai-aret/index.mdx
@@ -12,6 +12,11 @@ tags:
   - digitalisation
   - artificial-intelligence
   - learning
+faq:
+  - q: "Hur förändrar AI barnens vardag år 2026?"
+    a: "AI håller på att bli en del av barnens dagliga liv: i vissa situationer ersätter den terapeuter och vänner, producerar underhållning och vägleder lärandet. Det är en större förändring än AI-användningen i företag."
+  - q: "Varför är AI-kompetens en ny medborglig färdighet?"
+    a: "AI-kompetens innebär förmågan att förstå hur AI fungerar, vad den kan göra och vad den inte kan. Utan denna färdighet kan barn och vuxna inte kritiskt utvärdera AI-genererat innehåll."
 heroImage: 'Lauri-Lavanti-Helsingin-yliopistolla'
 alt: 'Lauri Lavanti stående framför en spegel med en telefon i handen och tar en selfie. Klädd i svart jacka, vit skjorta och grön slips. I bakgrunden den ljusa korridoren i Helsingfors universitets huvudbyggnad.'
 ---

--- a/src/pages/sv/blog/47/ar-2026-ar-ai-aret/index.mdx
+++ b/src/pages/sv/blog/47/ar-2026-ar-ai-aret/index.mdx
@@ -7,7 +7,7 @@ pageTitle: 'År 2026 är AI-året — en överraskande sanning'
 title: 'År 2026 är AI-året'
 description: 'AI förändrar samhället — men kanske inte som du tror. De största förändringarna ser vi i privatlivet och i barnens och ungdomarnas vardag.'
 publishDate: '2026-01-10'
-updatedDate: '2026-05-03'
+updatedDate: '2026-05-15'
 tags:
   - digitalisation
   - artificial-intelligence

--- a/src/pages/sv/blog/48/anvandningen-av-biometriska-identifierare-i-pass-far-inte-utvidgas/index.mdx
+++ b/src/pages/sv/blog/48/anvandningen-av-biometriska-identifierare-i-pass-far-inte-utvidgas/index.mdx
@@ -12,6 +12,11 @@ tags:
   - technology
   - privacy
   - freedom
+faq:
+  - q: "Varför är Finlands biometriska passregister exceptionellt i EU?"
+    a: "Finland är ett av få EU-länder som lagrar biometriska passuppgifter i ett permanent nationellt register. I de flesta EU-länder lagras uppgifterna enbart på passkortet och förstörs efter att passet utfärdats."
+  - q: "Vilka risker medför en utvidgning av biometriska uppgifter till polisbruk?"
+    a: "Biometriska identifierare är permanenta – de kan inte bytas ut som ett lösenord. När en databas väl finns är det historiskt sannolikt att användningsområdet utvidgas. Tyskland förstör uppgifterna direkt efter att passet utfärdats som ett föredöme för dataskydd."
 heroImage: 'Atte-Harjanne-ja-Lauri-Lavanti'
 alt: 'Ett foto av Atte Harjanne och Lauri Lavanti. Båda bär svart jacka och skjorta.'
 ---

--- a/src/pages/sv/blog/48/anvandningen-av-biometriska-identifierare-i-pass-far-inte-utvidgas/index.mdx
+++ b/src/pages/sv/blog/48/anvandningen-av-biometriska-identifierare-i-pass-far-inte-utvidgas/index.mdx
@@ -7,7 +7,7 @@ pageTitle: 'Biometriska identifierare i pass – motstånd'
 title: 'Använd­ningen av biometriska identi­fierare i pass får inte utvidgas'
 description: 'När fingeravtryck infördes i pass skapades ett nationellt biometriskt register i Finland. Nu vill regeringen öppna det för polisens bruk.'
 publishDate: '2026-01-23'
-updatedDate: '2026-05-03'
+updatedDate: '2026-05-15'
 tags:
   - technology
   - privacy

--- a/src/pages/sv/blog/51/digital-sjalvstandighet-ar-en-nodvandighet/index.mdx
+++ b/src/pages/sv/blog/51/digital-sjalvstandighet-ar-en-nodvandighet/index.mdx
@@ -7,9 +7,15 @@ pageTitle: 'Digital självständighet är en nödvändighet'
 title: 'Digital själv­ständighet är en nöd­vändighet'
 description: 'Som Rysslands granne har Finland lärt sig att vara beredd. Begreppen försörjningstrygghet och suveränitet har dock inte spridit sig till digitala tjänster.'
 publishDate: '2026-03-05'
+updatedDate: '2026-05-15'
 tags:
   - digital-independence
   - digitalisation
+faq:
+  - q: "Varför hotas Finlands digitala självständighet?"
+    a: "Finlands offentliga förvaltning är nästan helt beroende av amerikanska molntjänster som Amazon, Microsoft, Google och Oracle. Den politiska risken har ökat då USA inte längre är en förutsägbar partner."
+  - q: "Vilka alternativ finns till amerikanska molntjänster?"
+    a: "Europeiska och finska alternativ finns för de flesta behov inom offentlig förvaltning. Helsingfors valde till exempel finska UpCloud för sina kärnsystem. Även Tyskland och Estland investerar aktivt i digital suveränitet."
 heroImage: Suomi-neito-suojaa-Suomea-valkopaamerikotkalta
 alt: 'En tecknad bild av en blond kvinna som håller en bärbar dator. Den finska flaggan visas på datorskärmen. En vitskallig örn försöker snappa datorn från kvinnan. Runt bilden står det skrivet "Digital independence", "Digitaalinen itsenäisyys" och "Digital självständighet". Upphovsrätten till bilden tillhör medborgarinitiativet Digital självständighet.'
 ---

--- a/src/pages/sv/blog/53/digital-sjalvstandighet-byggs-steg-for-steg/index.mdx
+++ b/src/pages/sv/blog/53/digital-sjalvstandighet-byggs-steg-for-steg/index.mdx
@@ -7,9 +7,15 @@ pageTitle: 'Digital självständighet byggs steg för steg'
 title: 'Digital själv­ständighet byggs steg för steg'
 description: 'Digital självständighet byggs i varje upphandlingsbeslut. Helsingfors valde finska UpCloud som plattform för kärnsystemet för stadens tjänster.'
 publishDate: '2026-03-28'
+updatedDate: '2026-05-15'
 tags:
   - digital-independence
   - digitalisation
+faq:
+  - q: "Hur främjar Helsingfors digital självständighet genom upphandling?"
+    a: "Helsingfors valde finska UpCloud som molntjänstleverantör för sina kärnsystem. Varje upphandlingsbeslut bygger upp eller urholkar digital suveränitet, eftersom leverantörsinlåsning gör ett byte allt dyrare med tiden."
+  - q: "Varför är leverantörsinlåsning ett problem för digital självständighet?"
+    a: "När den offentliga förvaltningen flyttar sina system till en enda leverantörs plattform blir ett byte dyrare och svårare för varje år. Europeiska alternativ är tekniskt tillräckliga för de flesta behov."
 heroImage: Lauri-Lavanti-digitaalinen-itsenaisyys-paidassa
 alt: 'Lauri Lavanti ler och tittar in i kameran. Han bär en vit t-tröja med texten Digitaalinen itsenäisyys och ett lejontryck ovanför, samt en kavaj. Foto: Erkki Laine.'
 ---

--- a/src/pages/sv/blog/54/chat-control-parlamentet-handlade-ratt/index.mdx
+++ b/src/pages/sv/blog/54/chat-control-parlamentet-handlade-ratt/index.mdx
@@ -7,11 +7,17 @@ pageTitle: 'Chat control: parlamentet handlade rätt'
 title: 'Chat control: parlamentet handlade rätt'
 description: 'Chat control-lagens förlängning röstades ned i Europaparlamentet. KRP:s siffror är verkliga, men parlamentet handlade ändå rätt — och här är skälet.'
 publishDate: '2026-04-04'
+updatedDate: '2026-05-15'
 tags:
   - privacy
   - technology
   - digitalisation
   - freedom
+faq:
+  - q: "Varför förkastade EU-parlamentet chat control-förordningen?"
+    a: "EU-parlamentet förkastade utvidgningen av chat control-förordningen med rösterna 331–228 i mars 2026. Massövervakning som automatiskt skannar alla meddelanden strider mot rättsstatsprincipen och riktar sig inte enbart mot kriminella."
+  - q: "Hur kan barns säkerhet förbättras utan massövervakning?"
+    a: "Konkret misstanke före övervakning och domstolsbeslut är rättsstatens minimikrav – inte ett privilegium för integritetsskydd. Riktad utredning är också effektivare än massövervakning, eftersom organiserad brottslighet kan kringgå krypteringsbaserade filter."
 heroImage: sermi-jonka-takana-huone
 alt: 'Bild på en japansk skärm bakom vilken ett rum skymtar suddigt.'
 ---


### PR DESCRIPTION
> This PR containes AI-generated code. The author has reviewed and is responsible for all AI-generated content.

Closes #1169

## Summary

- Add `faq:` frontmatter (2 Q&A pairs each) to posts 47, 48, 51, 53, 54 across all 3 locales (fi/en/sv) — 15 files total
- Add `updatedDate: 2026-05-15` to posts 51, 53, 54 (missing) and bump posts 47, 48 (were 2026-05-03)
- Posts 43 and 44 already had FAQ — skipped

Each FAQ generates a JSON-LD FAQPage schema alongside the existing BlogPosting schema, increasing AEO surface area for AI answer engines.

## Test plan

- [x] `npm run build` passes (469 pages, no errors)
- [x] `grep -r "FAQPage" dist/` confirms posts 47, 48, 51, 53, 54 have schema
- [ ] Spot-check one post in browser (`npm run preview`) — confirm two `<script type="application/ld+json">` blocks