### PR TITLE
feat(seo): emit BreadcrumbList JSON-LD on posts and tag pages

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -1,7 +1,16 @@
 ---
 import type { Lang } from '../content/nav'
 
-import { BLOGPOSTING, type BreadcrumbItem, FAQPAGE, JSON_LD_TYPES, type JsonLdType, PERSON, WEBPAGE, WEBSITE } from '../lib/jsonld'
+import {
+    BLOGPOSTING,
+    type BreadcrumbItem,
+    FAQPAGE,
+    JSON_LD_TYPES,
+    type JsonLdType,
+    PERSON,
+    WEBPAGE,
+    WEBSITE,
+} from '../lib/jsonld'
 
 interface Props {
     breadcrumbs?: BreadcrumbItem[]

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -1,9 +1,10 @@
 ---
 import type { Lang } from '../content/nav'
 
-import { BLOGPOSTING, FAQPAGE, JSON_LD_TYPES, type JsonLdType, PERSON, WEBPAGE, WEBSITE } from '../lib/jsonld'
+import { BLOGPOSTING, type BreadcrumbItem, FAQPAGE, JSON_LD_TYPES, type JsonLdType, PERSON, WEBPAGE, WEBSITE } from '../lib/jsonld'
 
 interface Props {
+    breadcrumbs?: BreadcrumbItem[]
     createdAt?: string
     description?: string
     faq?: Array<{ a: string; q: string }>
@@ -19,6 +20,7 @@ interface Props {
 }
 
 const {
+    breadcrumbs,
     description = 'Lauri Lavanti on diplomi-insinööri, johtava ohjelmistokehittäjä ja Kirkkonummen kunnanvaltuutettu (Vihreät). Hän keskittyy digitalisaatioon, yksityisyyden suojaan, tekoälyn vastuulliseen käyttöönottoon ja talouteen.',
     faq,
     lang = 'fi',
@@ -158,6 +160,20 @@ const faqJsonLd =
           })
         : null
 
+const breadcrumbJsonLd =
+    breadcrumbs && breadcrumbs.length >= 2
+        ? JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'BreadcrumbList',
+              itemListElement: breadcrumbs.map(({ name, url }: BreadcrumbItem, i: number) => ({
+                  '@type': 'ListItem',
+                  item: url,
+                  name,
+                  position: i + 1,
+              })),
+          })
+        : null
+
 const keywords = [
     'Kirkkonummi',
     'Länsi-Uusimaa',
@@ -232,6 +248,7 @@ const keywords = [
 <title>{title.startsWith('Lauri Lavanti') ? title : `${title} | Lauri Lavanti`}</title>
 <script is:inline set:html={jsonLd} type="application/ld+json" />
 {faqJsonLd && <script is:inline set:html={faqJsonLd} type="application/ld+json" />}
+{breadcrumbJsonLd && <script is:inline set:html={breadcrumbJsonLd} type="application/ld+json" />}
 <link crossorigin="" href="https://static.cloudflareinsights.com" rel="preconnect" />
 <link crossorigin="" href="https://res.cloudinary.com" rel="preconnect" />
 <link href="https://res.cloudinary.com" rel="dns-prefetch" />

--- a/src/components/Head.spec.ts
+++ b/src/components/Head.spec.ts
@@ -313,6 +313,122 @@ describe('<Head />', () => {
         expect(result.querySelector('link[rel="alternate"]')).toBeNull()
     })
 
+    it('should emit BreadcrumbList JSON-LD for a blog post (3 items)', async () => {
+        const breadcrumbs = [
+            { name: 'Etusivu', url: 'https://laurilavanti.fi/fi/' },
+            { name: 'Blogi', url: 'https://laurilavanti.fi/fi/blog/' },
+            { name: 'Testijulkaisu', url: 'https://laurilavanti.fi/fi/blog/1/testijulkaisu/' },
+        ]
+
+        const result = await renderAstroComponent(Head, {
+            props: {
+                breadcrumbs,
+                title: 'Testijulkaisu',
+                type: 'BlogPosting',
+            },
+        })
+
+        const scripts = result.querySelectorAll('script[type="application/ld+json"]')
+        const jsonLdItems = Array.from(scripts).map((s) => JSON.parse(s.textContent || '{}'))
+
+        const breadcrumbSchema = jsonLdItems.find((j) => j['@type'] === 'BreadcrumbList')
+        expect(breadcrumbSchema).toBeDefined()
+        expect(breadcrumbSchema?.['@context']).toBe('https://schema.org')
+        expect(breadcrumbSchema?.itemListElement).toHaveLength(3)
+        expect(breadcrumbSchema?.itemListElement[0]).toEqual({
+            '@type': 'ListItem',
+            item: 'https://laurilavanti.fi/fi/',
+            name: 'Etusivu',
+            position: 1,
+        })
+        expect(breadcrumbSchema?.itemListElement[1]).toEqual({
+            '@type': 'ListItem',
+            item: 'https://laurilavanti.fi/fi/blog/',
+            name: 'Blogi',
+            position: 2,
+        })
+        expect(breadcrumbSchema?.itemListElement[2]).toEqual({
+            '@type': 'ListItem',
+            item: 'https://laurilavanti.fi/fi/blog/1/testijulkaisu/',
+            name: 'Testijulkaisu',
+            position: 3,
+        })
+    })
+
+    it('should emit BreadcrumbList JSON-LD for a tag page (2 items)', async () => {
+        const breadcrumbs = [
+            { name: 'Etusivu', url: 'https://laurilavanti.fi/fi/' },
+            { name: 'Kategoria', url: 'https://laurilavanti.fi/fi/category/tekoaly/' },
+        ]
+
+        const result = await renderAstroComponent(Head, {
+            props: {
+                breadcrumbs,
+                title: 'Tekoäly',
+                type: 'CollectionPage',
+            },
+        })
+
+        const scripts = result.querySelectorAll('script[type="application/ld+json"]')
+        const jsonLdItems = Array.from(scripts).map((s) => JSON.parse(s.textContent || '{}'))
+
+        const breadcrumbSchema = jsonLdItems.find((j) => j['@type'] === 'BreadcrumbList')
+        expect(breadcrumbSchema).toBeDefined()
+        expect(breadcrumbSchema?.itemListElement).toHaveLength(2)
+        expect(breadcrumbSchema?.itemListElement[0].position).toBe(1)
+        expect(breadcrumbSchema?.itemListElement[1].position).toBe(2)
+    })
+
+    it('should not emit BreadcrumbList when breadcrumbs prop is absent', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                title: 'No breadcrumbs',
+            },
+        })
+
+        const scripts = result.querySelectorAll('script[type="application/ld+json"]')
+        const jsonLdItems = Array.from(scripts).map((s) => JSON.parse(s.textContent || '{}'))
+        const breadcrumbSchema = jsonLdItems.find((j) => j['@type'] === 'BreadcrumbList')
+        expect(breadcrumbSchema).toBeUndefined()
+    })
+
+    it('should not emit BreadcrumbList when breadcrumbs has fewer than 2 items', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                breadcrumbs: [{ name: 'Etusivu', url: 'https://laurilavanti.fi/fi/' }],
+                title: 'Single breadcrumb',
+            },
+        })
+
+        const scripts = result.querySelectorAll('script[type="application/ld+json"]')
+        const jsonLdItems = Array.from(scripts).map((s) => JSON.parse(s.textContent || '{}'))
+        const breadcrumbSchema = jsonLdItems.find((j) => j['@type'] === 'BreadcrumbList')
+        expect(breadcrumbSchema).toBeUndefined()
+    })
+
+    it('should localise BreadcrumbList labels correctly for English', async () => {
+        const breadcrumbs = [
+            { name: 'Home', url: 'https://laurilavanti.fi/en/' },
+            { name: 'Blog', url: 'https://laurilavanti.fi/en/blog/' },
+            { name: 'Test post', url: 'https://laurilavanti.fi/en/blog/1/test-post/' },
+        ]
+
+        const result = await renderAstroComponent(Head, {
+            props: {
+                breadcrumbs,
+                lang: 'en',
+                title: 'Test post',
+                type: 'BlogPosting',
+            },
+        })
+
+        const scripts = result.querySelectorAll('script[type="application/ld+json"]')
+        const jsonLdItems = Array.from(scripts).map((s) => JSON.parse(s.textContent || '{}'))
+        const breadcrumbSchema = jsonLdItems.find((j) => j['@type'] === 'BreadcrumbList')
+        expect(breadcrumbSchema?.itemListElement[0].name).toBe('Home')
+        expect(breadcrumbSchema?.itemListElement[1].name).toBe('Blog')
+    })
+
     it('should accept langAlternates prop without error', async () => {
         const langAlternates = {
             en: '/en/blog/10/sote-is-the-cornerstone-of-the-welfare-society/',

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,6 @@
 ---
 /* eslint-disable astro/no-unused-css-selector */
-import type { JsonLdType } from '../lib/jsonld'
+import type { BreadcrumbItem, JsonLdType } from '../lib/jsonld'
 
 import Footer from '../components/Footer.astro'
 import GlobalStyle from '../components/GlobalStyle.astro'
@@ -17,6 +17,7 @@ import {
 } from '../lib/styles'
 
 interface Props {
+    breadcrumbs?: BreadcrumbItem[]
     createdAt?: string
     description?: string
     faq?: Array<{ a: string; q: string }>
@@ -32,6 +33,7 @@ interface Props {
 }
 
 const {
+    breadcrumbs,
     createdAt,
     description,
     faq,
@@ -51,6 +53,7 @@ const {
     <head>
         <GlobalStyle />
         <Head
+            breadcrumbs={breadcrumbs}
             createdAt={createdAt}
             description={description}
             faq={faq}

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -1,7 +1,8 @@
 ---
-import type { JsonLdType } from '../lib/jsonld'
+import type { BreadcrumbItem, JsonLdType } from '../lib/jsonld'
 
 import { getCldImageUrl } from 'astro-cloudinary/helpers' // eslint-disable-line import/namespace
+import { COLLECTIONPAGE } from '../lib/jsonld'
 
 import TitleBanner from '../components/TitleBanner.astro'
 import BaseLayout from './BaseLayout.astro'
@@ -31,9 +32,20 @@ const { alt, createdAt, description, faq, heroImage, lang, noindex, pageTitle, s
 const ogImage = heroImage
     ? getCldImageUrl({ crop: { source: true, type: 'fill' }, height: 630, src: heroImage, width: 1200 })
     : undefined
+
+const homeLabel: Record<string, string> = { en: 'Home', fi: 'Etusivu', sv: 'Hem' }
+const categoryLabel: Record<string, string> = { en: 'Category', fi: 'Kategoria', sv: 'Kategori' }
+const breadcrumbs: BreadcrumbItem[] | undefined =
+    type === COLLECTIONPAGE && lang && slug
+        ? [
+              { name: homeLabel[lang], url: `https://laurilavanti.fi/${lang}/` },
+              { name: categoryLabel[lang], url: `https://laurilavanti.fi/${slug}/` },
+          ]
+        : undefined
 ---
 
 <BaseLayout
+    breadcrumbs={breadcrumbs}
     createdAt={createdAt}
     description={description}
     faq={faq}

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -2,9 +2,9 @@
 import type { BreadcrumbItem, JsonLdType } from '../lib/jsonld'
 
 import { getCldImageUrl } from 'astro-cloudinary/helpers' // eslint-disable-line import/namespace
-import { COLLECTIONPAGE } from '../lib/jsonld'
 
 import TitleBanner from '../components/TitleBanner.astro'
+import { COLLECTIONPAGE } from '../lib/jsonld'
 import BaseLayout from './BaseLayout.astro'
 
 interface Props {

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -7,7 +7,7 @@ import ExcerptList from '../components/ExcerptList.astro'
 import H2 from '../components/H2.astro'
 import SocialShare from '../components/SocialShare.astro'
 import TitleBanner from '../components/TitleBanner.astro'
-import { BLOGPOSTING } from '../lib/jsonld'
+import { BLOGPOSTING, type BreadcrumbItem } from '../lib/jsonld'
 import { getPostAlternates } from '../lib/mdxPosts'
 import { gridTemplateColumnsArticle, sizes } from '../lib/styles'
 import BaseLayout from './BaseLayout.astro'
@@ -55,6 +55,15 @@ const t = i18n[lang]
 const ogImage = heroImage
     ? getCldImageUrl({ crop: { source: true, type: 'fill' }, height: 630, src: heroImage, width: 1200 })
     : undefined
+
+const siteOrigin = 'https://laurilavanti.fi'
+const homeLabel: Record<string, string> = { en: 'Home', fi: 'Etusivu', sv: 'Hem' }
+const blogLabel: Record<string, string> = { en: 'Blog', fi: 'Blogi', sv: 'Blogg' }
+const breadcrumbs: BreadcrumbItem[] = [
+    { name: homeLabel[lang], url: `${siteOrigin}/${lang}/` },
+    { name: blogLabel[lang], url: `${siteOrigin}/${lang}/blog/` },
+    { name: pageTitle, url: `${siteOrigin}/${canonicalSlug}/` },
+]
 ---
 
 <style
@@ -73,6 +82,7 @@ const ogImage = heroImage
     }
 </style>
 <BaseLayout
+    breadcrumbs={breadcrumbs}
     createdAt={publishDate}
     description={description}
     faq={faq}

--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -8,3 +8,5 @@ export const WEBSITE = 'WebSite' as const
 export const JSON_LD_TYPES = [BLOGPOSTING, COLLECTIONPAGE, PERSON, WEBPAGE, WEBSITE] as const
 
 export type JsonLdType = (typeof JSON_LD_TYPES)[number]
+
+export type BreadcrumbItem = { name: string; url: string }


### PR DESCRIPTION
> This PR contains AI-generated code. The author has reviewed and is responsible for all AI-generated content.

## Summary

- Adds `BreadcrumbItem` type to `src/lib/jsonld.ts`
- Extends `Head.astro` to emit a supplemental `BreadcrumbList` JSON-LD block (alongside FAQPage, not replacing the primary type)
- `PostLayout` builds a 3-item breadcrumb trail (Home → Blog → Post) with localised fi/en/sv labels
- `PageLayout` builds a 2-item trail (Home → Category) when `type === CollectionPage`
- `BaseLayout` threads the `breadcrumbs` prop through to `Head`
- 5 new `Head.spec.ts` assertions covering blog post, tag page, absent prop, single-item guard, and localised labels

Closes #1211

## Test plan

- [x] `npm run test` — 769 tests pass
- [x] `npm run check` — 0 errors, 0 warnings
- [ ] Google Rich Results Test on a deployed post + tag page URL (post-merge)