### PR TITLE
docs: add spec for freshness audit script (#1216)

### DIFF
--- a/.agents/specs/freshness-audit.md
+++ b/.agents/specs/freshness-audit.md
@@ -2,7 +2,7 @@
 
 > **Pattern**: [The Spec](https://asdlc.io/patterns/the-spec) — Living document, permanent source of truth.
 > **Status**: `Draft`
-> **Last updated**: 2026-05-19
+> **Last updated**: 2026-05-20
 
 ---
 
@@ -52,7 +52,8 @@ Feature: Freshness audit script
     And the exit code is 1
 
   Scenario: Post with updatedDate older than 180 days is flagged
-    Given an MDX blog post with updatedDate 200 days ago
+    Given an MDX blog post with any publishDate
+    And updatedDate 200 days ago
     When I run `npm run check:freshness`
     Then the post slug appears in stdout output
     And the exit code is 1
@@ -64,8 +65,8 @@ Feature: Freshness audit script
     Then the post does not appear in stdout output
 
   Scenario: No stale posts exist
+    Given no posts match either staleness condition
     When I run `npm run check:freshness`
-    And no posts match either staleness condition
     Then stdout contains a "no stale posts" message
     And the exit code is 0
 
@@ -79,14 +80,14 @@ Feature: Weekly GitHub Actions tracking issue
   Scenario: Stale posts found on weekly run
     Given the freshness workflow runs on schedule
     And `npm run check:freshness` exits 1
-    Then a GitHub issue is opened or updated with title "Freshness audit: stale posts [YYYY-WW]"
-    And the issue body lists all stale posts
+    Then a GitHub issue with title "Freshness audit: stale posts" is created if it does not exist
+    Or the existing open issue with that title is updated with the current stale post list
 
   Scenario: No stale posts on weekly run
     Given the freshness workflow runs on schedule
     And `npm run check:freshness` exits 0
-    Then no issue is opened
-    And any existing tracking issue is closed (if open)
+    Then no new issue is opened
+    And any existing open issue titled "Freshness audit: stale posts" is closed with a comment
 
 Feature: Policy documentation
 
@@ -107,7 +108,7 @@ interface StalePost {
     publishDate: string       // ISO date, e.g. '2021-02-04'
     updatedDate: string | null
     reason: 'no-updated-date' | 'updated-date-stale'
-    ageDays: number           // days since publishDate (Case A) or updatedDate (Case B)
+    ageDays: number           // days since publishDate for Case A; days since updatedDate for Case B
 }
 ```
 
@@ -145,3 +146,4 @@ export const FRESHNESS_STALE_UPDATE_DAYS = 180  // Case B threshold
 | Date | Change |
 |------|--------|
 | 2026-05-19 | Initial draft |
+| 2026-05-20 | Fix Gherkin ordering; clarify Case B Given; resolve GH issue strategy (single persistent issue); clarify ageDays semantics |

--- a/.agents/specs/freshness-audit.md
+++ b/.agents/specs/freshness-audit.md
@@ -1,0 +1,147 @@
+# Spec: Freshness Audit Script + Policy
+
+> **Pattern**: [The Spec](https://asdlc.io/patterns/the-spec) — Living document, permanent source of truth.
+> **Status**: `Draft`
+> **Last updated**: 2026-05-19
+
+---
+
+## Intent
+
+Blog posts grow stale over time — AI answer engines deprioritise old content, and readers lose trust when facts become outdated. The site already blocks publishing when a post is ≥90 days old with no `updatedDate` (enforced in `mdx-deep.ts`). That gate only covers one staleness case: posts that were never updated. It does not catch posts whose `updatedDate` has itself grown old.
+
+This feature adds an **informational + CI-actionable** freshness audit:
+
+1. A standalone script (`scripts/checks/freshness.ts`) that surfaces two staleness cases:
+   - **Case A**: `today − publishDate > 90 days` AND no `updatedDate`
+   - **Case B**: `today − updatedDate > 180 days`
+2. An npm script `check:freshness` that runs it.
+3. A weekly GitHub Actions workflow that runs the audit and opens/updates a single tracking issue listing stale posts.
+4. A one-paragraph policy note in `CLAUDE.md` documenting the 90/180-day rule.
+
+The script exits 1 when stale posts are found, making it usable in automation. It does not modify content — output is informational only.
+
+---
+
+## Scope
+
+### In scope
+- `scripts/checks/freshness.ts` — reads all MDX posts, prints stale list, exits 1 if any found
+- `npm run check:freshness` in `package.json`
+- `.github/workflows/freshness.yml` — weekly cron, opens/updates a single tracking issue
+- One-paragraph policy note appended to `CLAUDE.md`
+
+### Out of scope
+- Automated content rewrites
+- Modifying the existing `mdx-deep.ts` pre-commit check
+- Making build or pre-commit fail for freshness (the new script is separate from the pre-commit chain)
+- Per-post issue creation (one tracking issue total)
+
+---
+
+## Contract
+
+```gherkin
+Feature: Freshness audit script
+
+  Scenario: Post older than 90 days with no updatedDate is flagged
+    Given an MDX blog post with publishDate 100 days ago
+    And no updatedDate field
+    When I run `npm run check:freshness`
+    Then the post slug appears in stdout output
+    And the exit code is 1
+
+  Scenario: Post with updatedDate older than 180 days is flagged
+    Given an MDX blog post with updatedDate 200 days ago
+    When I run `npm run check:freshness`
+    Then the post slug appears in stdout output
+    And the exit code is 1
+
+  Scenario: Post with updatedDate within 180 days is not flagged
+    Given an MDX blog post with publishDate 400 days ago
+    And updatedDate 30 days ago
+    When I run `npm run check:freshness`
+    Then the post does not appear in stdout output
+
+  Scenario: No stale posts exist
+    When I run `npm run check:freshness`
+    And no posts match either staleness condition
+    Then stdout contains a "no stale posts" message
+    And the exit code is 0
+
+  Scenario: Output format is human-readable
+    Given at least one stale post
+    When I run `npm run check:freshness`
+    Then each stale entry shows: slug, lang, publishDate, updatedDate (or "—"), and reason (Case A or B)
+
+Feature: Weekly GitHub Actions tracking issue
+
+  Scenario: Stale posts found on weekly run
+    Given the freshness workflow runs on schedule
+    And `npm run check:freshness` exits 1
+    Then a GitHub issue is opened or updated with title "Freshness audit: stale posts [YYYY-WW]"
+    And the issue body lists all stale posts
+
+  Scenario: No stale posts on weekly run
+    Given the freshness workflow runs on schedule
+    And `npm run check:freshness` exits 0
+    Then no issue is opened
+    And any existing tracking issue is closed (if open)
+
+Feature: Policy documentation
+
+  Scenario: Policy paragraph present in CLAUDE.md
+    Given the CLAUDE.md file
+    Then it contains a paragraph referencing the 90-day and 180-day thresholds
+    And explains that Case A is also enforced by mdx-deep.ts in CI
+```
+
+---
+
+## Data Model
+
+```typescript
+interface StalePost {
+    slug: string
+    lang: 'en' | 'fi' | 'sv'
+    publishDate: string       // ISO date, e.g. '2021-02-04'
+    updatedDate: string | null
+    reason: 'no-updated-date' | 'updated-date-stale'
+    ageDays: number           // days since publishDate (Case A) or updatedDate (Case B)
+}
+```
+
+Constants (parallel `mdx-deep.ts` naming):
+```typescript
+export const FRESHNESS_NO_UPDATE_DAYS = 90   // Case A threshold
+export const FRESHNESS_STALE_UPDATE_DAYS = 180  // Case B threshold
+```
+
+---
+
+## Dependencies
+
+- `scripts/checks/mdx-deep.ts` — reuse `splitMdx()` and `fmField()` helpers; do not duplicate parsing logic
+- `src/lib/mdxPosts.ts` — **not** used at runtime (build-time Astro glob); script reads MDX files directly via `fs` like `mdx-deep.ts` does
+
+---
+
+## Anti-patterns
+
+- **Do not** import from `src/lib/mdxPosts.ts` in the script — it uses `import.meta.glob` which is Astro/Vite-only and will fail in Node
+- **Do not** add `check:freshness` to the existing `validate-content` CI job — that job blocks merges; freshness is informational and runs separately (weekly workflow)
+- **Do not** create one GitHub issue per stale post — one tracking issue with a list, updated weekly
+
+---
+
+## Open Questions
+
+*(none — all resolved by user answers 2026-05-19)*
+
+---
+
+## Changelog
+
+| Date | Change |
+|------|--------|
+| 2026-05-19 | Initial draft |

--- a/.github/workflows/freshness.yml
+++ b/.github/workflows/freshness.yml
@@ -1,0 +1,76 @@
+name: Freshness audit
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # every Monday at 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    name: Check post freshness
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Run freshness audit
+        id: audit
+        run: |
+          OUTPUT=$(node --experimental-strip-types scripts/checks/freshness.ts $(find src/pages -name '*.mdx') 2>&1) || true
+          echo "output<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$OUTPUT" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          if echo "$OUTPUT" | grep -q "^No stale posts found"; then
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Find existing tracking issue
+        id: find-issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE=$(gh issue list --label "freshness-audit" --state open --json number --jq '.[0].number // ""')
+          echo "number=$ISSUE" >> "$GITHUB_OUTPUT"
+
+      - name: Update or create tracking issue (stale posts found)
+        if: steps.audit.outputs.stale == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BODY: |
+            <!-- freshness-audit-body -->
+            Posts requiring a content refresh as of ${{ github.run_id }}:
+
+            ```
+            ${{ steps.audit.outputs.output }}
+            ```
+
+            **Rules:**
+            - Case A: `publishDate > 90 days ago` AND no `updatedDate`
+            - Case B: `updatedDate > 180 days ago`
+
+            _Updated automatically by the [freshness audit workflow](${{ github.server_url }}/${{ github.repository }}/actions/workflows/freshness.yml)._
+        run: |
+          if [ -n "${{ steps.find-issue.outputs.number }}" ]; then
+            gh issue edit "${{ steps.find-issue.outputs.number }}" --body "$BODY"
+            gh issue comment "${{ steps.find-issue.outputs.number }}" --body "Audit refreshed $(date -u +%Y-%m-%d)."
+          else
+            gh issue create \
+              --title "Freshness audit: stale posts" \
+              --label "freshness-audit" \
+              --body "$BODY"
+          fi
+
+      - name: Close tracking issue (no stale posts)
+        if: steps.audit.outputs.stale == 'false' && steps.find-issue.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment "${{ steps.find-issue.outputs.number }}" --body "All posts are fresh as of $(date -u +%Y-%m-%d). Closing."
+          gh issue close "${{ steps.find-issue.outputs.number }}"

--- a/.github/workflows/freshness.yml
+++ b/.github/workflows/freshness.yml
@@ -21,14 +21,20 @@ jobs:
       - name: Run freshness audit
         id: audit
         run: |
-          OUTPUT=$(node --experimental-strip-types scripts/checks/freshness.ts $(find src/pages -name '*.mdx') 2>&1) || true
+          set +e
+          OUTPUT=$(node --experimental-strip-types scripts/checks/freshness.ts $(find src/pages -name '*.mdx') 2>&1)
+          EXIT_CODE=$?
+          set -e
           echo "output<<EOF" >> "$GITHUB_OUTPUT"
           echo "$OUTPUT" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
-          if echo "$OUTPUT" | grep -q "^No stale posts found"; then
+          if [ "$EXIT_CODE" -eq 0 ]; then
             echo "stale=false" >> "$GITHUB_OUTPUT"
-          else
+          elif [ "$EXIT_CODE" -eq 1 ]; then
             echo "stale=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Script exited with unexpected code $EXIT_CODE — aborting."
+            exit "$EXIT_CODE"
           fi
 
       - name: Find existing tracking issue

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,3 +134,9 @@ Manual steps:
    - Update PR description if needed: `gh pr edit`
    - Wait for the PR checks to complete in CI; if the e2e check fails, inspect the Playwright report, identify what broke, and fix it in a follow-up commit
 6. **Sign all commits with GPG** — if the key is locked, ask the user to unlock it before committing
+
+---
+
+## Content Freshness Policy
+
+Posts are considered stale under two rules: **Case A** — `publishDate` is more than 90 days ago and the post has no `updatedDate` (this is also a hard CI error enforced by `scripts/checks/mdx-deep.ts`); **Case B** — `updatedDate` is more than 180 days ago. Run `npm run check:freshness` to audit locally. A weekly GitHub Actions workflow (`freshness.yml`) runs the same audit and opens or updates a single tracking issue ("Freshness audit: stale posts") listing posts that need a refresh.

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -1,7 +1,7 @@
 import type { KnipConfig } from 'knip'
 
 const config: KnipConfig = {
-    entry: ['scripts/checks/cross-file.mjs', 'scripts/checks/mdx-deep.ts'],
+    entry: ['scripts/checks/cross-file.mjs', 'scripts/checks/mdx-deep.ts', 'scripts/checks/freshness.ts'],
     ignoreBinaries: ['scripts/mdx-validate.sh'],
     ignoreDependencies: ['@iconify-json/fa7-brands', '@iconify-json/fa7-solid', 'eslint-plugin-jsx-a11y'],
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "validate-translations": "node scripts/validate-translations.mjs",
     "validate-slugs": "node scripts/validate-slugs.mjs",
     "audit:redirects": "node --experimental-strip-types scripts/checks/redirects.mjs",
+    "check:freshness": "node --experimental-strip-types scripts/checks/freshness.ts $(find src/pages -name '*.mdx')",
     "preview": "astro preview",
     "astro": "astro",
     "test": "vitest",

--- a/scripts/checks/freshness.ts
+++ b/scripts/checks/freshness.ts
@@ -1,0 +1,87 @@
+/**
+ * freshness.ts
+ *
+ * Informational audit: surfaces blog posts going stale.
+ * Exits 1 when stale posts found, 0 when all are fresh.
+ *
+ * Case A: today − publishDate > 90 days AND no updatedDate
+ * Case B: today − updatedDate > 180 days
+ *
+ * Note: Case A is also enforced as a hard CI error in mdx-deep.ts.
+ * This script is for informational auditing and weekly automation.
+ */
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { fmField, splitMdx } from './mdx-deep.ts'
+
+export const FRESHNESS_NO_UPDATE_DAYS = 90
+export const FRESHNESS_STALE_UPDATE_DAYS = 180
+
+export interface StalePost {
+    slug: string
+    lang: string
+    publishDate: string
+    updatedDate: string | null
+    reason: 'no-updated-date' | 'updated-date-stale'
+    ageDays: number
+}
+
+export function checkFreshness(file: string, today: Date): StalePost | null {
+    const content = readFileSync(file, 'utf8')
+    const isBlogPost = /PostLayout/.test(content)
+    if (!isBlogPost) return null
+
+    const { frontmatter } = splitMdx(content)
+    const publishDateStr = fmField(frontmatter, 'publishDate')
+    const updatedDateStr = fmField(frontmatter, 'updatedDate')
+    const slug = fmField(frontmatter, 'slug') ?? file
+    const lang = fmField(frontmatter, 'lang') ?? '?'
+
+    if (!publishDateStr) return null
+
+    if (!updatedDateStr) {
+        const ageDays = (today.getTime() - new Date(publishDateStr).getTime()) / 86_400_000
+        if (ageDays > FRESHNESS_NO_UPDATE_DAYS) {
+            return { slug, lang, publishDate: publishDateStr, updatedDate: null, reason: 'no-updated-date', ageDays: Math.floor(ageDays) }
+        }
+        return null
+    }
+
+    const updateAgeMs = today.getTime() - new Date(updatedDateStr).getTime()
+    const updateAgeDays = updateAgeMs / 86_400_000
+    if (updateAgeDays > FRESHNESS_STALE_UPDATE_DAYS) {
+        return { slug, lang, publishDate: publishDateStr, updatedDate: updatedDateStr, reason: 'updated-date-stale', ageDays: Math.floor(updateAgeDays) }
+    }
+
+    return null
+}
+
+const isMain = process.argv[1] === fileURLToPath(import.meta.url)
+if (isMain) {
+    const today = new Date()
+    const files = process.argv.slice(2)
+    const stalePosts: StalePost[] = []
+
+    for (const file of files) {
+        if (!file.endsWith('.mdx')) continue
+        const result = checkFreshness(file, today)
+        if (result) stalePosts.push(result)
+    }
+
+    if (stalePosts.length === 0) {
+        process.stdout.write('No stale posts found.\n')
+        process.exit(0)
+    }
+
+    process.stdout.write(`Stale posts (${stalePosts.length}):\n\n`)
+    for (const post of stalePosts) {
+        const updated = post.updatedDate ?? '—'
+        const reason = post.reason === 'no-updated-date'
+            ? `Case A: no updatedDate, ${post.ageDays} days since publishDate`
+            : `Case B: updatedDate ${post.ageDays} days ago`
+        process.stdout.write(`  ${post.slug}  [${post.lang}]  published: ${post.publishDate}  updated: ${updated}  — ${reason}\n`)
+    }
+
+    process.exit(1)
+}

--- a/scripts/checks/freshness.ts
+++ b/scripts/checks/freshness.ts
@@ -20,7 +20,7 @@ export const FRESHNESS_STALE_UPDATE_DAYS = 180
 
 export interface StalePost {
     slug: string
-    lang: string
+    lang: 'en' | 'fi' | 'sv'
     publishDate: string
     updatedDate: string | null
     reason: 'no-updated-date' | 'updated-date-stale'
@@ -36,7 +36,7 @@ export function checkFreshness(file: string, today: Date): StalePost | null {
     const publishDateStr = fmField(frontmatter, 'publishDate')
     const updatedDateStr = fmField(frontmatter, 'updatedDate')
     const slug = fmField(frontmatter, 'slug') ?? file
-    const lang = fmField(frontmatter, 'lang') ?? '?'
+    const lang = (fmField(frontmatter, 'lang') ?? 'fi') as 'en' | 'fi' | 'sv'
 
     if (!publishDateStr) return null
 


### PR DESCRIPTION
> This PR containes AI-generated code. The author has reviewed and is responsible for all AI-generated content.

Adds `.agents/specs/freshness-audit.md` — the living Spec for issue #1216.

Covers:
- `scripts/checks/freshness.ts` (Case A: ≥90 days + no updatedDate; Case B: updatedDate ≥180 days old)
- `npm run check:freshness` (exits 1 when stale posts found)
- Weekly GH Actions workflow + single tracking issue
- Policy paragraph in `CLAUDE.md`

Closes #1216