### PR TITLE
fix(seo): remove keywords meta tag

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -187,35 +187,11 @@ const breadcrumbJsonLd =
           })
         : null
 
-const keywords = [
-    'Kirkkonummi',
-    'Länsi-Uusimaa',
-    'Uusimaa',
-    'Vihreät',
-    'Lauri Lavanti',
-    'Lauri',
-    'Lavanti',
-    'poliitikko',
-    'kunnanvaltuutettu',
-    'eduskuntavaalit',
-    'digitalisaatio',
-    'tekoäly',
-    'teknologia',
-    'tietopolitiikka',
-    'digitaalinen itsenäisyys',
-    'digitaalinen riippumattomuus',
-    'yksityisyydensuoja',
-    'vastuullinen tekoäly',
-    'yrittäjyys',
-    'talous',
-    'innovaatiopolitiikka',
-].join(', ')
 ---
 
 <meta charset="utf-8" />
 {noindex && <meta content="noindex, nofollow" name="robots" />}
 <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport" />
-<meta content={keywords} name="keywords" />
 <meta content={title} property="og:title" />
 <meta content={name} name="author" />
 <meta content={ogLocale[lang]} property="og:locale" />

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -186,7 +186,6 @@ const breadcrumbJsonLd =
               })),
           })
         : null
-
 ---
 
 <meta charset="utf-8" />


### PR DESCRIPTION
> This PR contains AI-generated code. The author has reviewed and is responsible for all AI-generated content.

Remove `<meta name="keywords">` from `Head.astro`. Google deprecated this tag in 2009 and ignores it entirely. The static 21-term list was identical on every page — zero ranking value, wasted bytes, and signals keyword-stuffing intent to third-party crawlers.

Closes #1225