### PR TITLE
docs(seo): add spec for BlogPosting ImageObject in JSON-LD (#1224)

### DIFF
--- a/.agents/specs/seo/imageobject.md
+++ b/.agents/specs/seo/imageobject.md
@@ -97,9 +97,9 @@ Feature: BlogPosting ImageObject in JSON-LD
 ```typescript
 interface ImageObject {
   '@type': 'ImageObject'
+  height: 630       // hard-coded — og:image is always 630px tall
   url: string       // ogImageUrl value, unchanged
   width: 1200       // hard-coded — og:image is always 1200px wide
-  height: 630       // hard-coded — og:image is always 630px tall
 }
 ```
 

--- a/.agents/specs/seo/imageobject.md
+++ b/.agents/specs/seo/imageobject.md
@@ -24,6 +24,7 @@ The change is narrowly scoped to `BlogPosting` type only and only when `ogImageU
 - Add `primaryImageOfPage: { '@type': 'ImageObject', url: ogImageUrl, width: 1200, height: 630 }` to the `BlogPosting` spread
 - Only when `ogImageUrl` is present — no change when image is absent
 - Update `Head.spec.ts` with assertions for `ImageObject` shape
+- Update `seo/spec.md` Architecture table to note `BlogPosting.image` is an `ImageObject`; all other types retain a bare URL string
 
 ### Out of scope
 - Changing image generation or Cloudinary URLs
@@ -40,23 +41,23 @@ Feature: BlogPosting ImageObject in JSON-LD
 
   Scenario: BlogPosting with image emits ImageObject for both image and primaryImageOfPage
     Given Head is rendered with type "BlogPosting"
-    And ogImage is a valid URL string
-    And createdAt is set
+    And ogImage is "https://res.cloudinary.com/example/image/upload/v1/test.jpg"
+    And createdAt is "2024-01-01"
     When the primary JSON-LD script tag is parsed
     Then jsonLd["@type"] equals "BlogPosting"
     And jsonLd.image["@type"] equals "ImageObject"
-    And jsonLd.image.url equals the ogImage URL
+    And jsonLd.image.url equals "https://res.cloudinary.com/example/image/upload/v1/test.jpg"
     And jsonLd.image.width equals 1200
     And jsonLd.image.height equals 630
     And jsonLd.primaryImageOfPage["@type"] equals "ImageObject"
-    And jsonLd.primaryImageOfPage.url equals the ogImage URL
+    And jsonLd.primaryImageOfPage.url equals "https://res.cloudinary.com/example/image/upload/v1/test.jpg"
     And jsonLd.primaryImageOfPage.width equals 1200
     And jsonLd.primaryImageOfPage.height equals 630
 
   Scenario: BlogPosting without image emits neither image nor primaryImageOfPage
     Given Head is rendered with type "BlogPosting"
     And ogImage is undefined
-    And createdAt is set
+    And createdAt is "2024-01-01"
     When the primary JSON-LD script tag is parsed
     Then jsonLd["@type"] equals "BlogPosting"
     And jsonLd.image is undefined
@@ -64,10 +65,10 @@ Feature: BlogPosting ImageObject in JSON-LD
 
   Scenario: Non-BlogPosting type with image emits bare string image, no primaryImageOfPage
     Given Head is rendered with type "WebSite"
-    And ogImage is a valid URL string
+    And ogImage is "https://res.cloudinary.com/example/image/upload/v1/test.jpg"
     When the primary JSON-LD script tag is parsed
     Then jsonLd["@type"] equals "WebSite"
-    And jsonLd.image equals the ogImage URL string
+    And jsonLd.image equals "https://res.cloudinary.com/example/image/upload/v1/test.jpg"
     And typeof jsonLd.image equals "string"
     And jsonLd.primaryImageOfPage is undefined
 
@@ -80,7 +81,7 @@ Feature: BlogPosting ImageObject in JSON-LD
 
   Scenario: BlogPosting ImageObject does not affect other BlogPosting fields
     Given Head is rendered with type "BlogPosting"
-    And ogImage is a valid URL string
+    And ogImage is "https://res.cloudinary.com/example/image/upload/v1/test.jpg"
     And createdAt is "2024-03-01"
     And updatedAt is "2024-06-01"
     When the primary JSON-LD script tag is parsed
@@ -104,35 +105,11 @@ interface ImageObject {
 
 The `ImageObject` shape is identical for both `image` and `primaryImageOfPage`. Dimensions are compile-time constants, not derived at runtime.
 
-**Spread ordering in `Head.astro`** (last-write-wins):
-
-```typescript
-// Outer spread — bare string for non-BlogPosting types (keep as-is)
-...(ogImageUrl ? { image: ogImageUrl } : {}),
-// BlogPosting spread — overwrites image with ImageObject, adds primaryImageOfPage
-...(type === BLOGPOSTING
-    ? {
-          ...(ogImageUrl
-              ? {
-                    image: { '@type': 'ImageObject', url: ogImageUrl, width: 1200, height: 630 },
-                    primaryImageOfPage: { '@type': 'ImageObject', url: ogImageUrl, width: 1200, height: 630 },
-                }
-              : {}),
-          dateModified: updatedAt ?? createdAt,
-          datePublished: createdAt,
-          mainEntityOfPage: { '@id': canonical, '@type': WEBPAGE },
-      }
-    : {}),
-```
-
-For `BlogPosting` + `ogImageUrl`: inner spread overwrites `image` (bare string → `ImageObject`) and adds `primaryImageOfPage`.
-For non-`BlogPosting`: inner spread absent; outer bare-string `image` survives.
-
 ---
 
 ## Dependencies
 
-- [seo/spec.md](./spec.md) — parent SEO spec; defines the BlogPosting schema structure and states `image` is included when `ogImage` is provided
+- [seo/spec.md](./spec.md) — parent SEO spec; defines the BlogPosting schema structure and states `image` is included when `ogImage` is provided. **Must be updated** to note that `BlogPosting.image` is an `ImageObject` while all other types retain a bare URL string.
 - [images/spec.md](../images/spec.md) — confirms 1200×630 as the og:image dimension standard and that `Head.astro` must not call Cloudinary
 
 ---
@@ -158,3 +135,4 @@ For non-`BlogPosting`: inner spread absent; outer bare-string `image` survives.
 | Date | Change |
 |------|--------|
 | 2026-05-18 | Initial draft |
+| 2026-05-18 | Critic fixes: concrete URL literals in scenarios, remove implementation spread from Data Model, add seo/spec.md update to scope |

--- a/.agents/specs/seo/imageobject.md
+++ b/.agents/specs/seo/imageobject.md
@@ -1,0 +1,160 @@
+# Spec: BlogPosting ImageObject in JSON-LD
+
+> **Pattern**: [The Spec](https://asdlc.io/patterns/the-spec) — Living document, permanent source of truth.
+> **Status**: `Active`
+> **Last updated**: 2026-05-18
+> **Issue**: [#1224](https://github.com/lapanti/laurilavanti/issues/1224)
+
+---
+
+## Intent
+
+Google's structured data guidelines for `Article`/`BlogPosting` require the `image` field to be an `ImageObject` — not a bare URL string — so that the page is eligible for Google Images rich results and image carousels. Without the `@type: 'ImageObject'` wrapper and explicit dimensions, Google's Rich Results Test flags the field as suboptimal and may not surface the post image in image search.
+
+Adding `primaryImageOfPage` alongside `image` signals which image is the canonical representative of the page. Google uses this hint for image indexing and featured-snippet selection. Both fields carry the same `ImageObject` shape and the same 1200×630 dimensions already used for `og:image`.
+
+The change is narrowly scoped to `BlogPosting` type only and only when `ogImageUrl` is present. No other schema type is affected, and no image generation logic is touched.
+
+---
+
+## Scope
+
+### In scope
+- Replace `image: ogImageUrl` (bare string) with `image: { '@type': 'ImageObject', url: ogImageUrl, width: 1200, height: 630 }` for `BlogPosting` type
+- Add `primaryImageOfPage: { '@type': 'ImageObject', url: ogImageUrl, width: 1200, height: 630 }` to the `BlogPosting` spread
+- Only when `ogImageUrl` is present — no change when image is absent
+- Update `Head.spec.ts` with assertions for `ImageObject` shape
+
+### Out of scope
+- Changing image generation or Cloudinary URLs
+- Adding `primaryImageOfPage` or `ImageObject` to non-`BlogPosting` types
+- Changing `ogImageAlt` handling
+- Adding `contentUrl`, `encodingFormat`, or other `ImageObject` properties beyond `@type`, `url`, `width`, `height`
+
+---
+
+## Contract
+
+```gherkin
+Feature: BlogPosting ImageObject in JSON-LD
+
+  Scenario: BlogPosting with image emits ImageObject for both image and primaryImageOfPage
+    Given Head is rendered with type "BlogPosting"
+    And ogImage is a valid URL string
+    And createdAt is set
+    When the primary JSON-LD script tag is parsed
+    Then jsonLd["@type"] equals "BlogPosting"
+    And jsonLd.image["@type"] equals "ImageObject"
+    And jsonLd.image.url equals the ogImage URL
+    And jsonLd.image.width equals 1200
+    And jsonLd.image.height equals 630
+    And jsonLd.primaryImageOfPage["@type"] equals "ImageObject"
+    And jsonLd.primaryImageOfPage.url equals the ogImage URL
+    And jsonLd.primaryImageOfPage.width equals 1200
+    And jsonLd.primaryImageOfPage.height equals 630
+
+  Scenario: BlogPosting without image emits neither image nor primaryImageOfPage
+    Given Head is rendered with type "BlogPosting"
+    And ogImage is undefined
+    And createdAt is set
+    When the primary JSON-LD script tag is parsed
+    Then jsonLd["@type"] equals "BlogPosting"
+    And jsonLd.image is undefined
+    And jsonLd.primaryImageOfPage is undefined
+
+  Scenario: Non-BlogPosting type with image emits bare string image, no primaryImageOfPage
+    Given Head is rendered with type "WebSite"
+    And ogImage is a valid URL string
+    When the primary JSON-LD script tag is parsed
+    Then jsonLd["@type"] equals "WebSite"
+    And jsonLd.image equals the ogImage URL string
+    And typeof jsonLd.image equals "string"
+    And jsonLd.primaryImageOfPage is undefined
+
+  Scenario: Non-BlogPosting type without image emits no image field
+    Given Head is rendered with type "WebSite"
+    And ogImage is undefined
+    When the primary JSON-LD script tag is parsed
+    Then jsonLd["@type"] equals "WebSite"
+    And jsonLd.image is undefined
+
+  Scenario: BlogPosting ImageObject does not affect other BlogPosting fields
+    Given Head is rendered with type "BlogPosting"
+    And ogImage is a valid URL string
+    And createdAt is "2024-03-01"
+    And updatedAt is "2024-06-01"
+    When the primary JSON-LD script tag is parsed
+    Then jsonLd.datePublished equals "2024-03-01"
+    And jsonLd.dateModified equals "2024-06-01"
+    And jsonLd.mainEntityOfPage["@type"] equals "WebPage"
+```
+
+---
+
+## Data Model
+
+```typescript
+interface ImageObject {
+  '@type': 'ImageObject'
+  url: string       // ogImageUrl value, unchanged
+  width: 1200       // hard-coded — og:image is always 1200px wide
+  height: 630       // hard-coded — og:image is always 630px tall
+}
+```
+
+The `ImageObject` shape is identical for both `image` and `primaryImageOfPage`. Dimensions are compile-time constants, not derived at runtime.
+
+**Spread ordering in `Head.astro`** (last-write-wins):
+
+```typescript
+// Outer spread — bare string for non-BlogPosting types (keep as-is)
+...(ogImageUrl ? { image: ogImageUrl } : {}),
+// BlogPosting spread — overwrites image with ImageObject, adds primaryImageOfPage
+...(type === BLOGPOSTING
+    ? {
+          ...(ogImageUrl
+              ? {
+                    image: { '@type': 'ImageObject', url: ogImageUrl, width: 1200, height: 630 },
+                    primaryImageOfPage: { '@type': 'ImageObject', url: ogImageUrl, width: 1200, height: 630 },
+                }
+              : {}),
+          dateModified: updatedAt ?? createdAt,
+          datePublished: createdAt,
+          mainEntityOfPage: { '@id': canonical, '@type': WEBPAGE },
+      }
+    : {}),
+```
+
+For `BlogPosting` + `ogImageUrl`: inner spread overwrites `image` (bare string → `ImageObject`) and adds `primaryImageOfPage`.
+For non-`BlogPosting`: inner spread absent; outer bare-string `image` survives.
+
+---
+
+## Dependencies
+
+- [seo/spec.md](./spec.md) — parent SEO spec; defines the BlogPosting schema structure and states `image` is included when `ogImage` is provided
+- [images/spec.md](../images/spec.md) — confirms 1200×630 as the og:image dimension standard and that `Head.astro` must not call Cloudinary
+
+---
+
+## Anti-patterns
+
+- **Do not apply `ImageObject` to non-`BlogPosting` types** — only `BlogPosting` is in scope; other types retain bare URL strings for `image`
+- **Do not derive `width`/`height` at runtime** — dimensions are a build-time constant (1200×630) set by `getCldImageUrl` in the layouts; computing them in `Head.astro` would require calling Cloudinary, violating the no-Cloudinary-in-Head constraint in the images spec
+- **Do not introduce a helper or type alias for `ImageObject`** — the object literal appears exactly twice in the same expression; abstraction adds indirection for no gain
+- **Do not remove the outer bare-string `image` spread** — non-`BlogPosting` types depend on it; its removal would silently omit `image` from all non-BlogPosting schemas
+- **Do not emit `primaryImageOfPage` when `ogImageUrl` is absent** — the conditional must guard both fields together
+
+---
+
+## Open Questions
+
+*(none)*
+
+---
+
+## Changelog
+
+| Date | Change |
+|------|--------|
+| 2026-05-18 | Initial draft |

--- a/.agents/specs/seo/spec.md
+++ b/.agents/specs/seo/spec.md
@@ -20,7 +20,7 @@ Every page emits structured metadata for search engines and social platforms: JS
 
   | Type | Extra fields |
   |---|---|
-  | `BlogPosting` | `datePublished`, `dateModified`, `mainEntityOfPage` |
+  | `BlogPosting` | `datePublished`, `dateModified`, `mainEntityOfPage`, `image` (ImageObject), `primaryImageOfPage` (ImageObject) |
   | `CollectionPage` | no extras (base fields only) |
   | `WebSite` | `name`, `sameAs` (all social profiles) |
   | `Person` | `jobTitle` (locale-specific), `description` (locale-specific), `knowsAbout[]`, `memberOf` (PoliticalParty), `sameAs` |
@@ -28,7 +28,7 @@ Every page emits structured metadata for search engines and social platforms: JS
 
 - **Supplemental FAQPage schema:** When a `BlogPosting` page includes a `faq` prop with 2 or more `{q, a}` entries, a second `<script type="application/ld+json">` block is emitted with `@type: FAQPage`. This block coexists alongside the primary `BlogPosting` schema — it does not replace it. The `FAQPAGE` constant is exported from `src/lib/jsonld.ts` but is **not** added to `JSON_LD_TYPES` (which lists only primary page types). The `faq` prop flows from MDX frontmatter → `PostLayout` → `BaseLayout` → `Head`.
 
-- **All schemas always include:** `@context`, `@type`, `author`, `description`, `headline`, `url`, and `image` (if `ogImage` provided)
+- **All schemas always include:** `@context`, `@type`, `author`, `description`, `headline`, `url`, and `image` (if `ogImage` provided). For `BlogPosting`, `image` is an `ImageObject` `{ '@type': 'ImageObject', url, width: 1200, height: 630 }` and `primaryImageOfPage` (same shape) is also emitted. All other types emit `image` as a bare URL string. See [imageobject.md](./imageobject.md).
 
 - **Canonical URL derivation:**
   - `slug === 'index'` → `Astro.site` (site root)

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -119,8 +119,8 @@ const jsonLd = JSON.stringify({
         ? {
               ...(ogImageUrl
                   ? {
-                        image: { '@type': 'ImageObject', url: ogImageUrl, width: 1200, height: 630 },
-                        primaryImageOfPage: { '@type': 'ImageObject', url: ogImageUrl, width: 1200, height: 630 },
+                        image: { '@type': 'ImageObject', height: 630, url: ogImageUrl, width: 1200 },
+                        primaryImageOfPage: { '@type': 'ImageObject', height: 630, url: ogImageUrl, width: 1200 },
                     }
                   : {}),
               dateModified: updatedAt ?? createdAt,

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -117,6 +117,12 @@ const jsonLd = JSON.stringify({
     ...(ogImageUrl ? { image: ogImageUrl } : {}),
     ...(type === BLOGPOSTING
         ? {
+              ...(ogImageUrl
+                  ? {
+                        image: { '@type': 'ImageObject', url: ogImageUrl, width: 1200, height: 630 },
+                        primaryImageOfPage: { '@type': 'ImageObject', url: ogImageUrl, width: 1200, height: 630 },
+                    }
+                  : {}),
               dateModified: updatedAt ?? createdAt,
               datePublished: createdAt,
               mainEntityOfPage: {

--- a/src/components/Head.spec.ts
+++ b/src/components/Head.spec.ts
@@ -532,4 +532,94 @@ describe('<Head />', () => {
 
         expect(result).toBeDefined()
     })
+
+    it('should emit ImageObject for image and primaryImageOfPage in BlogPosting JSON-LD when ogImage is set', async () => {
+        const ogImage = 'https://res.cloudinary.com/example/image/upload/v1/test.jpg'
+        const result = await renderAstroComponent(Head, {
+            props: {
+                createdAt: '2024-01-01',
+                ogImage,
+                title: 'Test Blog Post',
+                type: 'BlogPosting',
+            },
+        })
+
+        const jsonLdScript = result.querySelector('script[type="application/ld+json"]')
+        const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
+        expect(jsonLd['@type']).toBe('BlogPosting')
+        expect(jsonLd.image['@type']).toBe('ImageObject')
+        expect(jsonLd.image.url).toBe(ogImage)
+        expect(jsonLd.image.width).toBe(1200)
+        expect(jsonLd.image.height).toBe(630)
+        expect(jsonLd.primaryImageOfPage['@type']).toBe('ImageObject')
+        expect(jsonLd.primaryImageOfPage.url).toBe(ogImage)
+        expect(jsonLd.primaryImageOfPage.width).toBe(1200)
+        expect(jsonLd.primaryImageOfPage.height).toBe(630)
+    })
+
+    it('should not emit image or primaryImageOfPage in BlogPosting JSON-LD when ogImage is absent', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                createdAt: '2024-01-01',
+                title: 'Test Blog Post',
+                type: 'BlogPosting',
+            },
+        })
+
+        const jsonLdScript = result.querySelector('script[type="application/ld+json"]')
+        const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
+        expect(jsonLd['@type']).toBe('BlogPosting')
+        expect(jsonLd.image).toBeUndefined()
+        expect(jsonLd.primaryImageOfPage).toBeUndefined()
+    })
+
+    it('should emit bare string image and no primaryImageOfPage for non-BlogPosting type with ogImage', async () => {
+        const ogImage = 'https://res.cloudinary.com/example/image/upload/v1/test.jpg'
+        const result = await renderAstroComponent(Head, {
+            props: {
+                ogImage,
+                title: 'Home',
+                type: 'WebSite',
+            },
+        })
+
+        const jsonLdScript = result.querySelector('script[type="application/ld+json"]')
+        const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
+        expect(jsonLd['@type']).toBe('WebSite')
+        expect(jsonLd.image).toBe(ogImage)
+        expect(typeof jsonLd.image).toBe('string')
+        expect(jsonLd.primaryImageOfPage).toBeUndefined()
+    })
+
+    it('should not emit image for non-BlogPosting type when ogImage is absent', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                title: 'Home',
+                type: 'WebSite',
+            },
+        })
+
+        const jsonLdScript = result.querySelector('script[type="application/ld+json"]')
+        const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
+        expect(jsonLd['@type']).toBe('WebSite')
+        expect(jsonLd.image).toBeUndefined()
+    })
+
+    it('should not affect datePublished, dateModified, or mainEntityOfPage when BlogPosting has ogImage', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                createdAt: '2024-03-01',
+                ogImage: 'https://res.cloudinary.com/example/image/upload/v1/test.jpg',
+                title: 'Test Blog Post',
+                type: 'BlogPosting',
+                updatedAt: '2024-06-01',
+            },
+        })
+
+        const jsonLdScript = result.querySelector('script[type="application/ld+json"]')
+        const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
+        expect(jsonLd.datePublished).toBe('2024-03-01')
+        expect(jsonLd.dateModified).toBe('2024-06-01')
+        expect(jsonLd.mainEntityOfPage['@type']).toBe('WebPage')
+    })
 })


### PR DESCRIPTION
> This PR contains AI-generated code. The author has reviewed and is responsible for all AI-generated content.

## Summary
- Adds `.agents/specs/seo/imageobject.md` — living spec for upgrading BlogPosting `image` to `ImageObject` and adding `primaryImageOfPage`
- Spec is `Active` status, scoped to `BlogPosting` type + `ogImageUrl` present only
- 5 Gherkin scenarios covering happy path, absent image, non-BlogPosting regression, field isolation

## Test plan
- [ ] Spec is self-contained — an agent can implement from it alone
- [ ] `/review-spec 1224` passes Critic review
- [ ] `/implement 1224` implements against this spec

Closes #1224