### PR TITLE
docs(specs): fix 4 spec/doc drift items found in audit

### DIFF
--- a/.agents/specs/navigation/spec.md
+++ b/.agents/specs/navigation/spec.md
@@ -16,7 +16,7 @@ The header navigation provides the primary wayfinding for all three locales. It 
       title: string       // aria-label for the link
   }
   ```
-- **Component tree:** `BaseLayout` → `Header` → `SkipLinks` + `MobileMenu` + `DesktopMenu` → `MainNavigationLink` + `NavigationLink`
+- **Component tree:** `BaseLayout` → `src/components/Header.astro` → `src/components/header/SkipLinks.astro` + `src/components/header/MobileMenu.astro` + `src/components/header/DesktopMenu.astro` → `MainNavigationLink` + `NavigationLink`
 - **Responsive split:** MobileMenu is visible below 1200px; DesktopMenu is visible at 1200px+. Both are always in the DOM — CSS `display:none` hides the inactive one. This is why e2e selectors use `.nth(0)` (mobile) vs `.nth(1)` (desktop).
 - **Mobile menu toggle:** A CSS-only hamburger — `<input type="checkbox">` drives the open/closed state via sibling selectors. No JS.
 - **Active link state:** `aria-current="page"` is set at build time:

--- a/.agents/specs/seo/spec.md
+++ b/.agents/specs/seo/spec.md
@@ -48,7 +48,7 @@ Every page emits structured metadata for search engines and social platforms: JS
 - **og:image:** Passed in as a pre-computed URL string from the layout. Layouts use `getCldImageUrl` from `astro-cloudinary/helpers` to generate a 1200×630 fill crop. `Head.astro` does not call Cloudinary — it only emits the URL it receives.
 
 - **Title format:** `title === 'Lauri Lavanti' ? title : `${title} | Lauri Lavanti``
-- **Title length:** The final rendered `<title>` must be 50–60 characters inclusive. Measured after stripping soft-hyphen characters (`\u00AD`) and applying the suffix rule. Enforced at build time by `scripts/validate-titles.mjs`.
+- **Title length:** The final rendered `<title>` must be 50–60 characters inclusive. Measured after stripping soft-hyphen characters (`\u00AD`) and applying the suffix rule. Enforced at build time by `scripts/check-overflow.mjs` via `npm run validate-page-titles`.
 
 - **og:type:** `'article'` for `BlogPosting`, `'website'` for everything else
 
@@ -79,7 +79,7 @@ Every page emits structured metadata for search engines and social platforms: JS
 - [ ] `og:type` is `article` for posts, `website` for all other pages
 - [ ] Twitter card is `summary_large_image` when image present, `summary` otherwise
 - [ ] `npm run test` passes (jsonld.spec.ts validates type constants)
-- [ ] Every page `<title>` is 50–60 characters (soft hyphens stripped, suffix applied); confirmed by `npm run validate-titles`
+- [ ] Every page `<title>` is 50–60 characters (soft hyphens stripped, suffix applied); confirmed by `npm run validate-page-titles`
 
 ### Regression Guardrails
 - `JSON_LD_TYPES` must stay in sync with the constants exported from `jsonld.ts` — the spec test enforces this
@@ -120,7 +120,7 @@ Every page emits structured metadata for search engines and social platforms: JS
 
 **Scenario: Title length enforcement**
 - Given: An MDX file whose rendered title is outside 50–60 chars
-- When: `npm run validate-titles` or `npm run build` is run
+- When: `npm run validate-page-titles` or `npm run build` is run
 - Then: Script exits 1 and prints `ERROR: title length N (expected 50–60): "…" — src/pages/…/index.mdx`
 
 **Scenario: FAQPage not emitted with fewer than 2 entries**

--- a/.agents/specs/tags/spec.md
+++ b/.agents/specs/tags/spec.md
@@ -9,13 +9,15 @@ Tags are the content taxonomy used to categorise blog posts and generate categor
 - **Single source of truth:** `src/content/tags.ts`
   ```ts
   interface LocalTag {
-      id: string                                          // URL-safe, kebab-case, never changes
-      names: { en: string; fi: string; sv: string }      // short display name (tag chips, links)
-      pageTitle: { en: string; fi: string; sv: string }  // 34–44 raw chars; full <title> after suffix = 50–60 chars
-      descriptions: { en: string; fi: string; sv: string } // intro paragraph text for category pages
-      heroImage?: string                                  // Cloudinary image id; fallback: 'Lauri-Lavanti-next-to-a-table'
+      id: string                                            // URL-safe, kebab-case, never changes
+      names: { en: string; fi: string; sv: string }        // short display name (tag chips, links)
+      pageTitle: { en: string; fi: string; sv: string }    // 34–44 raw chars; full <title> after suffix = 50–60 chars
+      descriptions: { en: string[]; fi: string[]; sv: string[] } // array of intro paragraphs for category pages
+      metaDescription: { en: string; fi: string; sv: string }    // meta description for SEO (single string)
+      updatedDate: string                                   // required; used by sitemap lastmod
+      heroImage?: string                                    // Cloudinary image id; fallback: 'Lauri-Lavanti-next-to-a-table'
       heroImageAlt?: { en: string; fi: string; sv: string } // required when heroImage is set
-      faq?: {                                             // per-locale; only renders when locale array has 2+ entries
+      faq?: {                                               // per-locale; only renders when locale array has 2+ entries
           en?: Array<{ q: string; a: string }>
           fi?: Array<{ q: string; a: string }>
           sv?: Array<{ q: string; a: string }>
@@ -24,7 +26,7 @@ Tags are the content taxonomy used to categorise blog posts and generate categor
   export const tags: LocalTag[]
   export function getTagName(id: string, lang?: Lang): string | undefined
   ```
-  Currently 24 tags.
+  Currently 30 tags.
 
 - **Post frontmatter reference:** `tags: [id1, id2]` — array of tag `id` strings. No validation at build time — an unknown id silently produces no category page match.
 
@@ -32,7 +34,7 @@ Tags are the content taxonomy used to categorise blog posts and generate categor
 
 - **Category pages:** `src/pages/{lang}/category/[tag].astro` — `getStaticPaths` maps `tags` → `{ params: { tag: t.id }, props: { tag: t } }`. Only ids in `tags.ts` get a page generated.
 
-- **Category page enrichment:** Each category page passes `type={COLLECTIONPAGE}`, `description` (from `tag.descriptions[lang]`), `heroImage` (tag override or `'Lauri-Lavanti-next-to-a-table'`), `alt`, and `faq` (locale-specific array) to `PageLayout`. An intro `<Paragraph>` is rendered before `<ExcerptList>`. FAQPage JSON-LD is emitted when the locale's `faq` array has 2+ entries.
+- **Category page enrichment:** Each category page passes `type={COLLECTIONPAGE}`, `description` (from `tag.metaDescription[lang]`), `heroImage` (tag override or `'Lauri-Lavanti-next-to-a-table'`), `alt`, and `faq` (locale-specific array) to `PageLayout`. Each string in `tag.descriptions[lang]` is rendered as a separate `<Paragraph>` before `<ExcerptList>`. FAQPage JSON-LD is emitted when the locale's `faq` array has 2+ entries.
 
 - **Filtering in `ExcerptList`:** filters `allMdxPosts` by `post.tags.includes(tagId)` — strict string equality. No fuzzy matching.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,6 +14,8 @@ Feature-specific specs (blueprint, contracts, scenarios) live at `.agents/specs/
 - [`.agents/specs/rss/spec.md`](./.agents/specs/rss/spec.md) — RSS feed endpoints, item structure, locale filtering
 - [`.agents/specs/design-system/spec.md`](./.agents/specs/design-system/spec.md) — design tokens, define:vars pattern, spacing/colour/typography constants
 - [`.agents/specs/recommendations/spec.md`](./.agents/specs/recommendations/spec.md) — recommendations page, Recommendation data type, single Finnish-only data file shared across locales
+- [`.agents/specs/newsletter/spec.md`](./.agents/specs/newsletter/spec.md) — newsletter landing pages, NewsletterSubscribe component, content data file
+- [`.agents/specs/cv-descriptions/spec.md`](./.agents/specs/cv-descriptions/spec.md) — CV description fields (string arrays per locale) for CurriculumVitae component
 
 ---
 
@@ -42,7 +44,7 @@ All content lives as MDX files under `src/pages/` in locale subdirectories.
 src/pages/
   fi/
     index.mdx                        # home page
-    {page}/index.mdx                 # about, contact, blog index, ...
+    {page}/index.mdx                 # about, contact, blog index, newsletter, recommendations, privacy-policy, topics, ...
     blog/{id}/{slug}/index.mdx       # blog posts
   sv/  (same structure)
   en/  (same structure)

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "dev": "astro dev",
     "build": "astro build",
     "validate-page-titles": "node scripts/check-overflow.mjs $(find src/pages -name '*.mdx') src/content/tags/*.ts",
-    "validate-titles": "node scripts/validate-titles.mjs",
     "validate-translations": "node scripts/validate-translations.mjs",
     "validate-slugs": "node scripts/validate-slugs.mjs",
     "audit:redirects": "node --experimental-strip-types scripts/checks/redirects.mjs",


### PR DESCRIPTION
> This PR containes AI-generated code. The author has reviewed and is responsible for all AI-generated content.

Fixes documentation drift found in a full audit of specs vs. reality:

- **tags/spec.md**: `descriptions` was typed as `string` per locale — actual code uses `string[]`. Added missing `metaDescription` and `updatedDate` fields. Fixed tag count (24 → 30). Fixed category enrichment prose.
- **seo/spec.md**: Referenced non-existent `scripts/validate-titles.mjs` — replaced with `scripts/check-overflow.mjs` / `npm run validate-page-titles`. Also removed the broken `"validate-titles"` npm script entry from `package.json`.
- **navigation/spec.md**: SkipLinks/MobileMenu/DesktopMenu paths lacked the `header/` subdirectory.
- **ARCHITECTURE.md**: Newsletter and cv-descriptions specs weren't listed; page types (newsletter, recommendations, privacy-policy, topics) weren't enumerated.