### PR TITLE
feat(seo): emit og:locale:alternate tags per locale

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -71,6 +71,10 @@ const hreflangLinks =
 
 const xDefaultHref = hreflangLinks.find((l) => l.hreflang === 'fi')?.href ?? null
 
+const ogLocaleAlternates = !noindex
+    ? (['fi', 'sv', 'en'] as Lang[]).filter((l) => l !== lang).map((l) => ogLocale[l])
+    : []
+
 const canonical = !noindex && (slug === 'index' ? Astro.site : slug ? new URL(`${slug}/`, siteUrl) : null)
 
 const ogImageUrl = ogImage ?? null
@@ -215,6 +219,7 @@ const keywords = [
 <meta content={title} property="og:title" />
 <meta content={name} name="author" />
 <meta content={ogLocale[lang]} property="og:locale" />
+{ogLocaleAlternates.map((loc) => <meta content={loc} property="og:locale:alternate" />)}
 <meta content={description} name="description" />
 <meta content={description} property="og:description" />
 <meta content={name} property="og:site_name" />

--- a/src/components/Head.spec.ts
+++ b/src/components/Head.spec.ts
@@ -313,6 +313,51 @@ describe('<Head />', () => {
         expect(result.querySelector('link[rel="alternate"]')).toBeNull()
     })
 
+    it('should emit two og:locale:alternate tags for fi page (en_GB, sv_SE)', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                lang: 'fi',
+                title: 'Blogi',
+            },
+        })
+
+        const alts = Array.from(result.querySelectorAll('meta[property="og:locale:alternate"]'))
+        expect(alts).toHaveLength(2)
+        const contents = alts.map((el) => el.getAttribute('content'))
+        expect(contents).toContain('en_GB')
+        expect(contents).toContain('sv_SE')
+        expect(contents).not.toContain('fi_FI')
+    })
+
+    it('should emit two og:locale:alternate tags for en page (fi_FI, sv_SE)', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                lang: 'en',
+                title: 'Blog',
+            },
+        })
+
+        const alts = Array.from(result.querySelectorAll('meta[property="og:locale:alternate"]'))
+        expect(alts).toHaveLength(2)
+        const contents = alts.map((el) => el.getAttribute('content'))
+        expect(contents).toContain('fi_FI')
+        expect(contents).toContain('sv_SE')
+        expect(contents).not.toContain('en_GB')
+    })
+
+    it('should not emit og:locale:alternate tags when noindex is true', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                lang: 'fi',
+                noindex: true,
+                title: 'Hidden Page',
+            },
+        })
+
+        const alts = result.querySelectorAll('meta[property="og:locale:alternate"]')
+        expect(alts).toHaveLength(0)
+    })
+
     it('should emit BreadcrumbList JSON-LD for a blog post (3 items)', async () => {
         const breadcrumbs = [
             { name: 'Etusivu', url: 'https://laurilavanti.fi/fi/' },


### PR DESCRIPTION
> This PR containes AI-generated code. The author has reviewed and is responsible for all AI-generated content.

## Summary

- Emits `og:locale:alternate` meta tags for the two non-current locales on every indexed page
- Tags are skipped when `noindex=true`, matching the existing `og:locale` behaviour
- Adds three unit tests covering fi/en page alternates and the noindex guard

Closes #1214