### PR TITLE
fix(seo): add article:modified_time OG meta tag

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -228,6 +228,7 @@ const keywords = [
 <meta content={description} name="twitter:description" />
 {isArticle && <meta content={name} property="article:author" />}
 {isArticle && <meta content={createdAt} property="article:published_time" />}
+{isArticle && updatedAt && <meta content={updatedAt} property="article:modified_time" />}
 <meta content="@laurilavanti@mastodon.social" name="fediverse:creator" />
 {
     canonical && (

--- a/src/components/Head.spec.ts
+++ b/src/components/Head.spec.ts
@@ -228,6 +228,46 @@ describe('<Head />', () => {
         expect(jsonLd.datePublished).toBe('2024-06-01')
     })
 
+    it('should emit article:modified_time meta when BlogPosting has updatedAt', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                createdAt: '2024-01-01',
+                title: 'Blog post',
+                type: 'BlogPosting',
+                updatedAt: '2024-06-01',
+            },
+        })
+
+        const meta = result.querySelector('meta[property="article:modified_time"]')
+        expect(meta).toBeDefined()
+        expect(meta?.getAttribute('content')).toBe('2024-06-01')
+    })
+
+    it('should not emit article:modified_time meta when BlogPosting has no updatedAt', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                createdAt: '2024-01-01',
+                title: 'Blog post',
+                type: 'BlogPosting',
+            },
+        })
+
+        const meta = result.querySelector('meta[property="article:modified_time"]')
+        expect(meta).toBeNull()
+    })
+
+    it('should not emit article:modified_time meta for non-article pages', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                title: 'Some page',
+                updatedAt: '2024-06-01',
+            },
+        })
+
+        const meta = result.querySelector('meta[property="article:modified_time"]')
+        expect(meta).toBeNull()
+    })
+
     it('should set Person JSON-LD when type is Person', async () => {
         const result = await renderAstroComponent(Head, {
             props: {


### PR DESCRIPTION
> This PR containes AI-generated code. The author has reviewed and is responsible for all AI-generated content.

## Summary

- Adds `<meta property="article:modified_time">` to `Head.astro` for `BlogPosting` pages that have an `updatedAt` value
- Tag is omitted when `updatedAt` is absent or the page is not an article
- Adds three test cases to `Head.spec.ts` covering: with `updatedAt`, without `updatedAt`, non-article page

Closes #1223

## Test plan

- [ ] `npm run test` — all 808 tests pass
- [ ] `npm run check` — 0 errors
- [ ] Build a post with `updatedDate` set and inspect `<head>` for `<meta property="article:modified_time">`
- [ ] Build a post without `updatedDate` and confirm tag absent