### PR TITLE
feat(seo): canonical Person @id, ProfilePage, co-author support (#1244)

### DIFF
--- a/.agents/specs/seo/jsonld-person.md
+++ b/.agents/specs/seo/jsonld-person.md
@@ -121,12 +121,13 @@ Feature: Canonical Person JSON-LD entity
     Given a BlogPosting in lang 'en' with authors:
       | entry           | role                  |
       | Miisa Jeremejew | municipal councillor  |
-      | 'lauri'         | municipal councillor  |
+      | lauri           | (sentinel)            |
     When the page is rendered
     Then the byline after the post content is:
-      _Authors: Miisa Jeremejew (municipal councillor) and Lauri Lavanti (municipal councillor)._
+      _Authors: Miisa Jeremejew (municipal councillor) and Lauri Lavanti (Municipal councillor & Lead Developer)._
     And the byline is rendered as an italic paragraph
     And render order follows frontmatter array order (first entry → first name)
+    # Lauri sentinel gets personJobTitle[lang] injected because a co-author has a role
 
   Scenario: Byline localises prefix in Finnish
     Given a BlogPosting in lang 'fi' with two co-authors
@@ -138,22 +139,23 @@ Feature: Canonical Person JSON-LD entity
     When the page is rendered
     Then the byline begins with "Författare:"
 
-  Scenario: Per-author byline when author has role
+  Scenario: Lauri sentinel gets personJobTitle when co-author has role
     Given a BlogPosting in lang 'en' with authors:
       | name          | role                  |
       | Atte Harjanne | member of parliament  |
-      | lauri         | (no role)             |
+      | lauri         | (sentinel)            |
     When the page is rendered
     Then the byline is:
-      _Authors: Atte Harjanne (member of parliament) and Lauri Lavanti._
+      _Authors: Atte Harjanne (member of parliament) and Lauri Lavanti (Municipal councillor & Lead Developer)._
 
   Scenario: Author with no role shows name only in byline
     Given a BlogPosting with a co-author entry that has no role field
+    And no other co-authors have roles
     When the page is rendered
     Then that author appears in the byline as name only (no parenthetical)
 
-  Scenario: Lauri sentinel resolves to name only — no defaults injected
-    Given a BlogPosting with authors: ['lauri', { name: 'Co-author', role: 'Some role' }]
+  Scenario: Lauri sentinel resolves to name only when no co-author has a role
+    Given a BlogPosting with authors: ['lauri', { name: 'Co-author' }] (no role on co-author)
     When the page is rendered
     Then Lauri appears as 'Lauri Lavanti' with no role parenthetical
 
@@ -218,16 +220,17 @@ Feature: Canonical Person JSON-LD entity
 
   Scenario: Migrated post 56 (Lähteelä) renders per-author byline with role
     Given post 56 in lang 'en' after migration
-    And authors frontmatter: [{ name: 'Miisa Jeremejew', role: 'municipal councillor' }, { name: 'Lauri Lavanti', role: 'municipal councillor' }]
+    And authors frontmatter: [{ name: 'Miisa Jeremejew', role: 'municipal councillor' }, 'lauri']
     When the page is rendered
-    Then the byline reads: _Authors: Miisa Jeremejew (municipal councillor) and Lauri Lavanti (municipal councillor)._
+    Then the byline reads: _Authors: Miisa Jeremejew (municipal councillor) and Lauri Lavanti (Municipal councillor & Lead Developer)._
     And is rendered as an italic paragraph after the post body
+    # Lauri sentinel gets personJobTitle['en'] because Miisa has a role
 
-  Scenario: Migrated post 48 (biometrics) renders per-author byline — Harjanne with role, Lauri name-only
+  Scenario: Migrated post 48 (biometrics) renders per-author byline — Harjanne with role, Lauri with personJobTitle
     Given post 48 in lang 'en' after migration
     And authors frontmatter: [{ name: 'Atte Harjanne', role: 'member of parliament' }, 'lauri']
     When the page is rendered
-    Then the byline reads: _Authors: Atte Harjanne (member of parliament) and Lauri Lavanti._
+    Then the byline reads: _Authors: Atte Harjanne (member of parliament) and Lauri Lavanti (Municipal councillor & Lead Developer)._
     And is rendered as an italic paragraph after the post body
 
   Scenario: Migrated post 41 renders name-only byline (Ronja has no role, Lauri is sentinel)
@@ -279,7 +282,10 @@ type ResolvedAuthor =
 
 // Byline rendering rules:
 // - Render order = frontmatter array order (first entry → first name).
-// - String sentinel 'lauri' resolves to name 'Lauri Lavanti' with NO role (name-only by default).
+// - String sentinel 'lauri' must always be used when Lauri is an author (never explicit name object).
+// - 'lauri' sentinel resolves to name 'Lauri Lavanti'.
+//   - If any co-author has a role → Lauri also gets personJobTitle[lang] as his role.
+//   - If no co-author has a role → Lauri appears name-only (no parenthetical).
 // - Per-author format: each author rendered as "Name (role)" if role present, "Name" if absent.
 //   Joining: two authors → "A and B"; three+ → Oxford comma "A, B, and C".
 // - Byline prefix per lang: 'en' → 'Authors:', 'fi' → 'Tekijät:', 'sv' → 'Författare:'
@@ -339,3 +345,4 @@ type ResolvedAuthor =
 | 2026-05-23 | Fix Critic findings: name-order rule (array order), article:author content spec, migration scenarios for all 5 posts, Wikipedia link scenario, WebSite regression scenario, sv knowsAbout scenario, byline Oxford-comma + name-only rules |
 | 2026-05-23 | Drop shared-suffix byline format; drop place field; Lauri sentinel = name-only; per-author role in parentheses only |
 | 2026-05-23 | Fix stale Given example (remove place); clarify fi/sv posts also had inline bylines requiring removal |
+| 2026-05-23 | Lauri sentinel always required; sentinel gets personJobTitle[lang] role injected when any co-author has a role |

--- a/.agents/specs/seo/jsonld-person.md
+++ b/.agents/specs/seo/jsonld-person.md
@@ -117,46 +117,45 @@ Feature: Canonical Person JSON-LD entity
     When the page is rendered
     Then no author byline element appears after the post content
 
-  Scenario: Shared-role byline for co-authors with identical role and place
+  Scenario: Per-author byline with role — role in parentheses after name
     Given a BlogPosting in lang 'en' with authors:
-      | entry             | role                                     | place       |
-      | Miisa Jeremejew   | Municipal councillor (Greens)            | Kirkkonummi |
-      | 'lauri' (string)  | Municipal councillor (Greens)            | Kirkkonummi |
+      | entry           | role                  |
+      | Miisa Jeremejew | municipal councillor  |
+      | 'lauri'         | municipal councillor  |
     When the page is rendered
     Then the byline after the post content is:
-      _Authors: Miisa Jeremejew and Lauri Lavanti, Municipal councillor (Greens), Kirkkonummi._
+      _Authors: Miisa Jeremejew (municipal councillor) and Lauri Lavanti (municipal councillor)._
     And the byline is rendered as an italic paragraph
     And render order follows frontmatter array order (first entry → first name)
 
-  Scenario: Shared-role byline localises prefix in Finnish
-    Given a BlogPosting in lang 'fi' with two co-authors sharing the same role and place
+  Scenario: Byline localises prefix in Finnish
+    Given a BlogPosting in lang 'fi' with two co-authors
     When the page is rendered
     Then the byline begins with "Tekijät:"
 
-  Scenario: Shared-role byline localises prefix in Swedish
-    Given a BlogPosting in lang 'sv' with two co-authors sharing the same role and place
+  Scenario: Byline localises prefix in Swedish
+    Given a BlogPosting in lang 'sv' with two co-authors
     When the page is rendered
     Then the byline begins with "Författare:"
 
-  Scenario: Per-author byline when roles differ
+  Scenario: Per-author byline when author has role
     Given a BlogPosting in lang 'en' with authors:
-      | name              | role                    | place       |
-      | lauri             | Lead developer          | Helsinki    |
-      | Atte Harjanne     | Member of Parliament    | Helsinki    |
+      | name          | role                  |
+      | Atte Harjanne | member of parliament  |
+      | lauri         | (no role)             |
     When the page is rendered
-    Then the byline uses per-author format:
-      _Authors: Lauri Lavanti (Lead developer, Helsinki) and Atte Harjanne (Member of Parliament, Helsinki)._
+    Then the byline is:
+      _Authors: Atte Harjanne (member of parliament) and Lauri Lavanti._
 
-  Scenario: Author with no role/place shows name only in byline
-    Given a BlogPosting with a co-author entry that has no role or place
+  Scenario: Author with no role shows name only in byline
+    Given a BlogPosting with a co-author entry that has no role field
     When the page is rendered
     Then that author appears in the byline as name only (no parenthetical)
 
-  Scenario: Lauri's defaults apply when his entry omits role/place
-    Given a BlogPosting in lang 'en' with authors: [{ name: 'Co-author', role: 'Some role', place: 'Some place' }, 'lauri']
-    And Lauri's entry (the string sentinel 'lauri') has no explicit role or place
+  Scenario: Lauri sentinel resolves to name only — no defaults injected
+    Given a BlogPosting with authors: ['lauri', { name: 'Co-author', role: 'Some role' }]
     When the page is rendered
-    Then Lauri's name appears with his default jobTitle['en'] and 'Kirkkonummi' as role/place in the per-author format
+    Then Lauri appears as 'Lauri Lavanti' with no role parenthetical
 
   # ── knowsAbout localisation ──────────────────────────────────────────────────
 
@@ -217,15 +216,22 @@ Feature: Canonical Person JSON-LD entity
     When the MDX content is read
     Then none contains a line matching _Tekijät:…_ or _Författare:…_ in the body
 
-  Scenario: Migrated post 56 renders auto-byline identically to former manual en byline
-    Given post 56 (Lähteelä) in lang 'en' after migration
-    And authors frontmatter: [{ name: 'Miisa Jeremejew', role: 'municipal councillors (Greens)', place: 'Kirkkonummi' }, 'lauri']
+  Scenario: Migrated post 56 (Lähteelä) renders per-author byline with role
+    Given post 56 in lang 'en' after migration
+    And authors frontmatter: [{ name: 'Miisa Jeremejew', role: 'municipal councillor' }, { name: 'Lauri Lavanti', role: 'municipal councillor' }]
     When the page is rendered
-    Then the byline reads: _Authors: Miisa Jeremejew and Lauri Lavanti, municipal councillors (Greens), Kirkkonummi._
+    Then the byline reads: _Authors: Miisa Jeremejew (municipal councillor) and Lauri Lavanti (municipal councillor)._
     And is rendered as an italic paragraph after the post body
 
-  Scenario: Migrated post 41 renders name-only byline (no role/place in original)
-    Given post 41 (public transport) in lang 'en' after migration
+  Scenario: Migrated post 48 (biometrics) renders per-author byline — Harjanne with role, Lauri name-only
+    Given post 48 in lang 'en' after migration
+    And authors frontmatter: [{ name: 'Atte Harjanne', role: 'member of parliament' }, 'lauri']
+    When the page is rendered
+    Then the byline reads: _Authors: Atte Harjanne (member of parliament) and Lauri Lavanti._
+    And is rendered as an italic paragraph after the post body
+
+  Scenario: Migrated post 41 renders name-only byline (Ronja has no role, Lauri is sentinel)
+    Given post 41 in lang 'en' after migration
     And authors frontmatter: [{ name: 'Ronja Karkinen' }, 'lauri']
     When the page is rendered
     Then the byline reads: _Authors: Ronja Karkinen and Lauri Lavanti._
@@ -256,8 +262,7 @@ export type AuthorEntry =
       name: string
       url?: string
       sameAs?: string[]
-      role?: string   // localized role/title string; omit for name-only byline
-      place?: string  // city/region; omit for name-only byline
+      role?: string   // localized role/title string (e.g. 'kunnanvaltuutettu'); omit for name-only byline
     }
 
 // Added to MdxPost in src/lib/mdxPosts.ts
@@ -274,19 +279,9 @@ type ResolvedAuthor =
 
 // Byline rendering rules:
 // - Render order = frontmatter array order (first entry → first name).
-// - String sentinel 'lauri' resolves to name 'Lauri Lavanti';
-//   its default role = personJobTitle[lang], default place = 'Kirkkonummi'
-//   (only used when the entry itself has no explicit role/place).
-// - Shared-suffix format (Lähteelä style):
-//     "Authors: A and B, role, place."
-//   Used when ALL resolved authors have identical role AND place strings (exact equality, incl. case/whitespace).
-// - Per-author format:
-//     "Authors: A (role_a, place_a) and B (role_b, place_b)."
-//   Used when any role OR place differs.
-// - Name-only: if an author has no role and no place → appears as name only, no parenthetical.
-//   If ALL authors are name-only → byline ends after the name list with no suffix:
-//     "Authors: A, B, and C."
-// - Three-author Oxford comma: "A, B, and C." (not "A and B and C")
+// - String sentinel 'lauri' resolves to name 'Lauri Lavanti' with NO role (name-only by default).
+// - Per-author format: each author rendered as "Name (role)" if role present, "Name" if absent.
+//   Joining: two authors → "A and B"; three+ → Oxford comma "A, B, and C".
 // - Byline prefix per lang: 'en' → 'Authors:', 'fi' → 'Tekijät:', 'sv' → 'Författare:'
 // - Byline is an italic paragraph (<p><em>…</em></p>), ends with period.
 
@@ -342,3 +337,4 @@ type ResolvedAuthor =
 |------|--------|
 | 2026-05-23 | Initial draft |
 | 2026-05-23 | Fix Critic findings: name-order rule (array order), article:author content spec, migration scenarios for all 5 posts, Wikipedia link scenario, WebSite regression scenario, sv knowsAbout scenario, byline Oxford-comma + name-only rules |
+| 2026-05-23 | Drop shared-suffix byline format; drop place field; Lauri sentinel = name-only; per-author role in parentheses only |

--- a/.agents/specs/seo/jsonld-person.md
+++ b/.agents/specs/seo/jsonld-person.md
@@ -101,7 +101,7 @@ Feature: Canonical Person JSON-LD entity
     And that meta content attribute is 'Lauri Lavanti'
 
   Scenario: Co-authored post references multiple Persons
-    Given a BlogPosting with authors: [{ name: 'Miisa Jeremejew', role: 'Kunnanvaltuutettu (Vihreät)', place: 'Kirkkonummi' }, 'lauri']
+    Given a BlogPosting with authors: [{ name: 'Miisa Jeremejew', role: 'municipal councillor' }, 'lauri']
     When the page is rendered
     Then BlogPosting.author is an array with two entries
     And the first entry is { '@type': 'Person', name: 'Miisa Jeremejew' }
@@ -338,3 +338,4 @@ type ResolvedAuthor =
 | 2026-05-23 | Initial draft |
 | 2026-05-23 | Fix Critic findings: name-order rule (array order), article:author content spec, migration scenarios for all 5 posts, Wikipedia link scenario, WebSite regression scenario, sv knowsAbout scenario, byline Oxford-comma + name-only rules |
 | 2026-05-23 | Drop shared-suffix byline format; drop place field; Lauri sentinel = name-only; per-author role in parentheses only |
+| 2026-05-23 | Fix stale Given example (remove place); clarify fi/sv posts also had inline bylines requiring removal |

--- a/.agents/specs/seo/jsonld-person.md
+++ b/.agents/specs/seo/jsonld-person.md
@@ -98,14 +98,17 @@ Feature: Canonical Person JSON-LD entity
     Then BlogPosting.author is an array with one entry
     And that entry is { '@type': 'Person', '@id': 'https://laurilavanti.fi/fi/about/#person' }
     And there is exactly one <meta property="article:author"> in the HTML
+    And that meta content attribute is 'Lauri Lavanti'
 
   Scenario: Co-authored post references multiple Persons
-    Given a BlogPosting with authors: ['lauri', { name: 'Miisa Jeremejew', role: 'Kunnanvaltuutettu (Vihreät)', place: 'Kirkkonummi' }]
+    Given a BlogPosting with authors: [{ name: 'Miisa Jeremejew', role: 'Kunnanvaltuutettu (Vihreät)', place: 'Kirkkonummi' }, 'lauri']
     When the page is rendered
     Then BlogPosting.author is an array with two entries
-    And the first entry is { '@type': 'Person', '@id': 'https://laurilavanti.fi/fi/about/#person' }
-    And the second entry is { '@type': 'Person', name: 'Miisa Jeremejew' }
+    And the first entry is { '@type': 'Person', name: 'Miisa Jeremejew' }
+    And the second entry is { '@type': 'Person', '@id': 'https://laurilavanti.fi/fi/about/#person' }
     And there are exactly two <meta property="article:author"> tags in the HTML
+    And the first meta content is 'Miisa Jeremejew'
+    And the second meta content is 'Lauri Lavanti'
 
   # ── Co-author byline rendering ───────────────────────────────────────────────
 
@@ -116,13 +119,14 @@ Feature: Canonical Person JSON-LD entity
 
   Scenario: Shared-role byline for co-authors with identical role and place
     Given a BlogPosting in lang 'en' with authors:
-      | name              | role                                     | place       |
-      | lauri             | Municipal councillor (Greens)            | Kirkkonummi |
+      | entry             | role                                     | place       |
       | Miisa Jeremejew   | Municipal councillor (Greens)            | Kirkkonummi |
+      | 'lauri' (string)  | Municipal councillor (Greens)            | Kirkkonummi |
     When the page is rendered
     Then the byline after the post content is:
-      _Authors: Lauri Lavanti and Miisa Jeremejew, Municipal councillor (Greens), Kirkkonummi._
+      _Authors: Miisa Jeremejew and Lauri Lavanti, Municipal councillor (Greens), Kirkkonummi._
     And the byline is rendered as an italic paragraph
+    And render order follows frontmatter array order (first entry → first name)
 
   Scenario: Shared-role byline localises prefix in Finnish
     Given a BlogPosting in lang 'fi' with two co-authors sharing the same role and place
@@ -149,10 +153,10 @@ Feature: Canonical Person JSON-LD entity
     Then that author appears in the byline as name only (no parenthetical)
 
   Scenario: Lauri's defaults apply when his entry omits role/place
-    Given a BlogPosting in lang 'en' with authors: ['lauri', { name: 'Co-author', role: 'Some role', place: 'Some place' }]
-    And Lauri's entry has no explicit role or place
+    Given a BlogPosting in lang 'en' with authors: [{ name: 'Co-author', role: 'Some role', place: 'Some place' }, 'lauri']
+    And Lauri's entry (the string sentinel 'lauri') has no explicit role or place
     When the page is rendered
-    Then Lauri's name appears with his default jobTitle[lang] and 'Kirkkonummi' as role/place in the per-author format
+    Then Lauri's name appears with his default jobTitle['en'] and 'Kirkkonummi' as role/place in the per-author format
 
   # ── knowsAbout localisation ──────────────────────────────────────────────────
 
@@ -167,20 +171,71 @@ Feature: Canonical Person JSON-LD entity
     When the Person (or mainEntity) is emitted
     Then Person.knowsAbout contains Finnish-language topic strings
 
+  Scenario: knowsAbout uses Swedish for sv locale
+    Given an About page or BlogPosting in lang 'sv'
+    When the Person (or mainEntity) is emitted
+    Then Person.knowsAbout contains Swedish-language topic strings
+    And does NOT contain Finnish-only strings (e.g. 'Talouspolitiikka')
+
+  # ── Wikipedia link on About pages ────────────────────────────────────────────
+
+  Scenario: Wikipedia link visible on all About pages
+    Given any About page (fi/en/sv) after migration
+    When the page is rendered
+    Then the page body contains a visible hyperlink to 'https://fi.wikipedia.org/wiki/Lauri_Lavanti'
+
+  # ── WebSite / default type regression ────────────────────────────────────────
+
+  Scenario: WebSite type pages unaffected by refactor
+    Given a page rendered with no explicit type (defaults to WebSite)
+    When the page is rendered
+    Then the JSON-LD contains @type: 'WebSite'
+    And the JSON-LD contains name: 'Lauri Lavanti'
+    And the JSON-LD contains sameAs with all 9 URLs (7 social + Wikipedia + Wikidata)
+
   # ── Co-authored posts migration ──────────────────────────────────────────────
 
-  Scenario: Migrated co-authored post has no inline byline in content
-    Given post 56 (Lähteelä) in any locale after migration
-    When the MDX content is read
-    Then there is no line matching the pattern _Authors:…_ in the MDX body
-    And there is no line matching the pattern _Tekijät:…_ in the MDX body
-    And there is no line matching the pattern _Författare:…_ in the MDX body
-    And publication-info lines (_Published in…_ / _Julkaistu…_ / _Publicerad…_) remain unchanged
+  Scenario: All 5 co-authored posts have authors frontmatter in all 3 locales
+    Given posts 22, 27, 41, 48, 56 in all three locales (fi/en/sv) after migration
+    When each MDX frontmatter is read
+    Then each post has an authors field listing the correct co-authors:
+      | post | authors (in array order)                                      |
+      | 22   | Johanna Fleming, Lauri Lavanti, Paula Oittinen                |
+      | 27   | Johanna Fleming, Lauri Lavanti, Paula Oittinen                |
+      | 41   | Ronja Karkinen, Lauri Lavanti                                 |
+      | 48   | Atte Harjanne, Lauri Lavanti                                  |
+      | 56   | Miisa Jeremejew, Lauri Lavanti                                |
 
-  Scenario: Migrated post renders auto-byline identically to former manual byline
+  Scenario: Migrated en posts have no inline Authors line in MDX body
+    Given posts 22, 27, 41, 48, 56 in lang 'en' after migration
+    When the MDX content is read
+    Then none contains a line matching _Authors:…_ in the body
+    And publication-info lines (_Published in…_) remain unchanged
+
+  Scenario: Migrated fi/sv posts had no inline Authors line to begin with
+    Given posts 22, 27, 41, 48, 56 in lang 'fi' or 'sv' after migration
+    When the MDX content is read
+    Then none contains a line matching _Tekijät:…_ or _Författare:…_ in the body
+
+  Scenario: Migrated post 56 renders auto-byline identically to former manual en byline
     Given post 56 (Lähteelä) in lang 'en' after migration
+    And authors frontmatter: [{ name: 'Miisa Jeremejew', role: 'municipal councillors (Greens)', place: 'Kirkkonummi' }, 'lauri']
     When the page is rendered
     Then the byline reads: _Authors: Miisa Jeremejew and Lauri Lavanti, municipal councillors (Greens), Kirkkonummi._
+    And is rendered as an italic paragraph after the post body
+
+  Scenario: Migrated post 41 renders name-only byline (no role/place in original)
+    Given post 41 (public transport) in lang 'en' after migration
+    And authors frontmatter: [{ name: 'Ronja Karkinen' }, 'lauri']
+    When the page is rendered
+    Then the byline reads: _Authors: Ronja Karkinen and Lauri Lavanti._
+    And is rendered as an italic paragraph after the post body
+
+  Scenario: Migrated post 22 renders three-author name-only byline
+    Given post 22 in lang 'en' after migration
+    And authors frontmatter: [{ name: 'Johanna Fleming' }, 'lauri', { name: 'Paula Oittinen' }]
+    When the page is rendered
+    Then the byline reads: _Authors: Johanna Fleming, Lauri Lavanti, and Paula Oittinen._
     And is rendered as an italic paragraph after the post body
 ```
 
@@ -217,16 +272,28 @@ type ResolvedAuthor =
   | { '@type': 'Person'; '@id': string }                   // Lauri → id ref
   | { '@type': 'Person'; name: string; url?: string; sameAs?: string[] }  // co-author
 
-// Byline rendering decision:
-// If all authors (after defaults applied) share identical role AND place
-//   → "Authors: A and B, role, place."  (Lähteelä style)
-// If any role OR place differs
-//   → "Authors: A (role_a, place_a) and B (role_b, place_b)."
-// If an author has no role/place → name only in list
-// Lauri's defaults (when his entry omits role/place):
-//   role = personJobTitle[lang], place = 'Kirkkonummi'
-// Byline prefix per lang: 'en' → 'Authors:', 'fi' → 'Tekijät:', 'sv' → 'Författare:'
-// Byline is italic (<em>), ends with period, rendered as a paragraph
+// Byline rendering rules:
+// - Render order = frontmatter array order (first entry → first name).
+// - String sentinel 'lauri' resolves to name 'Lauri Lavanti';
+//   its default role = personJobTitle[lang], default place = 'Kirkkonummi'
+//   (only used when the entry itself has no explicit role/place).
+// - Shared-suffix format (Lähteelä style):
+//     "Authors: A and B, role, place."
+//   Used when ALL resolved authors have identical role AND place strings (exact equality, incl. case/whitespace).
+// - Per-author format:
+//     "Authors: A (role_a, place_a) and B (role_b, place_b)."
+//   Used when any role OR place differs.
+// - Name-only: if an author has no role and no place → appears as name only, no parenthetical.
+//   If ALL authors are name-only → byline ends after the name list with no suffix:
+//     "Authors: A, B, and C."
+// - Three-author Oxford comma: "A, B, and C." (not "A and B and C")
+// - Byline prefix per lang: 'en' → 'Authors:', 'fi' → 'Tekijät:', 'sv' → 'Författare:'
+// - Byline is an italic paragraph (<p><em>…</em></p>), ends with period.
+
+// <meta property="article:author"> content:
+// - For 'lauri' sentinel → content = 'Lauri Lavanti'
+// - For inline co-author object → content = the entry's name field
+// - Emit one tag per author, in frontmatter array order.
 
 // Person image: Cloudinary URL
 // src: 'Lauri-Lavanti-seisoo-suorassa-sinisella-taustalla'
@@ -274,3 +341,4 @@ type ResolvedAuthor =
 | Date | Change |
 |------|--------|
 | 2026-05-23 | Initial draft |
+| 2026-05-23 | Fix Critic findings: name-order rule (array order), article:author content spec, migration scenarios for all 5 posts, Wikipedia link scenario, WebSite regression scenario, sv knowsAbout scenario, byline Oxford-comma + name-only rules |

--- a/.agents/specs/seo/jsonld-person.md
+++ b/.agents/specs/seo/jsonld-person.md
@@ -1,0 +1,276 @@
+# Spec: Canonical Person + ProfilePage JSON-LD with co-author support
+
+> **Pattern**: [The Spec](https://asdlc.io/patterns/the-spec) — Living document, permanent source of truth.
+> **Status**: `Active`
+> **Last updated**: 2026-05-23
+
+---
+
+## Intent
+
+Search engines, LLMs, and answer engines (Google AI Overviews, ChatGPT, Perplexity, Gemini) rely on schema.org structured data to identify and attach authority to real-world entities. Currently laurilavanti.fi emits a `Person` schema on About pages, but it lacks a stable `@id`, misses key authority signals (Wikipedia, Wikidata, employer, education, localized expertise), and every `BlogPosting.author` is a bare name stub with no entity link. This prevents LLMs from confidently resolving "Lauri Lavanti" as the same entity across pages and external knowledge sources.
+
+This spec defines: a canonical `Person` entity with a stable `@id`, a `ProfilePage` wrapper for About pages (2025/2026 best practice per Google Search Central), entity-by-id references on all `BlogPosting` author fields, and optional co-author support with auto-rendered bylines.
+
+The goal is maximum E-E-A-T entity reconciliation: LLMs and answer engines should attach Lauri Lavanti as an authority on artificial intelligence, digital independence, technology, and politics.
+
+---
+
+## Scope
+
+### In scope
+- `src/content/person.ts` — new file, single source of truth for all canonical Person data
+- `PERSON_ID = 'https://laurilavanti.fi/fi/about/#person'` — stable entity identifier; `id="person"` anchor added to FI About page to make fragment resolvable
+- `src/lib/jsonld.ts` — add `PROFILEPAGE = 'ProfilePage'` constant
+- `src/components/Head.astro` — consume `person.ts`; emit `ProfilePage > mainEntity Person` branch; emit `BlogPosting.author` as Person id-reference array; emit `<meta property="article:author">` once per author
+- `src/lib/mdxPosts.ts` — add optional `authors` field to `MdxPost` interface
+- `src/layouts/PostLayout.astro` — auto-rendered co-author byline after `<slot />` when `authors.length > 1`
+- About-page frontmatter: `type: 'Person'` → `'ProfilePage'` in fi/en/sv
+- Visible Wikipedia link sentence on all three About pages
+- Migrate hand-written `_Authors:…_` lines to `authors` frontmatter on 5 co-authored posts (× 3 locales = 15 files):
+  - post 22 — Johanna Fleming, Lauri Lavanti, Paula Oittinen
+  - post 27 — Johanna Fleming, Lauri Lavanti, Paula Oittinen
+  - post 41 — Ronja Karkinen, Lauri Lavanti
+  - post 48 — Atte Harjanne, Lauri Lavanti
+  - post 56 — Miisa Jeremejew, Lauri Lavanti
+- Tests: `Head.spec.ts`, `jsonld.spec.ts`
+
+### Out of scope
+- Editing Wikipedia (adding citations or sameAs links from Wikipedia to this site)
+- `Organization` schema for the site itself
+- `disambiguatingDescription` (no known namesakes)
+- Backfilling `authors` on posts beyond the five listed above
+
+---
+
+## Contract
+
+```gherkin
+Feature: Canonical Person JSON-LD entity
+
+  # ── Person source of truth ──────────────────────────────────────────────────
+
+  Scenario: person.ts exports canonical Person data
+    Given src/content/person.ts exists
+    Then it exports PERSON_ID = 'https://laurilavanti.fi/fi/about/#person'
+    And it exports personGivenName = 'Lauri', personFamilyName = 'Lavanti'
+    And it exports personBirthDate = '1991-10-01'
+    And it exports personBirthPlace as a Place with name 'Jyväskylä'
+    And it exports personNationality as a Country with name 'FI'
+    And it exports personWorksFor as Organization { name: 'OP', url: 'https://www.op.fi/' }
+    And it exports personAlumniOf as an array of 3 educational orgs (Aalto-yliopisto, Omnia, Masalan lukio)
+    And it exports personSameAs containing 'https://fi.wikipedia.org/wiki/Lauri_Lavanti'
+    And it exports personSameAs containing 'https://www.wikidata.org/wiki/Q139711658'
+    And personSameAs does NOT contain 'https://digitaalinenitsenaisyys.fi/'
+    And it exports personAffiliation containing { '@type': 'Organization', name: 'Digitaalinen itsenäisyys -kansalaisaloite', url: 'https://digitaalinenitsenaisyys.fi/' }
+    And it exports personKnowsAbout as a Record<Lang, string[]> with distinct values per locale
+    And it exports personHasOccupation as a Record<Lang, array> with two Occupation entries (politician, lead developer)
+    And personImage is a Cloudinary URL built with c_fill, g_north (top-anchored), 1200×1200 from 'Lauri-Lavanti-seisoo-suorassa-sinisella-taustalla'
+
+  # ── ProfilePage on About pages ───────────────────────────────────────────────
+
+  Scenario: About page emits ProfilePage with canonical Person
+    Given an About page (fi/en/sv) with frontmatter type: 'ProfilePage'
+    When the page is rendered
+    Then the JSON-LD contains @type: 'ProfilePage'
+    And the JSON-LD contains mainEntity with @type: 'Person'
+    And mainEntity['@id'] = 'https://laurilavanti.fi/fi/about/#person'
+    And mainEntity contains name, givenName, familyName, birthDate, birthPlace, nationality
+    And mainEntity contains worksFor, alumniOf (3 entries), memberOf, affiliation
+    And mainEntity contains knowsAbout localised to the page's lang
+    And mainEntity contains hasOccupation localised to the page's lang
+    And mainEntity contains knowsLanguage: ['fi', 'en', 'sv']
+    And mainEntity.sameAs includes Wikipedia and Wikidata URLs
+    And mainEntity.sameAs does NOT include 'https://digitaalinenitsenaisyys.fi/'
+    And mainEntity.image is a Cloudinary URL with g_north crop, 1200×1200
+
+  Scenario: PERSON_ID fragment resolves on FI About page
+    Given the FI About page at /fi/about/
+    When the HTML is rendered
+    Then an element with id="person" exists in the page (wrapping the bio/hero section)
+    And navigating to /fi/about/#person anchors to that element
+
+  # ── BlogPosting author ────────────────────────────────────────────────────────
+
+  Scenario: Solo-authored post references Person by id
+    Given a BlogPosting with no authors frontmatter field
+    When the page is rendered
+    Then BlogPosting.author is an array with one entry
+    And that entry is { '@type': 'Person', '@id': 'https://laurilavanti.fi/fi/about/#person' }
+    And there is exactly one <meta property="article:author"> in the HTML
+
+  Scenario: Co-authored post references multiple Persons
+    Given a BlogPosting with authors: ['lauri', { name: 'Miisa Jeremejew', role: 'Kunnanvaltuutettu (Vihreät)', place: 'Kirkkonummi' }]
+    When the page is rendered
+    Then BlogPosting.author is an array with two entries
+    And the first entry is { '@type': 'Person', '@id': 'https://laurilavanti.fi/fi/about/#person' }
+    And the second entry is { '@type': 'Person', name: 'Miisa Jeremejew' }
+    And there are exactly two <meta property="article:author"> tags in the HTML
+
+  # ── Co-author byline rendering ───────────────────────────────────────────────
+
+  Scenario: No byline rendered for solo-authored post
+    Given a BlogPosting with no authors frontmatter field (or authors: ['lauri'])
+    When the page is rendered
+    Then no author byline element appears after the post content
+
+  Scenario: Shared-role byline for co-authors with identical role and place
+    Given a BlogPosting in lang 'en' with authors:
+      | name              | role                                     | place       |
+      | lauri             | Municipal councillor (Greens)            | Kirkkonummi |
+      | Miisa Jeremejew   | Municipal councillor (Greens)            | Kirkkonummi |
+    When the page is rendered
+    Then the byline after the post content is:
+      _Authors: Lauri Lavanti and Miisa Jeremejew, Municipal councillor (Greens), Kirkkonummi._
+    And the byline is rendered as an italic paragraph
+
+  Scenario: Shared-role byline localises prefix in Finnish
+    Given a BlogPosting in lang 'fi' with two co-authors sharing the same role and place
+    When the page is rendered
+    Then the byline begins with "Tekijät:"
+
+  Scenario: Shared-role byline localises prefix in Swedish
+    Given a BlogPosting in lang 'sv' with two co-authors sharing the same role and place
+    When the page is rendered
+    Then the byline begins with "Författare:"
+
+  Scenario: Per-author byline when roles differ
+    Given a BlogPosting in lang 'en' with authors:
+      | name              | role                    | place       |
+      | lauri             | Lead developer          | Helsinki    |
+      | Atte Harjanne     | Member of Parliament    | Helsinki    |
+    When the page is rendered
+    Then the byline uses per-author format:
+      _Authors: Lauri Lavanti (Lead developer, Helsinki) and Atte Harjanne (Member of Parliament, Helsinki)._
+
+  Scenario: Author with no role/place shows name only in byline
+    Given a BlogPosting with a co-author entry that has no role or place
+    When the page is rendered
+    Then that author appears in the byline as name only (no parenthetical)
+
+  Scenario: Lauri's defaults apply when his entry omits role/place
+    Given a BlogPosting in lang 'en' with authors: ['lauri', { name: 'Co-author', role: 'Some role', place: 'Some place' }]
+    And Lauri's entry has no explicit role or place
+    When the page is rendered
+    Then Lauri's name appears with his default jobTitle[lang] and 'Kirkkonummi' as role/place in the per-author format
+
+  # ── knowsAbout localisation ──────────────────────────────────────────────────
+
+  Scenario: knowsAbout uses correct locale
+    Given an About page or BlogPosting in lang 'en'
+    When the Person (or mainEntity) is emitted
+    Then Person.knowsAbout contains English-language topic strings
+    And does NOT contain Finnish-only strings (e.g. 'Talouspolitiikka')
+
+  Scenario: knowsAbout uses Finnish for fi locale
+    Given an About page or BlogPosting in lang 'fi'
+    When the Person (or mainEntity) is emitted
+    Then Person.knowsAbout contains Finnish-language topic strings
+
+  # ── Co-authored posts migration ──────────────────────────────────────────────
+
+  Scenario: Migrated co-authored post has no inline byline in content
+    Given post 56 (Lähteelä) in any locale after migration
+    When the MDX content is read
+    Then there is no line matching the pattern _Authors:…_ in the MDX body
+    And there is no line matching the pattern _Tekijät:…_ in the MDX body
+    And there is no line matching the pattern _Författare:…_ in the MDX body
+    And publication-info lines (_Published in…_ / _Julkaistu…_ / _Publicerad…_) remain unchanged
+
+  Scenario: Migrated post renders auto-byline identically to former manual byline
+    Given post 56 (Lähteelä) in lang 'en' after migration
+    When the page is rendered
+    Then the byline reads: _Authors: Miisa Jeremejew and Lauri Lavanti, municipal councillors (Greens), Kirkkonummi._
+    And is rendered as an italic paragraph after the post body
+```
+
+---
+
+## Data Model
+
+```typescript
+// src/content/person.ts
+
+export const PERSON_ID = 'https://laurilavanti.fi/fi/about/#person'
+
+// Co-author entry in post frontmatter
+// String shorthand 'lauri' resolves to the canonical PERSON_ID reference
+export type AuthorEntry =
+  | 'lauri'
+  | {
+      name: string
+      url?: string
+      sameAs?: string[]
+      role?: string   // localized role/title string; omit for name-only byline
+      place?: string  // city/region; omit for name-only byline
+    }
+
+// Added to MdxPost in src/lib/mdxPosts.ts
+// When absent, implementation defaults to ['lauri']
+interface MdxPost {
+  // … existing fields …
+  authors?: AuthorEntry[]
+}
+
+// Resolved author for JSON-LD emission
+type ResolvedAuthor =
+  | { '@type': 'Person'; '@id': string }                   // Lauri → id ref
+  | { '@type': 'Person'; name: string; url?: string; sameAs?: string[] }  // co-author
+
+// Byline rendering decision:
+// If all authors (after defaults applied) share identical role AND place
+//   → "Authors: A and B, role, place."  (Lähteelä style)
+// If any role OR place differs
+//   → "Authors: A (role_a, place_a) and B (role_b, place_b)."
+// If an author has no role/place → name only in list
+// Lauri's defaults (when his entry omits role/place):
+//   role = personJobTitle[lang], place = 'Kirkkonummi'
+// Byline prefix per lang: 'en' → 'Authors:', 'fi' → 'Tekijät:', 'sv' → 'Författare:'
+// Byline is italic (<em>), ends with period, rendered as a paragraph
+
+// Person image: Cloudinary URL
+// src: 'Lauri-Lavanti-seisoo-suorassa-sinisella-taustalla'
+// crop: { type: 'fill', gravity: 'north' }  ← g_north, top-anchored
+// width: 1200, height: 1200
+
+// sameAs array (complete):
+// 1. https://bsky.app/profile/laurilavanti.fi
+// 2. https://www.facebook.com/laurilavanti
+// 3. https://www.instagram.com/laurilavanti/
+// 4. https://www.linkedin.com/in/lapanti
+// 5. https://mastodon.social/@laurilavanti
+// 6. https://www.threads.com/@laurilavanti
+// 7. https://www.tiktok.com/@laurilavanti
+// 8. https://fi.wikipedia.org/wiki/Lauri_Lavanti
+// 9. https://www.wikidata.org/wiki/Q139711658
+```
+
+---
+
+## Dependencies
+
+- [seo/spec.md](./spec.md) — overarching SEO strategy for laurilavanti.fi; this spec extends it with entity/E-E-A-T concerns
+
+---
+
+## Anti-patterns
+
+- **Do not** put `digitaalinenitsenaisyys.fi` in `sameAs` — it is a multi-author citizen initiative, not a canonical URL for Lauri Lavanti. Use `affiliation` instead.
+- **Do not** repeat the full Person object on every `BlogPosting` — emit a bare `{ '@type': 'Person', '@id': PERSON_ID }` reference. Duplicating the full object risks entity fragmentation across pages.
+- **Do not** use `g_center` (default Cloudinary gravity) for the Person image — the face will be cropped on square format. Always specify `gravity: 'north'`.
+- **Do not** hardcode person data in `Head.astro` — all Person constants must come from `src/content/person.ts` to keep a single source of truth.
+- **Do not** compare role/place with case-insensitive or trimmed equality for the shared-suffix byline decision — use exact string equality. If strings differ by even whitespace, use per-author format; let the content author standardise.
+
+---
+
+## Open Questions
+
+*(none — all decisions resolved in planning)*
+
+---
+
+## Changelog
+
+| Date | Change |
+|------|--------|
+| 2026-05-23 | Initial draft |

--- a/src/components/Byline.astro
+++ b/src/components/Byline.astro
@@ -1,9 +1,15 @@
 ---
+import type { AuthorEntry } from '../content/person'
+
+import { buildBylineText } from '../lib/byline'
+
 interface Props {
-    text: string
+    authors: AuthorEntry[]
+    lang: 'en' | 'fi' | 'sv'
 }
 
-const { text } = Astro.props
+const { authors, lang } = Astro.props
+const text = buildBylineText(authors, lang)
 ---
 
 <style>
@@ -12,4 +18,10 @@ const { text } = Astro.props
         margin-block: 0;
     }
 </style>
-<p><em>{text}</em></p>
+{
+    text && (
+        <p>
+            <em>{text}</em>
+        </p>
+    )
+}

--- a/src/components/Byline.astro
+++ b/src/components/Byline.astro
@@ -1,0 +1,15 @@
+---
+interface Props {
+    text: string
+}
+
+const { text } = Astro.props
+---
+
+<style>
+    p {
+        grid-column-start: 3;
+        margin-block: 0;
+    }
+</style>
+<p><em>{text}</em></p>

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -1,6 +1,28 @@
 ---
 import type { Lang } from '../content/nav'
+import type { AuthorEntry } from '../content/person'
 
+import {
+    PERSON_ID,
+    personAffiliation,
+    personAlumniOf,
+    personBirthDate,
+    personBirthPlace,
+    personDescription,
+    personFamilyName,
+    personGivenName,
+    personHasOccupation,
+    personImage,
+    personJobTitle,
+    personKnowsAbout,
+    personKnowsLanguage,
+    personMemberOf,
+    personName,
+    personNationality,
+    personSameAs,
+    personUrl,
+    personWorksFor,
+} from '../content/person'
 import {
     BLOGPOSTING,
     type BreadcrumbItem,
@@ -8,11 +30,13 @@ import {
     JSON_LD_TYPES,
     type JsonLdType,
     PERSON,
+    PROFILEPAGE,
     WEBPAGE,
     WEBSITE,
 } from '../lib/jsonld'
 
 interface Props {
+    authors?: AuthorEntry[]
     breadcrumbs?: BreadcrumbItem[]
     createdAt?: string
     description?: string
@@ -29,10 +53,11 @@ interface Props {
 }
 
 const {
+    authors,
     breadcrumbs,
     description = 'Lauri Lavanti on diplomi-insinööri, johtava ohjelmistokehittäjä ja Kirkkonummen kunnanvaltuutettu (Vihreät). Hän keskittyy digitalisaatioon, yksityisyyden suojaan, tekoälyn vastuulliseen käyttöönottoon ja talouteen.',
     faq,
-    lang = 'fi',
+    lang: rawLang = 'fi',
     langAlternates,
     noindex,
     title,
@@ -43,6 +68,8 @@ const {
     createdAt,
     updatedAt,
 } = Astro.props
+
+const lang: Lang = rawLang
 
 const ogLocale: Record<Lang, string> = {
     en: 'en_GB',
@@ -79,89 +106,95 @@ const canonical = !noindex && (slug === 'index' ? Astro.site : slug ? new URL(`$
 
 const ogImageUrl = ogImage ?? null
 
-const name = 'Lauri Lavanti'
+const resolvedAuthors = (authors ?? (['lauri'] as AuthorEntry[])).map((entry: AuthorEntry) => {
+    if (entry === 'lauri') {
+        return { '@id': PERSON_ID, '@type': 'Person' as const }
+    }
+    return {
+        '@type': 'Person' as const,
+        name: entry.name,
+        ...(entry.url ? { url: entry.url } : {}),
+        ...(entry.sameAs ? { sameAs: entry.sameAs } : {}),
+    }
+})
 
-const bluesky = 'https://bsky.app/profile/laurilavanti.fi'
-const facebook = 'https://www.facebook.com/laurilavanti'
-const instagram = 'https://www.instagram.com/laurilavanti/'
-const linkedIn = 'https://www.linkedin.com/in/lapanti'
-const mastodon = 'https://mastodon.social/@laurilavanti'
-const threads = 'https://www.threads.com/@laurilavanti'
-const tikTok = 'https://www.tiktok.com/@laurilavanti'
+const articleAuthorNames = (authors ?? (['lauri'] as AuthorEntry[])).map((entry: AuthorEntry) =>
+    entry === 'lauri' ? personName : entry.name
+)
 
-const personJobTitle: Record<Lang, string> = {
-    en: 'Municipal councillor & Lead Developer',
-    fi: 'Kunnanvaltuutettu ja johtava ohjelmistokehittäjä',
-    sv: 'Kommunfullmäktigeledamot och ledande mjukvarutvecklare',
+const canonicalPersonObject = {
+    '@id': PERSON_ID,
+    '@type': 'Person',
+    affiliation: personAffiliation,
+    alumniOf: personAlumniOf,
+    birthDate: personBirthDate,
+    birthPlace: personBirthPlace,
+    description: personDescription[lang],
+    familyName: personFamilyName,
+    givenName: personGivenName,
+    hasOccupation: personHasOccupation[lang],
+    image: personImage,
+    jobTitle: personJobTitle[lang],
+    knowsAbout: personKnowsAbout[lang],
+    knowsLanguage: personKnowsLanguage,
+    memberOf: personMemberOf,
+    name: personName,
+    nationality: personNationality,
+    sameAs: personSameAs,
+    url: personUrl,
+    worksFor: personWorksFor,
 }
 
-const personDescription: Record<Lang, string> = {
-    en: 'Municipal councillor in Kirkkonummi (Greens) and lead software developer. Focused on economics, entrepreneurship, digital independence, and responsible AI policy.',
-    fi: 'Kirkkonummen kunnanvaltuutettu (Vihreät) ja johtava ohjelmistokehittäjä. Keskittyy talouteen, yrittäjyyteen, digitaaliseen itsenäisyyteen ja vastuulliseen tekoälypolitiikkaan. Seuraa eduskuntavaaleja.',
-    sv: 'Kommunfullmäktigeledamot i Kyrkslätt (De Gröna) och ledande mjukvarutvecklare. Fokuserar på ekonomi, företagande, digital självständighet och ansvarsfull AI-politik. Följer riksdagsvalen.',
-}
-
-const sameAs = [bluesky, facebook, instagram, linkedIn, mastodon, threads, tikTok]
-
-const jsonLd = JSON.stringify({
-    '@context': 'https://schema.org',
-    '@type': type && JSON_LD_TYPES.includes(type) ? type : WEBSITE,
-    author: {
-        '@type': 'Person',
-        name,
-    },
-    description,
-    headline: title,
-    license: 'https://creativecommons.org/licenses/by-sa/4.0/',
-    url: canonical,
-    ...(ogImageUrl ? { image: ogImageUrl } : {}),
-    ...(type === BLOGPOSTING
+const jsonLd = JSON.stringify(
+    type === PROFILEPAGE
         ? {
-              ...(ogImageUrl
+              '@context': 'https://schema.org',
+              '@type': PROFILEPAGE,
+              ...(updatedAt ? { dateModified: updatedAt } : {}),
+              description,
+              mainEntity: canonicalPersonObject,
+              name: title,
+              url: canonical,
+          }
+        : {
+              '@context': 'https://schema.org',
+              '@type': type && JSON_LD_TYPES.includes(type) ? type : WEBSITE,
+              author: isArticle ? resolvedAuthors : { '@type': 'Person', name: personName },
+              description,
+              headline: title,
+              license: 'https://creativecommons.org/licenses/by-sa/4.0/',
+              url: canonical,
+              ...(ogImageUrl ? { image: ogImageUrl } : {}),
+              ...(type === BLOGPOSTING
                   ? {
-                        image: { '@type': 'ImageObject', height: 630, url: ogImageUrl, width: 1200 },
-                        primaryImageOfPage: { '@type': 'ImageObject', height: 630, url: ogImageUrl, width: 1200 },
+                        ...(ogImageUrl
+                            ? {
+                                  image: { '@type': 'ImageObject', height: 630, url: ogImageUrl, width: 1200 },
+                                  primaryImageOfPage: {
+                                      '@type': 'ImageObject',
+                                      height: 630,
+                                      url: ogImageUrl,
+                                      width: 1200,
+                                  },
+                              }
+                            : {}),
+                        dateModified: updatedAt ?? createdAt,
+                        datePublished: createdAt,
+                        mainEntityOfPage: {
+                            '@id': canonical,
+                            '@type': WEBPAGE,
+                        },
                     }
                   : {}),
-              dateModified: updatedAt ?? createdAt,
-              datePublished: createdAt,
-              mainEntityOfPage: {
-                  '@id': canonical,
-                  '@type': WEBPAGE,
-              },
+              ...(type === WEBSITE
+                  ? {
+                        name: personName,
+                        sameAs: personSameAs,
+                    }
+                  : {}),
+              ...(type === PERSON ? { ...canonicalPersonObject } : {}),
           }
-        : {}),
-    ...(type === WEBSITE
-        ? {
-              name,
-              sameAs,
-          }
-        : {}),
-    ...(type === PERSON
-        ? {
-              description: personDescription[lang],
-              jobTitle: personJobTitle[lang],
-              knowsAbout: [
-                  'Talouspolitiikka',
-                  'Yrittäjyys',
-                  'Innovaatiopolitiikka',
-                  'Digitaalinen itsenäisyys',
-                  'Digitaalinen riippumattomuus',
-                  'Tekoäly',
-                  'Vastuullinen tekoäly',
-                  'Vihreä siirtymä',
-                  'Eduskuntavaalit',
-              ],
-              memberOf: {
-                  '@type': 'PoliticalParty',
-                  name: 'Vihreä liitto',
-                  url: 'https://www.vihreat.fi',
-              },
-              name,
-              sameAs,
-          }
-        : {}),
-})
+)
 
 const faqJsonLd =
     faq && faq.length >= 2
@@ -198,16 +231,16 @@ const breadcrumbJsonLd =
 {noindex && <meta content="noindex, nofollow" name="robots" />}
 <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport" />
 <meta content={title} property="og:title" />
-<meta content={name} name="author" />
+<meta content={personName} name="author" />
 <meta content={ogLocale[lang]} property="og:locale" />
 {ogLocaleAlternates.map((loc) => <meta content={loc} property="og:locale:alternate" />)}
 <meta content={description} name="description" />
 <meta content={description} property="og:description" />
-<meta content={name} property="og:site_name" />
+<meta content={personName} property="og:site_name" />
 <meta content={title} property="twitter:title" />
 <meta content={isArticle ? 'article' : 'website'} property="og:type" />
 <meta content={description} name="twitter:description" />
-{isArticle && <meta content={name} property="article:author" />}
+{isArticle && articleAuthorNames.map((n: string) => <meta content={n} property="article:author" />)}
 {isArticle && <meta content={createdAt} property="article:published_time" />}
 {isArticle && updatedAt && <meta content={updatedAt} property="article:modified_time" />}
 <meta content="@laurilavanti@mastodon.social" name="fediverse:creator" />

--- a/src/components/Head.spec.ts
+++ b/src/components/Head.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { renderAstroComponent } from '../../tests/helpers'
+import { PERSON_ID } from '../content/person'
 import Head from './Head.astro'
 
 describe('<Head />', () => {
@@ -88,6 +89,86 @@ describe('<Head />', () => {
         expect(jsonLd['@type']).toBe('BlogPosting')
         expect(jsonLd.datePublished).toBe('2024-01-01')
         expect(jsonLd.dateModified).toBe('2024-01-02')
+    })
+
+    it('should emit author as array with @id reference for BlogPosting (default sole author)', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                createdAt: '2024-01-01',
+                title: 'Test Blog Post',
+                type: 'BlogPosting',
+            },
+        })
+
+        const jsonLdScript = result.querySelector('script[type="application/ld+json"]')
+        const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
+        expect(jsonLd['@type']).toBe('BlogPosting')
+        expect(Array.isArray(jsonLd.author)).toBe(true)
+        expect(jsonLd.author).toHaveLength(1)
+        expect(jsonLd.author[0]['@id']).toBe(PERSON_ID)
+        expect(jsonLd.author[0]['@type']).toBe('Person')
+        expect(jsonLd.author[0].name).toBeUndefined()
+    })
+
+    it('should emit author array with co-author inline Person for BlogPosting', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                authors: [
+                    {
+                        name: 'Co-author',
+                        sameAs: ['https://example.com/co-author'],
+                        url: 'https://example.com/co-author',
+                    },
+                    'lauri',
+                ],
+                createdAt: '2024-01-01',
+                title: 'Co-authored Post',
+                type: 'BlogPosting',
+            },
+        })
+
+        const jsonLdScript = result.querySelector('script[type="application/ld+json"]')
+        const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
+        expect(jsonLd['@type']).toBe('BlogPosting')
+        expect(Array.isArray(jsonLd.author)).toBe(true)
+        expect(jsonLd.author).toHaveLength(2)
+        expect(jsonLd.author[0]['@type']).toBe('Person')
+        expect(jsonLd.author[0].name).toBe('Co-author')
+        expect(jsonLd.author[0].url).toBe('https://example.com/co-author')
+        expect(jsonLd.author[0]['@id']).toBeUndefined()
+        expect(jsonLd.author[1]['@id']).toBe(PERSON_ID)
+        expect(jsonLd.author[1].name).toBeUndefined()
+    })
+
+    it('should emit one article:author meta for sole-author BlogPosting', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                createdAt: '2024-01-01',
+                title: 'Test Blog Post',
+                type: 'BlogPosting',
+            },
+        })
+
+        const metas = Array.from(result.querySelectorAll('meta[property="article:author"]'))
+        expect(metas).toHaveLength(1)
+        expect(metas[0].getAttribute('content')).toBe('Lauri Lavanti')
+    })
+
+    it('should emit multiple article:author metas for co-authored BlogPosting', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                authors: [{ name: 'Co-author' }, 'lauri'],
+                createdAt: '2024-01-01',
+                title: 'Co-authored Post',
+                type: 'BlogPosting',
+            },
+        })
+
+        const metas = Array.from(result.querySelectorAll('meta[property="article:author"]'))
+        expect(metas).toHaveLength(2)
+        const contents = metas.map((m) => m.getAttribute('content'))
+        expect(contents).toContain('Co-author')
+        expect(contents).toContain('Lauri Lavanti')
     })
 
     it('should emit a secondary FAQPage JSON-LD script when faq has 2 or more entries', async () => {
@@ -280,13 +361,30 @@ describe('<Head />', () => {
         const jsonLdScript = result.querySelector('script[type="application/ld+json"]')
         const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
         expect(jsonLd['@type']).toBe('Person')
+        expect(jsonLd['@id']).toBe(PERSON_ID)
         expect(jsonLd.name).toBe('Lauri Lavanti')
+        expect(jsonLd.givenName).toBe('Lauri')
+        expect(jsonLd.familyName).toBe('Lavanti')
+        expect(jsonLd.url).toBe('https://laurilavanti.fi/fi/')
+        expect(jsonLd.birthDate).toBe('1991-10-01')
+        expect(jsonLd.birthPlace).toEqual({ '@type': 'Place', name: 'Jyväskylä' })
+        expect(jsonLd.nationality).toEqual({ '@type': 'Country', name: 'FI' })
         expect(jsonLd.jobTitle).toBe('Kunnanvaltuutettu ja johtava ohjelmistokehittäjä')
-        expect(jsonLd.sameAs).toHaveLength(7)
+        expect(jsonLd.sameAs).toHaveLength(9)
+        expect(jsonLd.sameAs).toContain('https://fi.wikipedia.org/wiki/Lauri_Lavanti')
+        expect(jsonLd.sameAs).toContain('https://www.wikidata.org/wiki/Q139711658')
+        expect(jsonLd.sameAs).not.toContain('https://digitaalinenitsenaisyys.fi/')
         expect(jsonLd.memberOf['@type']).toBe('PoliticalParty')
         expect(jsonLd.memberOf.name).toBe('Vihreä liitto')
         expect(jsonLd.memberOf.url).toBe('https://www.vihreat.fi')
         expect(jsonLd.knowsAbout).toHaveLength(9)
+        expect(jsonLd.knowsAbout).toContain('Talouspolitiikka')
+        expect(jsonLd.worksFor).toEqual({ '@type': 'Organization', name: 'OP', url: 'https://www.op.fi/' })
+        expect(jsonLd.alumniOf).toHaveLength(3)
+        expect(jsonLd.hasOccupation).toHaveLength(2)
+        expect(jsonLd.knowsLanguage).toEqual(['fi', 'en', 'sv'])
+        expect(jsonLd.affiliation).toHaveLength(1)
+        expect(jsonLd.affiliation[0].url).toBe('https://digitaalinenitsenaisyys.fi/')
     })
 
     it('should localise Person jobTitle for English', async () => {
@@ -301,6 +399,8 @@ describe('<Head />', () => {
         const jsonLdScript = result.querySelector('script[type="application/ld+json"]')
         const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
         expect(jsonLd.jobTitle).toBe('Municipal councillor & Lead Developer')
+        expect(jsonLd.knowsAbout).toContain('Economic policy')
+        expect(jsonLd.knowsAbout).not.toContain('Talouspolitiikka')
     })
 
     it('should localise Person jobTitle for Swedish', async () => {
@@ -315,6 +415,47 @@ describe('<Head />', () => {
         const jsonLdScript = result.querySelector('script[type="application/ld+json"]')
         const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
         expect(jsonLd.jobTitle).toBe('Kommunfullmäktigeledamot och ledande mjukvarutvecklare')
+        expect(jsonLd.knowsAbout).toContain('Ekonomisk politik')
+        expect(jsonLd.knowsAbout).not.toContain('Talouspolitiikka')
+    })
+
+    it('should emit ProfilePage JSON-LD with mainEntity Person when type is ProfilePage', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                lang: 'fi',
+                title: 'Lauri Lavanti',
+                type: 'ProfilePage',
+                updatedAt: '2025-01-01',
+            },
+        })
+
+        const jsonLdScript = result.querySelector('script[type="application/ld+json"]')
+        const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
+        expect(jsonLd['@type']).toBe('ProfilePage')
+        expect(jsonLd.dateModified).toBe('2025-01-01')
+        expect(jsonLd.mainEntity).toBeDefined()
+        expect(jsonLd.mainEntity['@type']).toBe('Person')
+        expect(jsonLd.mainEntity['@id']).toBe(PERSON_ID)
+        expect(jsonLd.mainEntity.name).toBe('Lauri Lavanti')
+        expect(jsonLd.mainEntity.sameAs).toHaveLength(9)
+        expect(jsonLd.mainEntity.affiliation).toHaveLength(1)
+    })
+
+    it('should not emit author, headline, or license on ProfilePage JSON-LD', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                lang: 'fi',
+                title: 'Lauri Lavanti',
+                type: 'ProfilePage',
+            },
+        })
+
+        const jsonLdScript = result.querySelector('script[type="application/ld+json"]')
+        const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
+        expect(jsonLd['@type']).toBe('ProfilePage')
+        expect(jsonLd.author).toBeUndefined()
+        expect(jsonLd.headline).toBeUndefined()
+        expect(jsonLd.license).toBeUndefined()
     })
 
     it('should emit noindex robots meta tag when noindex is true', async () => {

--- a/src/components/SummaryBox.astro
+++ b/src/components/SummaryBox.astro
@@ -10,12 +10,13 @@ import UL from './UL.astro'
 
 interface Props {
     ariaLabel?: string
+    id?: string
     lang: Lang
     summaryRows: string[]
     title: string
 }
 
-const { ariaLabel, lang, summaryRows, title } = Astro.props
+const { ariaLabel, id, lang, summaryRows, title } = Astro.props
 const content = summaryBoxContent[lang]
 const isCollapsible = summaryRows.length > 3
 const expandLabelJson = JSON.stringify(content.expandLabel)
@@ -85,7 +86,7 @@ const collapseLabelJson = JSON.stringify(content.collapseLabel)
         text-decoration: underline;
     }
 </style>
-<aside aria-label={ariaLabel}>
+<aside aria-label={ariaLabel} id={id}>
     <H2>{title}</H2>
     {
         isCollapsible ? (

--- a/src/content/person.ts
+++ b/src/content/person.ts
@@ -156,5 +156,4 @@ export type AuthorEntry =
           url?: string
           sameAs?: string[]
           role?: string
-          place?: string
       }

--- a/src/content/person.ts
+++ b/src/content/person.ts
@@ -1,0 +1,160 @@
+import { getCldImageUrl } from 'astro-cloudinary/helpers' // eslint-disable-line import/namespace
+
+import type { Lang } from './nav'
+
+export const PERSON_ID = 'https://laurilavanti.fi/fi/about/#person'
+
+export const personName = 'Lauri Lavanti'
+export const personGivenName = 'Lauri'
+export const personFamilyName = 'Lavanti'
+export const personBirthDate = '1991-10-01'
+export const personBirthPlace = { '@type': 'Place', name: 'Jyväskylä' }
+export const personNationality = { '@type': 'Country', name: 'FI' }
+export const personUrl = 'https://laurilavanti.fi/fi/'
+
+export const personImage = getCldImageUrl({
+    crop: { gravity: 'north', source: true, type: 'fill' },
+    height: 1200,
+    src: 'Lauri-Lavanti-seisoo-suorassa-sinisella-taustalla',
+    width: 1200,
+})
+
+export const personSameAs = [
+    'https://bsky.app/profile/laurilavanti.fi',
+    'https://www.facebook.com/laurilavanti',
+    'https://www.instagram.com/laurilavanti/',
+    'https://www.linkedin.com/in/lapanti',
+    'https://mastodon.social/@laurilavanti',
+    'https://www.threads.com/@laurilavanti',
+    'https://www.tiktok.com/@laurilavanti',
+    'https://fi.wikipedia.org/wiki/Lauri_Lavanti',
+    'https://www.wikidata.org/wiki/Q139711658',
+]
+
+export const personJobTitle: Record<Lang, string> = {
+    en: 'Municipal councillor & Lead Developer',
+    fi: 'Kunnanvaltuutettu ja johtava ohjelmistokehittäjä',
+    sv: 'Kommunfullmäktigeledamot och ledande mjukvarutvecklare',
+}
+
+export const personDescription: Record<Lang, string> = {
+    en: 'Municipal councillor in Kirkkonummi (Greens) and lead software developer. Focused on economics, entrepreneurship, digital independence, and responsible AI policy.',
+    fi: 'Kirkkonummen kunnanvaltuutettu (Vihreät) ja johtava ohjelmistokehittäjä. Keskittyy talouteen, yrittäjyyteen, digitaaliseen itsenäisyyteen ja vastuulliseen tekoälypolitiikkaan. Seuraa eduskuntavaaleja.',
+    sv: 'Kommunfullmäktigeledamot i Kyrkslätt (De Gröna) och ledande mjukvarutvecklare. Fokuserar på ekonomi, företagande, digital självständighet och ansvarsfull AI-politik. Följer riksdagsvalen.',
+}
+
+export const personKnowsAbout: Record<Lang, string[]> = {
+    en: [
+        'Economic policy',
+        'Entrepreneurship',
+        'Innovation policy',
+        'Digital independence',
+        'Digital sovereignty',
+        'Artificial intelligence',
+        'Responsible AI',
+        'Green transition',
+        'Parliamentary elections',
+    ],
+    fi: [
+        'Talouspolitiikka',
+        'Yrittäjyys',
+        'Innovaatiopolitiikka',
+        'Digitaalinen itsenäisyys',
+        'Digitaalinen riippumattomuus',
+        'Tekoäly',
+        'Vastuullinen tekoäly',
+        'Vihreä siirtymä',
+        'Eduskuntavaalit',
+    ],
+    sv: [
+        'Ekonomisk politik',
+        'Företagande',
+        'Innovationspolitik',
+        'Digital självständighet',
+        'Digitalt oberoende',
+        'Artificiell intelligens',
+        'Ansvarsfull AI',
+        'Grön omställning',
+        'Riksdagsval',
+    ],
+}
+
+export const personKnowsLanguage = ['fi', 'en', 'sv']
+
+export const personWorksFor = {
+    '@type': 'Organization',
+    name: 'OP',
+    url: 'https://www.op.fi/',
+}
+
+export const personAlumniOf = [
+    { '@type': 'CollegeOrUniversity', name: 'Aalto-yliopisto', url: 'https://www.aalto.fi/' },
+    { '@type': 'EducationalOrganization', name: 'Omnia', url: 'https://www.omnia.fi/' },
+    { '@type': 'HighSchool', name: 'Masalan lukio' },
+]
+
+export const personMemberOf = {
+    '@type': 'PoliticalParty',
+    name: 'Vihreä liitto',
+    url: 'https://www.vihreat.fi',
+}
+
+export const personAffiliation = [
+    {
+        '@type': 'Organization',
+        name: 'Digitaalinen itsenäisyys -kansalaisaloite',
+        url: 'https://digitaalinenitsenaisyys.fi/',
+    },
+]
+
+export const personHasOccupation: Record<Lang, object[]> = {
+    en: [
+        {
+            '@type': 'Occupation',
+            name: 'Municipal councillor',
+            occupationLocation: { '@type': 'City', name: 'Kirkkonummi' },
+            skills: 'Digital policy, AI governance, economic policy, entrepreneurship, local government',
+        },
+        {
+            '@type': 'Occupation',
+            name: 'Lead developer',
+            skills: 'Artificial intelligence, software architecture, digital sovereignty, secure software development',
+        },
+    ],
+    fi: [
+        {
+            '@type': 'Occupation',
+            name: 'Kunnanvaltuutettu',
+            occupationLocation: { '@type': 'City', name: 'Kirkkonummi' },
+            skills: 'Digitaalinen politiikka, tekoälyhallinto, talouspolitiikka, yrittäjyys, kunnallishallinto',
+        },
+        {
+            '@type': 'Occupation',
+            name: 'Johtava ohjelmistokehittäjä',
+            skills: 'Tekoäly, ohjelmistoarkkitehtuuri, digitaalinen itsenäisyys, tietoturvallinen ohjelmistokehitys',
+        },
+    ],
+    sv: [
+        {
+            '@type': 'Occupation',
+            name: 'Kommunfullmäktigeledamot',
+            occupationLocation: { '@type': 'City', name: 'Kyrkslätt' },
+            skills: 'Digital politik, AI-styrning, ekonomisk politik, företagande, kommunal förvaltning',
+        },
+        {
+            '@type': 'Occupation',
+            name: 'Ledande mjukvarutvecklare',
+            skills: 'Artificiell intelligens, programvaruarkitektur, digital självständighet, säker mjukvaruutveckling',
+        },
+    ],
+}
+
+export type AuthorEntry =
+    | 'lauri'
+    | {
+          name: string
+          url?: string
+          sameAs?: string[]
+          role?: string
+          place?: string
+      }

--- a/src/content/person.ts
+++ b/src/content/person.ts
@@ -1,6 +1,6 @@
-import { getCldImageUrl } from 'astro-cloudinary/helpers' // eslint-disable-line import/namespace
-
 import type { Lang } from './nav'
+
+import { getCldImageUrl } from 'astro-cloudinary/helpers'
 
 export const PERSON_ID = 'https://laurilavanti.fi/fi/about/#person'
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 /* eslint-disable astro/no-unused-css-selector */
+import type { AuthorEntry } from '../content/person'
 import type { BreadcrumbItem, JsonLdType } from '../lib/jsonld'
 
 import Footer from '../components/Footer.astro'
@@ -17,6 +18,7 @@ import {
 } from '../lib/styles'
 
 interface Props {
+    authors?: AuthorEntry[]
     breadcrumbs?: BreadcrumbItem[]
     createdAt?: string
     description?: string
@@ -33,6 +35,7 @@ interface Props {
 }
 
 const {
+    authors,
     breadcrumbs,
     createdAt,
     description,
@@ -53,6 +56,7 @@ const {
     <head>
         <GlobalStyle />
         <Head
+            authors={authors}
             breadcrumbs={breadcrumbs}
             createdAt={createdAt}
             description={description}

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -9,7 +9,6 @@ import ExcerptList from '../components/ExcerptList.astro'
 import H2 from '../components/H2.astro'
 import SocialShare from '../components/SocialShare.astro'
 import TitleBanner from '../components/TitleBanner.astro'
-import { personJobTitle, personName } from '../content/person'
 import { BLOGPOSTING, type BreadcrumbItem } from '../lib/jsonld'
 import { getPostAlternates } from '../lib/mdxPosts'
 import { gridTemplateColumnsArticle, sizes } from '../lib/styles'
@@ -34,38 +33,6 @@ type Props = MDXLayoutProps<{
 const { frontmatter } = Astro.props
 const { alt, authors, description, faq, heroImage, id, lang, pageTitle, publishDate, slug, tags, title, updatedDate } =
     frontmatter
-
-type ResolvedAuthor = { name: string; role?: string }
-
-const typedLang = lang as 'en' | 'fi' | 'sv'
-
-const rawAuthors = authors ?? (['lauri'] as AuthorEntry[])
-const anyCoAuthorHasRole = rawAuthors.some((e: AuthorEntry) => e !== 'lauri' && !!e.role)
-
-const resolvedAuthors: ResolvedAuthor[] = rawAuthors.map((entry: AuthorEntry) => {
-    if (entry === 'lauri') {
-        return { name: personName, role: anyCoAuthorHasRole ? personJobTitle[typedLang] : undefined }
-    }
-    return { name: entry.name, role: entry.role }
-})
-
-const bylinePrefix: Record<'en' | 'fi' | 'sv', string> = { en: 'Authors', fi: 'Tekijät', sv: 'Författare' }
-const andConjunction: Record<'en' | 'fi' | 'sv', string> = { en: 'and', fi: 'ja', sv: 'och' }
-
-const joinNames = (parts: string[]): string => {
-    if (parts.length === 1) return parts[0]
-    if (parts.length === 2) return `${parts[0]} ${andConjunction[typedLang]} ${parts[1]}`
-    return `${parts.slice(0, -1).join(', ')}, ${andConjunction[typedLang]} ${parts[parts.length - 1]}`
-}
-
-const showByline = resolvedAuthors.length > 1
-
-const bylineText = (() => {
-    if (!showByline) return ''
-    const parts = resolvedAuthors.map((a: ResolvedAuthor) => (a.role ? `${a.name} (${a.role})` : a.name))
-
-    return `${bylinePrefix[typedLang]}: ${joinNames(parts)}.`
-})()
 
 const canonicalSlug = `${lang}/blog/${id}/${slug}`
 const shareUrl = `https://laurilavanti.fi/${canonicalSlug}/`
@@ -142,7 +109,7 @@ const breadcrumbs: BreadcrumbItem[] = [
         title={title}
     />
     <slot />
-    {showByline && <Byline text={bylineText} />}
+    <Byline authors={authors ?? ['lauri']} lang={lang} />
     <SocialShare ariaLabel={t.shareAriaLabel(pageTitle)} locale={lang} shareUrl={shareUrl} title={pageTitle} />
     <section class="other-posts">
         <H2>{t.otherPosts}</H2>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -3,6 +3,9 @@ import type { MDXLayoutProps } from 'astro'
 
 import { getCldImageUrl } from 'astro-cloudinary/helpers' // eslint-disable-line import/namespace
 
+import type { AuthorEntry } from '../content/person'
+import { personJobTitle, personName } from '../content/person'
+import Byline from '../components/Byline.astro'
 import ExcerptList from '../components/ExcerptList.astro'
 import H2 from '../components/H2.astro'
 import SocialShare from '../components/SocialShare.astro'
@@ -13,6 +16,7 @@ import { gridTemplateColumnsArticle, sizes } from '../lib/styles'
 import BaseLayout from './BaseLayout.astro'
 
 type Props = MDXLayoutProps<{
+    authors?: AuthorEntry[]
     description: string
     faq?: Array<{ a: string; q: string }>
     id: number
@@ -28,8 +32,51 @@ type Props = MDXLayoutProps<{
 }>
 
 const { frontmatter } = Astro.props
-const { alt, description, faq, heroImage, id, lang, pageTitle, publishDate, slug, tags, title, updatedDate } =
+const { alt, authors, description, faq, heroImage, id, lang, pageTitle, publishDate, slug, tags, title, updatedDate } =
     frontmatter
+
+type ResolvedAuthor = { name: string; place?: string; role?: string }
+
+const typedLang = lang as 'en' | 'fi' | 'sv'
+
+const resolvedAuthors: ResolvedAuthor[] = (authors ?? ['lauri']).map((entry: AuthorEntry) =>
+    entry === 'lauri'
+        ? { name: personName, place: 'Kirkkonummi', role: personJobTitle[typedLang] }
+        : { name: entry.name, place: entry.place, role: entry.role }
+)
+
+const bylinePrefix: Record<'en' | 'fi' | 'sv', string> = { en: 'Authors', fi: 'Tekijät', sv: 'Författare' }
+const andConjunction: Record<'en' | 'fi' | 'sv', string> = { en: 'and', fi: 'ja', sv: 'och' }
+
+const formatBylineNames = (names: string[]): string => {
+    if (names.length === 1) return names[0]
+    if (names.length === 2) return `${names[0]} ${andConjunction[typedLang]} ${names[1]}`
+    return `${names.slice(0, -1).join(', ')}, ${andConjunction[typedLang]} ${names[names.length - 1]}`
+}
+
+const allSameRoleAndPlace =
+    resolvedAuthors.length > 1 &&
+    resolvedAuthors.every(
+        (a: ResolvedAuthor) => a.role === resolvedAuthors[0].role && a.place === resolvedAuthors[0].place
+    )
+
+const showByline = resolvedAuthors.length > 1
+
+const bylineText = (() => {
+    if (!showByline) return ''
+    const names = formatBylineNames(resolvedAuthors.map((a: ResolvedAuthor) => a.name))
+    const { place, role } = resolvedAuthors[0]
+    if (allSameRoleAndPlace && (role || place)) {
+        const suffix = [role, place].filter(Boolean).join(', ')
+        return `${bylinePrefix[typedLang]}: ${names}, ${suffix}.`
+    }
+    if (allSameRoleAndPlace) return `${bylinePrefix[typedLang]}: ${names}.`
+    const parts = resolvedAuthors.map((a: ResolvedAuthor) => {
+        const suffix = [a.role, a.place].filter(Boolean).join(', ')
+        return suffix ? `${a.name} (${suffix})` : a.name
+    })
+    return `${bylinePrefix[typedLang]}: ${formatBylineNames(parts)}.`
+})()
 
 const canonicalSlug = `${lang}/blog/${id}/${slug}`
 const shareUrl = `https://laurilavanti.fi/${canonicalSlug}/`
@@ -82,6 +129,7 @@ const breadcrumbs: BreadcrumbItem[] = [
     }
 </style>
 <BaseLayout
+    authors={authors}
     breadcrumbs={breadcrumbs}
     createdAt={publishDate}
     description={description}
@@ -105,6 +153,7 @@ const breadcrumbs: BreadcrumbItem[] = [
         title={title}
     />
     <slot />
+    {showByline && <Byline text={bylineText} />}
     <SocialShare ariaLabel={t.shareAriaLabel(pageTitle)} locale={lang} shareUrl={shareUrl} title={pageTitle} />
     <section class="other-posts">
         <H2>{t.otherPosts}</H2>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -9,7 +9,7 @@ import ExcerptList from '../components/ExcerptList.astro'
 import H2 from '../components/H2.astro'
 import SocialShare from '../components/SocialShare.astro'
 import TitleBanner from '../components/TitleBanner.astro'
-import { personName } from '../content/person'
+import { personJobTitle, personName } from '../content/person'
 import { BLOGPOSTING, type BreadcrumbItem } from '../lib/jsonld'
 import { getPostAlternates } from '../lib/mdxPosts'
 import { gridTemplateColumnsArticle, sizes } from '../lib/styles'
@@ -39,9 +39,15 @@ type ResolvedAuthor = { name: string; role?: string }
 
 const typedLang = lang as 'en' | 'fi' | 'sv'
 
-const resolvedAuthors: ResolvedAuthor[] = (authors ?? ['lauri']).map((entry: AuthorEntry) =>
-    entry === 'lauri' ? { name: personName } : { name: entry.name, role: entry.role }
-)
+const rawAuthors = authors ?? (['lauri'] as AuthorEntry[])
+const anyCoAuthorHasRole = rawAuthors.some((e: AuthorEntry) => e !== 'lauri' && !!e.role)
+
+const resolvedAuthors: ResolvedAuthor[] = rawAuthors.map((entry: AuthorEntry) => {
+    if (entry === 'lauri') {
+        return { name: personName, role: anyCoAuthorHasRole ? personJobTitle[typedLang] : undefined }
+    }
+    return { name: entry.name, role: entry.role }
+})
 
 const bylinePrefix: Record<'en' | 'fi' | 'sv', string> = { en: 'Authors', fi: 'Tekijät', sv: 'Författare' }
 const andConjunction: Record<'en' | 'fi' | 'sv', string> = { en: 'and', fi: 'ja', sv: 'och' }

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -9,7 +9,7 @@ import ExcerptList from '../components/ExcerptList.astro'
 import H2 from '../components/H2.astro'
 import SocialShare from '../components/SocialShare.astro'
 import TitleBanner from '../components/TitleBanner.astro'
-import { personJobTitle, personName } from '../content/person'
+import { personName } from '../content/person'
 import { BLOGPOSTING, type BreadcrumbItem } from '../lib/jsonld'
 import { getPostAlternates } from '../lib/mdxPosts'
 import { gridTemplateColumnsArticle, sizes } from '../lib/styles'
@@ -35,50 +35,30 @@ const { frontmatter } = Astro.props
 const { alt, authors, description, faq, heroImage, id, lang, pageTitle, publishDate, slug, tags, title, updatedDate } =
     frontmatter
 
-type ResolvedAuthor = { name: string; place?: string; role?: string }
+type ResolvedAuthor = { name: string; role?: string }
 
 const typedLang = lang as 'en' | 'fi' | 'sv'
 
 const resolvedAuthors: ResolvedAuthor[] = (authors ?? ['lauri']).map((entry: AuthorEntry) =>
-    entry === 'lauri'
-        ? { name: personName, place: 'Kirkkonummi', role: personJobTitle[typedLang] }
-        : { name: entry.name, place: entry.place, role: entry.role }
+    entry === 'lauri' ? { name: personName } : { name: entry.name, role: entry.role }
 )
 
 const bylinePrefix: Record<'en' | 'fi' | 'sv', string> = { en: 'Authors', fi: 'Tekijät', sv: 'Författare' }
 const andConjunction: Record<'en' | 'fi' | 'sv', string> = { en: 'and', fi: 'ja', sv: 'och' }
 
-const formatBylineNames = (names: string[]): string => {
-    if (names.length === 1) return names[0]
-    if (names.length === 2) return `${names[0]} ${andConjunction[typedLang]} ${names[1]}`
-    return `${names.slice(0, -1).join(', ')}, ${andConjunction[typedLang]} ${names[names.length - 1]}`
+const joinNames = (parts: string[]): string => {
+    if (parts.length === 1) return parts[0]
+    if (parts.length === 2) return `${parts[0]} ${andConjunction[typedLang]} ${parts[1]}`
+    return `${parts.slice(0, -1).join(', ')}, ${andConjunction[typedLang]} ${parts[parts.length - 1]}`
 }
-
-const allSameRoleAndPlace =
-    resolvedAuthors.length > 1 &&
-    resolvedAuthors.every(
-        (a: ResolvedAuthor) => a.role === resolvedAuthors[0].role && a.place === resolvedAuthors[0].place
-    )
 
 const showByline = resolvedAuthors.length > 1
 
 const bylineText = (() => {
     if (!showByline) return ''
-    const names = formatBylineNames(resolvedAuthors.map((a: ResolvedAuthor) => a.name))
-    const { place, role } = resolvedAuthors[0]
-    if (allSameRoleAndPlace && (role || place)) {
-        const suffix = [role, place].filter(Boolean).join(', ')
+    const parts = resolvedAuthors.map((a: ResolvedAuthor) => (a.role ? `${a.name} (${a.role})` : a.name))
 
-        return `${bylinePrefix[typedLang]}: ${names}, ${suffix}.`
-    }
-    if (allSameRoleAndPlace) return `${bylinePrefix[typedLang]}: ${names}.`
-    const parts = resolvedAuthors.map((a: ResolvedAuthor) => {
-        const suffix = [a.role, a.place].filter(Boolean).join(', ')
-
-        return suffix ? `${a.name} (${suffix})` : a.name
-    })
-
-    return `${bylinePrefix[typedLang]}: ${formatBylineNames(parts)}.`
+    return `${bylinePrefix[typedLang]}: ${joinNames(parts)}.`
 })()
 
 const canonicalSlug = `${lang}/blog/${id}/${slug}`

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,15 +1,15 @@
 ---
 import type { MDXLayoutProps } from 'astro'
+import type { AuthorEntry } from '../content/person'
 
 import { getCldImageUrl } from 'astro-cloudinary/helpers' // eslint-disable-line import/namespace
 
-import type { AuthorEntry } from '../content/person'
-import { personJobTitle, personName } from '../content/person'
 import Byline from '../components/Byline.astro'
 import ExcerptList from '../components/ExcerptList.astro'
 import H2 from '../components/H2.astro'
 import SocialShare from '../components/SocialShare.astro'
 import TitleBanner from '../components/TitleBanner.astro'
+import { personJobTitle, personName } from '../content/person'
 import { BLOGPOSTING, type BreadcrumbItem } from '../lib/jsonld'
 import { getPostAlternates } from '../lib/mdxPosts'
 import { gridTemplateColumnsArticle, sizes } from '../lib/styles'
@@ -68,13 +68,16 @@ const bylineText = (() => {
     const { place, role } = resolvedAuthors[0]
     if (allSameRoleAndPlace && (role || place)) {
         const suffix = [role, place].filter(Boolean).join(', ')
+
         return `${bylinePrefix[typedLang]}: ${names}, ${suffix}.`
     }
     if (allSameRoleAndPlace) return `${bylinePrefix[typedLang]}: ${names}.`
     const parts = resolvedAuthors.map((a: ResolvedAuthor) => {
         const suffix = [a.role, a.place].filter(Boolean).join(', ')
+
         return suffix ? `${a.name} (${suffix})` : a.name
     })
+
     return `${bylinePrefix[typedLang]}: ${formatBylineNames(parts)}.`
 })()
 

--- a/src/lib/byline.spec.ts
+++ b/src/lib/byline.spec.ts
@@ -36,27 +36,25 @@ describe('buildBylineText', () => {
 
     describe('two authors — co-author has role', () => {
         it('injects personJobTitle for lauri sentinel when co-author has role (en)', () => {
-            expect(
-                buildBylineText([{ name: 'Atte Harjanne', role: 'member of parliament' }, 'lauri'], 'en')
-            ).toBe(`Authors: Atte Harjanne (member of parliament) and ${personName} (${personJobTitle['en']}).`)
+            expect(buildBylineText([{ name: 'Atte Harjanne', role: 'member of parliament' }, 'lauri'], 'en')).toBe(
+                `Authors: Atte Harjanne (member of parliament) and ${personName} (${personJobTitle['en']}).`
+            )
         })
 
         it('injects personJobTitle for lauri sentinel when co-author has role (fi)', () => {
-            expect(
-                buildBylineText([{ name: 'Atte Harjanne', role: 'kansanedustaja' }, 'lauri'], 'fi')
-            ).toBe(`Tekijät: Atte Harjanne (kansanedustaja) ja ${personName} (${personJobTitle['fi']}).`)
+            expect(buildBylineText([{ name: 'Atte Harjanne', role: 'kansanedustaja' }, 'lauri'], 'fi')).toBe(
+                `Tekijät: Atte Harjanne (kansanedustaja) ja ${personName} (${personJobTitle['fi']}).`
+            )
         })
 
         it('injects personJobTitle for lauri sentinel when co-author has role (sv)', () => {
-            expect(
-                buildBylineText([{ name: 'Atte Harjanne', role: 'riksdagsledamot' }, 'lauri'], 'sv')
-            ).toBe(`Författare: Atte Harjanne (riksdagsledamot) och ${personName} (${personJobTitle['sv']}).`)
+            expect(buildBylineText([{ name: 'Atte Harjanne', role: 'riksdagsledamot' }, 'lauri'], 'sv')).toBe(
+                `Författare: Atte Harjanne (riksdagsledamot) och ${personName} (${personJobTitle['sv']}).`
+            )
         })
 
         it('renders co-author role in parentheses next to name', () => {
-            expect(
-                buildBylineText([{ name: 'Miisa Jeremejew', role: 'municipal councillor' }, 'lauri'], 'en')
-            ).toBe(
+            expect(buildBylineText([{ name: 'Miisa Jeremejew', role: 'municipal councillor' }, 'lauri'], 'en')).toBe(
                 `Authors: Miisa Jeremejew (municipal councillor) and ${personName} (${personJobTitle['en']}).`
             )
         })
@@ -64,21 +62,21 @@ describe('buildBylineText', () => {
 
     describe('three authors — no roles', () => {
         it('uses Oxford comma', () => {
-            expect(
-                buildBylineText([{ name: 'Johanna Fleming' }, 'lauri', { name: 'Paula Oittinen' }], 'en')
-            ).toBe(`Authors: Johanna Fleming, ${personName}, and Paula Oittinen.`)
+            expect(buildBylineText([{ name: 'Johanna Fleming' }, 'lauri', { name: 'Paula Oittinen' }], 'en')).toBe(
+                `Authors: Johanna Fleming, ${personName}, and Paula Oittinen.`
+            )
         })
 
         it('uses correct conjunction in Finnish', () => {
-            expect(
-                buildBylineText([{ name: 'Johanna Fleming' }, 'lauri', { name: 'Paula Oittinen' }], 'fi')
-            ).toBe(`Tekijät: Johanna Fleming, ${personName}, ja Paula Oittinen.`)
+            expect(buildBylineText([{ name: 'Johanna Fleming' }, 'lauri', { name: 'Paula Oittinen' }], 'fi')).toBe(
+                `Tekijät: Johanna Fleming, ${personName}, ja Paula Oittinen.`
+            )
         })
 
         it('uses correct conjunction in Swedish', () => {
-            expect(
-                buildBylineText([{ name: 'Johanna Fleming' }, 'lauri', { name: 'Paula Oittinen' }], 'sv')
-            ).toBe(`Författare: Johanna Fleming, ${personName}, och Paula Oittinen.`)
+            expect(buildBylineText([{ name: 'Johanna Fleming' }, 'lauri', { name: 'Paula Oittinen' }], 'sv')).toBe(
+                `Författare: Johanna Fleming, ${personName}, och Paula Oittinen.`
+            )
         })
     })
 
@@ -101,9 +99,7 @@ describe('buildBylineText', () => {
                     [{ name: 'Johanna Fleming' }, 'lauri', { name: 'Paula Oittinen', role: 'teacher' }],
                     'en'
                 )
-            ).toBe(
-                `Authors: Johanna Fleming, ${personName} (${personJobTitle['en']}), and Paula Oittinen (teacher).`
-            )
+            ).toBe(`Authors: Johanna Fleming, ${personName} (${personJobTitle['en']}), and Paula Oittinen (teacher).`)
         })
     })
 })

--- a/src/lib/byline.spec.ts
+++ b/src/lib/byline.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+
+import { personJobTitle, personName } from '../content/person'
+import { buildBylineText } from './byline'
+
+describe('buildBylineText', () => {
+    describe('solo author', () => {
+        it('returns empty string for single lauri sentinel', () => {
+            expect(buildBylineText(['lauri'], 'en')).toBe('')
+        })
+
+        it('returns empty string for single co-author object', () => {
+            expect(buildBylineText([{ name: 'Miisa Jeremejew' }], 'en')).toBe('')
+        })
+    })
+
+    describe('two authors — no roles', () => {
+        it('renders name-only byline in English', () => {
+            expect(buildBylineText([{ name: 'Ronja Karkinen' }, 'lauri'], 'en')).toBe(
+                `Authors: Ronja Karkinen and ${personName}.`
+            )
+        })
+
+        it('renders name-only byline in Finnish', () => {
+            expect(buildBylineText([{ name: 'Ronja Karkinen' }, 'lauri'], 'fi')).toBe(
+                `Tekijät: Ronja Karkinen ja ${personName}.`
+            )
+        })
+
+        it('renders name-only byline in Swedish', () => {
+            expect(buildBylineText([{ name: 'Ronja Karkinen' }, 'lauri'], 'sv')).toBe(
+                `Författare: Ronja Karkinen och ${personName}.`
+            )
+        })
+    })
+
+    describe('two authors — co-author has role', () => {
+        it('injects personJobTitle for lauri sentinel when co-author has role (en)', () => {
+            expect(
+                buildBylineText([{ name: 'Atte Harjanne', role: 'member of parliament' }, 'lauri'], 'en')
+            ).toBe(`Authors: Atte Harjanne (member of parliament) and ${personName} (${personJobTitle['en']}).`)
+        })
+
+        it('injects personJobTitle for lauri sentinel when co-author has role (fi)', () => {
+            expect(
+                buildBylineText([{ name: 'Atte Harjanne', role: 'kansanedustaja' }, 'lauri'], 'fi')
+            ).toBe(`Tekijät: Atte Harjanne (kansanedustaja) ja ${personName} (${personJobTitle['fi']}).`)
+        })
+
+        it('injects personJobTitle for lauri sentinel when co-author has role (sv)', () => {
+            expect(
+                buildBylineText([{ name: 'Atte Harjanne', role: 'riksdagsledamot' }, 'lauri'], 'sv')
+            ).toBe(`Författare: Atte Harjanne (riksdagsledamot) och ${personName} (${personJobTitle['sv']}).`)
+        })
+
+        it('renders co-author role in parentheses next to name', () => {
+            expect(
+                buildBylineText([{ name: 'Miisa Jeremejew', role: 'municipal councillor' }, 'lauri'], 'en')
+            ).toBe(
+                `Authors: Miisa Jeremejew (municipal councillor) and ${personName} (${personJobTitle['en']}).`
+            )
+        })
+    })
+
+    describe('three authors — no roles', () => {
+        it('uses Oxford comma', () => {
+            expect(
+                buildBylineText([{ name: 'Johanna Fleming' }, 'lauri', { name: 'Paula Oittinen' }], 'en')
+            ).toBe(`Authors: Johanna Fleming, ${personName}, and Paula Oittinen.`)
+        })
+
+        it('uses correct conjunction in Finnish', () => {
+            expect(
+                buildBylineText([{ name: 'Johanna Fleming' }, 'lauri', { name: 'Paula Oittinen' }], 'fi')
+            ).toBe(`Tekijät: Johanna Fleming, ${personName}, ja Paula Oittinen.`)
+        })
+
+        it('uses correct conjunction in Swedish', () => {
+            expect(
+                buildBylineText([{ name: 'Johanna Fleming' }, 'lauri', { name: 'Paula Oittinen' }], 'sv')
+            ).toBe(`Författare: Johanna Fleming, ${personName}, och Paula Oittinen.`)
+        })
+    })
+
+    describe('author ordering', () => {
+        it('preserves frontmatter array order', () => {
+            const result = buildBylineText([{ name: 'Miisa Jeremejew' }, 'lauri'], 'en')
+            expect(result.indexOf('Miisa')).toBeLessThan(result.indexOf(personName))
+        })
+
+        it('lauri first when sentinel is first entry', () => {
+            const result = buildBylineText(['lauri', { name: 'Miisa Jeremejew' }], 'en')
+            expect(result.indexOf(personName)).toBeLessThan(result.indexOf('Miisa'))
+        })
+    })
+
+    describe('co-author without role when another co-author has role', () => {
+        it('shows name only for the role-less co-author, role for the one with role', () => {
+            expect(
+                buildBylineText(
+                    [{ name: 'Johanna Fleming' }, 'lauri', { name: 'Paula Oittinen', role: 'teacher' }],
+                    'en'
+                )
+            ).toBe(
+                `Authors: Johanna Fleming, ${personName} (${personJobTitle['en']}), and Paula Oittinen (teacher).`
+            )
+        })
+    })
+})

--- a/src/lib/byline.ts
+++ b/src/lib/byline.ts
@@ -1,0 +1,32 @@
+import type { Lang } from '../content/nav'
+import type { AuthorEntry } from '../content/person'
+
+import { personJobTitle, personName } from '../content/person'
+
+export type { Lang }
+
+const bylinePrefix: Record<Lang, string> = { en: 'Authors', fi: 'Tekijät', sv: 'Författare' }
+const andConjunction: Record<Lang, string> = { en: 'and', fi: 'ja', sv: 'och' }
+
+const joinParts = (parts: string[], lang: Lang): string => {
+    if (parts.length === 1) return parts[0]
+    if (parts.length === 2) return `${parts[0]} ${andConjunction[lang]} ${parts[1]}`
+    return `${parts.slice(0, -1).join(', ')}, ${andConjunction[lang]} ${parts[parts.length - 1]}`
+}
+
+export const buildBylineText = (authors: AuthorEntry[], lang: Lang): string => {
+    if (authors.length < 2) return ''
+
+    const anyCoAuthorHasRole = authors.some((e) => e !== 'lauri' && typeof e === 'object' && !!e.role)
+
+    const parts = authors.map((entry) => {
+        if (entry === 'lauri') {
+            const role = anyCoAuthorHasRole ? personJobTitle[lang] : undefined
+
+            return role ? `${personName} (${role})` : personName
+        }
+        return entry.role ? `${entry.name} (${entry.role})` : entry.name
+    })
+
+    return `${bylinePrefix[lang]}: ${joinParts(parts, lang)}.`
+}

--- a/src/lib/jsonld.spec.ts
+++ b/src/lib/jsonld.spec.ts
@@ -1,18 +1,19 @@
 import { describe, expect, it } from 'vitest'
 
-import { BLOGPOSTING, COLLECTIONPAGE, FAQPAGE, JSON_LD_TYPES, PERSON, WEBPAGE, WEBSITE } from './jsonld'
+import { BLOGPOSTING, COLLECTIONPAGE, FAQPAGE, JSON_LD_TYPES, PERSON, PROFILEPAGE, WEBPAGE, WEBSITE } from './jsonld'
 
 describe('jsonld', () => {
     it('should export correct JSON-LD types', () => {
         expect(BLOGPOSTING).toBe('BlogPosting')
         expect(COLLECTIONPAGE).toBe('CollectionPage')
         expect(PERSON).toBe('Person')
+        expect(PROFILEPAGE).toBe('ProfilePage')
         expect(WEBPAGE).toBe('WebPage')
         expect(WEBSITE).toBe('WebSite')
     })
 
     it('should include all JSON-LD types in JSON_LD_TYPES', () => {
-        expect(JSON_LD_TYPES).toEqual([BLOGPOSTING, COLLECTIONPAGE, PERSON, WEBPAGE, WEBSITE])
+        expect(JSON_LD_TYPES).toEqual([BLOGPOSTING, COLLECTIONPAGE, PERSON, PROFILEPAGE, WEBPAGE, WEBSITE])
     })
 
     it('should export FAQPAGE constant', () => {

--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -2,10 +2,11 @@ export const BLOGPOSTING = 'BlogPosting' as const
 export const COLLECTIONPAGE = 'CollectionPage' as const
 export const FAQPAGE = 'FAQPage' as const
 export const PERSON = 'Person' as const
+export const PROFILEPAGE = 'ProfilePage' as const
 export const WEBPAGE = 'WebPage' as const
 export const WEBSITE = 'WebSite' as const
 
-export const JSON_LD_TYPES = [BLOGPOSTING, COLLECTIONPAGE, PERSON, WEBPAGE, WEBSITE] as const
+export const JSON_LD_TYPES = [BLOGPOSTING, COLLECTIONPAGE, PERSON, PROFILEPAGE, WEBPAGE, WEBSITE] as const
 
 export type JsonLdType = (typeof JSON_LD_TYPES)[number]
 

--- a/src/lib/mdxPosts.ts
+++ b/src/lib/mdxPosts.ts
@@ -1,5 +1,8 @@
+import type { AuthorEntry } from '../content/person'
+
 interface MdxPost {
     alt: string
+    authors?: AuthorEntry[]
     description: string
     faq?: Array<{ a: string; q: string }>
     heroImage: string

--- a/src/pages/en/about/index.mdx
+++ b/src/pages/en/about/index.mdx
@@ -5,8 +5,8 @@ pageTitle: 'At the crossroads of technology and society'
 title: 'At the crossroads of technology and society'
 description: 'Lauri Lavanti is a lead developer, Kirkkonummi councillor, and Greens group chair. Focus: economic policy, entrepreneurship and digital independence.'
 slug: 'en/about'
-updatedDate: '2026-05-22'
-type: 'Person'
+updatedDate: '2026-05-23'
+type: 'ProfilePage'
 heroImage: 'Lauri-Lavanti-sitting-in-front-of-a-window'
 alt: 'Lauri Lavanti sitting on a stool in front of a window, looking at the camera, smiling. He is wearing a white shirt with blue flower patterns and a dark jacket. Photo was taken by Juha Jantunen.'
 faq:
@@ -54,6 +54,8 @@ Lauri works where technology is changing society—and where decision-making sho
 Lauri Lavanti is a lead software developer, municipal councillor in Kirkkonummi, and chair of the Greens council group. He graduated as a Master of Science (Tech.) from Aalto University and focuses on AI, economic policy, entrepreneurship, innovation, and digital independence.
 
 Digitalization, privacy, and the responsible implementation of artificial intelligence are all part of the same whole: how we build technological development that is both competitive and sustainable for nature and people.
+
+Lauri also has a [Wikipedia article](https://fi.wikipedia.org/wiki/Lauri_Lavanti) (in Finnish).
 
 ## Expert in digitalization and privacy
 

--- a/src/pages/en/blog/22/one-step-forward-two-steps-back/index.mdx
+++ b/src/pages/en/blog/22/one-step-forward-two-steps-back/index.mdx
@@ -7,7 +7,11 @@ pageTitle: 'One step forward, two steps back – education'
 title: 'One step forward, two steps back'
 description: 'The government is making necessary reforms to upper secondary education, but they do not compensate for €120 million cuts to vocational education.'
 publishDate: '2024-11-27'
-updatedDate: '2026-03-02'
+updatedDate: '2026-05-23'
+authors:
+  - name: 'Johanna Fleming'
+  - lauri
+  - name: 'Paula Oittinen'
 tags:
   - kirkkonummi
   - municipal-elections-2025
@@ -53,7 +57,6 @@ As a whole, these steps forward do not compensate for the steps backwards the go
 
 The Minister of Education responded to our article — and we responded back: [Is education under special protection?](/en/blog/27/is-education-under-special-protection/) For a broader picture of why education is the municipality's most important task, from early childhood education to lifelong learning, see [Education is the municipality's most important task](/en/blog/37/education-is-the-municipalitys-most-important-task/). All my education posts are in the [education category](/en/category/opetus/).
 
-_Authors: Johanna Fleming, Lauri Lavanti, and Paula Oittinen._
 
 ---
 

--- a/src/pages/en/blog/27/is-education-under-special-protection/index.mdx
+++ b/src/pages/en/blog/27/is-education-under-special-protection/index.mdx
@@ -7,7 +7,11 @@ pageTitle: 'Is education under special protection?'
 title: 'Is education under special protection?'
 description: 'Education is being cut deeply, despite government claims to the contrary. Index increases and legal reforms do not cover hundreds of millions in cuts.'
 publishDate: '2024-12-12'
-updatedDate: '2026-03-02'
+updatedDate: '2026-05-23'
+authors:
+  - name: 'Johanna Fleming'
+  - lauri
+  - name: 'Paula Oittinen'
 tags:
   - kirkkonummi
   - municipal-elections-2025
@@ -51,8 +55,6 @@ The cuts to vocational education were also justified by the argument that index 
 The government promised that education would be under special protection — it turned out otherwise. On the whole, the Minister of Education seems to have forgotten that investing in education is an investment in the future.
 
 For a broader picture of education's role in the municipality, see [Education is the municipality's most important task](/en/blog/37/education-is-the-municipalitys-most-important-task/). Read more in the [education category](/en/category/opetus/).
-
-_Authors: Johanna Fleming, Lauri Lavanti, and Paula Oittinen._
 
 ---
 

--- a/src/pages/en/blog/41/public-transport-cannot-keep-getting-more-expensive/index.mdx
+++ b/src/pages/en/blog/41/public-transport-cannot-keep-getting-more-expensive/index.mdx
@@ -7,7 +7,10 @@ pageTitle: 'Public transport cannot keep getting pricier'
 title: 'Public transport cannot keep getting more expensive'
 description: 'HSL plans significant fare increases for buses and trains. This risks a downward spiral — fewer users means more pressure to raise prices further.'
 publishDate: '2025-08-25'
-updatedDate: '2026-03-02'
+updatedDate: '2026-05-23'
+authors:
+  - name: 'Ronja Karkinen'
+  - lauri
 tags:
   - infrastructure
   - kirkkonummi
@@ -41,8 +44,6 @@ The planned fare increases would cause the entire public transport system to spi
 With the measures currently under discussion, our public transport system is heading towards collapse. Dismantling the infrastructure compensation system is essential to securing the future of public transport in the HSL area.
 
 Public transport is also why [I voted for Kirkkonummi joining the Western Rail Link](/en/blog/46/i-voted-for-the-western-rail-link/) — a commuter rail station in Northern Kirkkonummi would have provided a sustainable alternative to car ownership. The council's decision to withdraw from the project has since caused significant disappointment, which I discuss in [The West Railway revealed problems in Kirkkonummi's governance](/en/blog/50/the-west-railway-decision-revealed-problems-in-kirkkonummis-long-term-strategic-development/). Read more in the [transport category](/en/category/liikenne/).
-
-_Authors: Ronja Karkinen and Lauri Lavanti._
 
 ---
 

--- a/src/pages/en/blog/48/the-use-of-biometric-identifiers-in-passports-must-not-be-expanded/index.mdx
+++ b/src/pages/en/blog/48/the-use-of-biometric-identifiers-in-passports-must-not-be-expanded/index.mdx
@@ -10,6 +10,7 @@ publishDate: '2026-01-23'
 updatedDate: '2026-05-23'
 authors:
   - name: 'Atte Harjanne'
+    role: 'member of parliament'
   - lauri
 tags:
   - technology

--- a/src/pages/en/blog/48/the-use-of-biometric-identifiers-in-passports-must-not-be-expanded/index.mdx
+++ b/src/pages/en/blog/48/the-use-of-biometric-identifiers-in-passports-must-not-be-expanded/index.mdx
@@ -7,7 +7,10 @@ pageTitle: 'Passport biometrics must stay protected'
 title: 'The use of biometric identifiers in passports must not be expanded'
 description: 'When fingerprints were added to passports, Finland created a national biometric register. Now the government wants to open it to police use.'
 publishDate: '2026-01-23'
-updatedDate: '2026-05-15'
+updatedDate: '2026-05-23'
+authors:
+  - name: 'Atte Harjanne'
+  - lauri
 tags:
   - technology
   - privacy
@@ -67,7 +70,6 @@ Authorities must have sufficient means to guarantee the security of society. How
 
 I have written more about digital rights and technology: [about dismantling fundamental rights](/en/blog/45/fundamental-rights-must-not-be-dismantled-without-justification/), [about digital independence](/en/blog/51/digital-independence-is-a-necessity/) and [about what AI can do in public services](/en/blog/44/ai-cannot-do-everything/). Read more in [my posts on technology](/en/category/teknologia/).
 
-_Authors: Atte Harjanne and Lauri Lavanti._
 
 ---
 

--- a/src/pages/en/blog/56/lahteela-a-gem-on-kirkkonummis-coast/index.mdx
+++ b/src/pages/en/blog/56/lahteela-a-gem-on-kirkkonummis-coast/index.mdx
@@ -10,11 +10,9 @@ publishDate: '2026-04-15'
 updatedDate: '2026-05-23'
 authors:
   - name: 'Miisa Jeremejew'
-    role: 'municipal councillor (Greens)'
-    place: 'Kirkkonummi'
+    role: 'municipal councillor'
   - name: 'Lauri Lavanti'
-    role: 'municipal councillor (Greens)'
-    place: 'Kirkkonummi'
+    role: 'municipal councillor'
 tags:
   - kirkkonummi
   - nature

--- a/src/pages/en/blog/56/lahteela-a-gem-on-kirkkonummis-coast/index.mdx
+++ b/src/pages/en/blog/56/lahteela-a-gem-on-kirkkonummis-coast/index.mdx
@@ -11,8 +11,7 @@ updatedDate: '2026-05-23'
 authors:
   - name: 'Miisa Jeremejew'
     role: 'municipal councillor'
-  - name: 'Lauri Lavanti'
-    role: 'municipal councillor'
+  - lauri
 tags:
   - kirkkonummi
   - nature

--- a/src/pages/en/blog/56/lahteela-a-gem-on-kirkkonummis-coast/index.mdx
+++ b/src/pages/en/blog/56/lahteela-a-gem-on-kirkkonummis-coast/index.mdx
@@ -7,7 +7,14 @@ pageTitle: 'Lähteelä — a gem on Kirkkonummi coast'
 title: 'Lähteelä — a gem on Kirkko­nummi coast'
 description: "Kirkkonummi acquired Lähteelä, a coastal area. One of the few places on Kirkkonummi's coast accessible without a private boat — now permanently open to all."
 publishDate: '2026-04-15'
-updatedDate: '2026-05-15'
+updatedDate: '2026-05-23'
+authors:
+  - name: 'Miisa Jeremejew'
+    role: 'municipal councillor (Greens)'
+    place: 'Kirkkonummi'
+  - name: 'Lauri Lavanti'
+    role: 'municipal councillor (Greens)'
+    place: 'Kirkkonummi'
 tags:
   - kirkkonummi
   - nature
@@ -55,7 +62,5 @@ As Lähteelä is developed, it is important to preserve its natural values and u
 Kirkkonummi is a coastal municipality. It is good that this is also reflected in how the sea and shores are accessible to all. The acquisition of Lähteelä is a step towards a municipality where nature unites and the shared environment is truly felt as shared.
 
 I have written more about Kirkkonummi's nature and planning: [why local nature is Kirkkonummi's trump card year after year](/en/blog/17/our-nature-is-our-trump-card-year-after-year/), [on cherishing local nature near schools and day-care centres](/en/blog/12/local-nature-must-be-cherished/) and [on what a growing municipality needs to thrive](/en/blog/35/a-growing-municipality-needs-a-vibrant-centre/).
-
-_Authors: Miisa Jeremejew and Lauri Lavanti, municipal councillors (Greens), Kirkkonummi._
 
 _Published in Kirkkonummen Sanomat on 22.4.2026._

--- a/src/pages/fi/about/index.mdx
+++ b/src/pages/fi/about/index.mdx
@@ -5,8 +5,8 @@ pageTitle: 'Teknologian ja yhteiskunnan rajapinnassa'
 title: 'Teknologian ja yhteis­kunnan raja­pinnassa'
 description: 'Lauri Lavanti on johtava ohjelmistokehittäjä, kunnanvaltuutettu ja Vihreän valtuustoryhmän pj. Painopisteet: talous, yrittäjyys ja digitaalinen riippumattomuus.'
 slug: 'fi/about'
-updatedDate: '2026-05-22'
-type: 'Person'
+updatedDate: '2026-05-23'
+type: 'ProfilePage'
 heroImage: Lauri-Lavanti-sitting-in-front-of-a-window
 alt: 'Lauri Lavanti istumassa tuolilla ikkunan edessä, katse kameraan, hymyillen. Hänellä on päällään valkoinen kauluspaita, jossa on sinisiä kukkakuvioita, sekä tumma pikkutakki. Kuvan otti Juha Jantunen.'
 faq:
@@ -49,11 +49,17 @@ export const components = { a: SmartLink, h2: H2, p: Paragraph }
     title="Lauri lyhyesti"
 />
 
+<section id="person">
+
 Lauri työskentelee siellä, missä teknologia muuttaa yhteiskuntaa – ja missä päätöksenteon pitäisi pysyä mukana.
 
 Lauri Lavanti on johtava ohjelmistokehittäjä, Kirkkonummen kunnanvaltuutettu sekä Vihreän valtuustoryhmän puheenjohtaja. Hän on Aalto-yliopistosta valmistunut diplomi-insinööri ja keskittyy tekoälyyn, talouteen, yrittäjyyteen, innovaatiopolitiikkaan sekä digitaaliseen riippumattomuuteen.
 
 Digitalisaatio, yksityisyyden suoja ja tekoälyn vastuullinen käyttöönotto ovat osa samaa kokonaisuutta: miten rakennamme teknologista kehitystä, joka on sekä kilpailukykyistä että kestävää niin luonnolle kuin ihmisille.
+
+Laurilla on myös [Wikipedia-artikkeli](https://fi.wikipedia.org/wiki/Lauri_Lavanti).
+
+</section>
 
 ## Digitalisaation ja yksityisyyden suojan asiantuntija
 

--- a/src/pages/fi/about/index.mdx
+++ b/src/pages/fi/about/index.mdx
@@ -49,7 +49,7 @@ export const components = { a: SmartLink, h2: H2, p: Paragraph }
     title="Lauri lyhyesti"
 />
 
-<section id="person">
+<div id="person" />
 
 Lauri työskentelee siellä, missä teknologia muuttaa yhteiskuntaa – ja missä päätöksenteon pitäisi pysyä mukana.
 
@@ -58,8 +58,6 @@ Lauri Lavanti on johtava ohjelmistokehittäjä, Kirkkonummen kunnanvaltuutettu s
 Digitalisaatio, yksityisyyden suoja ja tekoälyn vastuullinen käyttöönotto ovat osa samaa kokonaisuutta: miten rakennamme teknologista kehitystä, joka on sekä kilpailukykyistä että kestävää niin luonnolle kuin ihmisille.
 
 Laurilla on myös [Wikipedia-artikkeli](https://fi.wikipedia.org/wiki/Lauri_Lavanti).
-
-</section>
 
 ## Digitalisaation ja yksityisyyden suojan asiantuntija
 

--- a/src/pages/fi/about/index.mdx
+++ b/src/pages/fi/about/index.mdx
@@ -37,6 +37,7 @@ export const components = { a: SmartLink, h2: H2, p: Paragraph }
 
 <SummaryBox
     ariaLabel="Faktoja Laurista"
+    id="person"
     lang="fi"
     summaryRows={[
         'Yhdistää käytännön teknologiaosaamisen talousajatteluun ja yhteiskunnalliseen vastuuseen.',
@@ -48,8 +49,6 @@ export const components = { a: SmartLink, h2: H2, p: Paragraph }
     ]}
     title="Lauri lyhyesti"
 />
-
-<div id="person" />
 
 Lauri työskentelee siellä, missä teknologia muuttaa yhteiskuntaa – ja missä päätöksenteon pitäisi pysyä mukana.
 

--- a/src/pages/fi/blog/22/yksi-askel-eteen-kaksi-taakse/index.mdx
+++ b/src/pages/fi/blog/22/yksi-askel-eteen-kaksi-taakse/index.mdx
@@ -7,7 +7,11 @@ pageTitle: 'Yksi askel eteen, kaksi taakse – koulutus'
 title: 'Yksi askel eteen, kaksi taakse'
 description: 'Hallitus tekee tarpeellisia uudistuksia toiselle asteelle, mutta ne eivät korvaa ammatilliseen koulutukseen kohdistuvia 120 miljoonan leikkauksia.'
 publishDate: '2024-11-27'
-updatedDate: '2025-12-19'
+updatedDate: '2026-05-23'
+authors:
+  - name: 'Johanna Fleming'
+  - lauri
+  - name: 'Paula Oittinen'
 tags:
   - kirkkonummi
   - municipal-elections-2025

--- a/src/pages/fi/blog/22/yksi-askel-eteen-kaksi-taakse/index.mdx
+++ b/src/pages/fi/blog/22/yksi-askel-eteen-kaksi-taakse/index.mdx
@@ -57,8 +57,6 @@ Kokonaisuutena siis nämä askeleet eteenpäin eivät paikkaa hallituksen samaan
 
 Opetusministeri vastasi kirjoitukseemme — ja vastasimme takaisin: [Koulutusko erityissuojelussa?](/fi/blog/27/koulutusko-erityissuojelussa/) Laajemman kuvan siitä, miksi koulutus on kunnan tärkein tehtävä varhaiskasvatuksesta elinikäiseen oppimiseen, löydät kirjoituksesta [Koulutus on kunnan tärkein tehtävä](/fi/blog/37/koulutus-on-kunnan-tarkein-tehtava/). Kaikki koulutuskirjoitukseni ovat [opetus-kategoriassa](/fi/category/opetus/).
 
-_Kirjoittajat: Johanna Fleming, Lauri Lavanti ja Paula Oittinen._
-
 ---
 
 _Julkaistu Kirkkonummen Sanomissa 27.11.2024._

--- a/src/pages/fi/blog/27/koulutusko-erityissuojelussa/index.mdx
+++ b/src/pages/fi/blog/27/koulutusko-erityissuojelussa/index.mdx
@@ -56,8 +56,6 @@ Hallitus lupaili koulutuksen olevan erityissuojelussa - toisin kävi. Ylipääns
 
 Laajemman kuvan siitä, miksi koulutus on kunnan ydintehtävä, tarjoaa kirjoitukseni [Koulutus on kunnan tärkein tehtävä](/fi/blog/37/koulutus-on-kunnan-tarkein-tehtava/). Lue lisää koulutuskirjoituksistani [opetus-kategoriasta](/fi/category/opetus/).
 
-_Kirjoittajat: Johanna Fleming, Lauri Lavanti ja Paula Oittinen._
-
 ---
 
 _Julkaistu Kirkkonummen Sanomissa 11.12.2024._

--- a/src/pages/fi/blog/27/koulutusko-erityissuojelussa/index.mdx
+++ b/src/pages/fi/blog/27/koulutusko-erityissuojelussa/index.mdx
@@ -7,7 +7,11 @@ pageTitle: 'Suojellaanko koulutusta? Koulutusleikkaukset'
 title: 'Koulutusko erityis­suojelussa?'
 description: 'Koulutuksesta leikataan reilusti, vaikka hallitus väittää muuta. Indeksikorotukset ja lakiuudistukset eivät paikkaa satoja miljoonia leikkauksia.'
 publishDate: '2024-12-12'
-updatedDate: '2025-12-19'
+updatedDate: '2026-05-23'
+authors:
+  - name: 'Johanna Fleming'
+  - lauri
+  - name: 'Paula Oittinen'
 tags:
   - kirkkonummi
   - municipal-elections-2025

--- a/src/pages/fi/blog/41/joukkoliikenne-ei-voi-kallistua-loputtomiin/index.mdx
+++ b/src/pages/fi/blog/41/joukkoliikenne-ei-voi-kallistua-loputtomiin/index.mdx
@@ -7,7 +7,10 @@ pageTitle: 'Joukkoliikenne ei voi kallistua loputtomiin'
 title: 'Joukko­liikenne ei voi kallistua loputtomiin'
 description: 'Pääkaupunkiseudun joukkoliikenteestä vastaava HSL-kuntayhtymä suunnittelee lähivuosille tuntuvia korotuksia bussien ja junien lippujen hintoihin.'
 publishDate: '2025-08-25'
-updatedDate: '2025-12-22'
+updatedDate: '2026-05-23'
+authors:
+  - name: 'Ronja Karkinen'
+  - lauri
 tags:
   - infrastructure
   - kirkkonummi

--- a/src/pages/fi/blog/41/joukkoliikenne-ei-voi-kallistua-loputtomiin/index.mdx
+++ b/src/pages/fi/blog/41/joukkoliikenne-ei-voi-kallistua-loputtomiin/index.mdx
@@ -45,8 +45,6 @@ Nyt esillä olevilla toimilla joukkoliikennejärjestelmämme on romuttumassa. In
 
 Joukkoliikenne on myös syy, miksi [äänestin Kirkkonummen liittymisen Länsirataan puolesta](/fi/blog/46/aanestin-lansiradan-puolesta/) — juna-asema Pohjois-Kirkkonummelle olisi tarjonnut kestävän vaihtoehdon autoilulle. Valtuuston päätös vetäytyä hankkeesta on nyt aiheuttanut pettymystä, jota käsittelen tekstissä [Länsirata nosti esiin ongelmia Kirkkonummen päätöksenteossa](/fi/blog/50/lansirata-paatos-nosti-esiin-ongelmia-kirkkonummen-pitkajanteisessa-strategisessa-kehittamisessa/). Lue lisää [liikenne-kategoriasta](/fi/category/liikenne/).
 
-_Kirjoittajat: Ronja Karkinen ja Lauri Lavanti._
-
 ---
 
 _Julkaistu Kirkkonummen Sanomissa 20.8.2025._

--- a/src/pages/fi/blog/48/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/index.mdx
+++ b/src/pages/fi/blog/48/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/index.mdx
@@ -10,6 +10,7 @@ publishDate: '2026-01-23'
 updatedDate: '2026-05-23'
 authors:
   - name: 'Atte Harjanne'
+    role: 'kansanedustaja'
   - lauri
 tags:
   - technology

--- a/src/pages/fi/blog/48/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/index.mdx
+++ b/src/pages/fi/blog/48/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/index.mdx
@@ -7,7 +7,10 @@ pageTitle: 'Passitunnisteiden käyttöä ei saa laajentaa'
 title: 'Passien bio­metristen tunnisteiden käyttöä ei pidä laajentaa'
 description: 'Kun sormenjäljet tuotiin passeihin, Suomeen perustettiin kansallinen biometrinen rekisteri. Nyt hallitus haluaa avata sen poliisin käyttöön.'
 publishDate: '2026-01-23'
-updatedDate: '2026-05-15'
+updatedDate: '2026-05-23'
+authors:
+  - name: 'Atte Harjanne'
+  - lauri
 tags:
   - technology
   - privacy

--- a/src/pages/fi/blog/48/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/index.mdx
+++ b/src/pages/fi/blog/48/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/index.mdx
@@ -71,8 +71,6 @@ Viranomaisilla on oltava riittävät keinot taata yhteiskunnan turvallisuus. Tur
 
 Digitaalisista oikeuksista ja teknologiasta olen kirjoittanut lisää: [perusoikeuksien purkamisesta](/fi/blog/45/perusoikeuksia-ei-pida-purkaa-perusteettomasti/), [digitaalisesta itsenäisyydestä](/fi/blog/51/digitaalinen-itsenaisyys-on-valttamattomyys/) sekä [tekoälyn mahdollisuuksista ja rajoista julkisissa palveluissa](/fi/blog/44/tekoaly-ei-pysty-mihin-tahansa/). Lue lisää [teknologiaa käsittelevistä kirjoituksistani](/fi/category/teknologia/).
 
-_Kirjoittajat: Atte Harjanne ja Lauri Lavanti._
-
 ---
 
 _Yksi versio tekstistä julkaistu _[_Helsingin Sanomissa_](https://www.hs.fi/mielipide/art-2000011743934.html)_ 14.1.2026 ja _[_Atte Harjanteen blogissa_](https://atteharjanne.fi/2026/01/15/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/)_ 15.1.2026._

--- a/src/pages/fi/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/index.mdx
+++ b/src/pages/fi/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/index.mdx
@@ -10,11 +10,9 @@ publishDate: '2026-04-15'
 updatedDate: '2026-05-23'
 authors:
   - name: 'Miisa Jeremejew'
-    role: 'kunnanvaltuutettu (vihr.)'
-    place: 'Kirkkonummi'
+    role: 'kunnanvaltuutettu'
   - name: 'Lauri Lavanti'
-    role: 'kunnanvaltuutettu (vihr.)'
-    place: 'Kirkkonummi'
+    role: 'kunnanvaltuutettu'
 tags:
   - kirkkonummi
   - nature

--- a/src/pages/fi/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/index.mdx
+++ b/src/pages/fi/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/index.mdx
@@ -61,6 +61,4 @@ Kirkkonummi on rannikkokunta. On hyvä, että tämä näkyy myös siinä, miten 
 
 Lue lisää Kirkkonummen luonnosta ja yhteisistä tiloista: [luontomme on valttimme vuodesta toiseen](/fi/blog/17/luontomme-on-valttimme-vuodesta-toiseen/), [lähiluontoa pitää vaalia](/fi/blog/12/lahiluontoa-pitaa-vaalia/) sekä [kasvava kunta tarvitsee elinvoimaisen keskustan](/fi/blog/35/kasvava-kunta-tarvitsee-elinvoimaisen-keskustan/).
 
-_Kirjoittajat: Miisa Jeremejew ja Lauri Lavanti, kunnanvaltuutettuja (vihr.), Kirkkonummi._
-
 _Julkaistu Kirkkonummen Sanomissa 22.4.2026._

--- a/src/pages/fi/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/index.mdx
+++ b/src/pages/fi/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/index.mdx
@@ -7,7 +7,14 @@ pageTitle: 'Lähteelä — helmi Kirkkonummen rannikolla'
 title: 'Lähteelä — yhteinen helmi Kirkko­nummen rannikolla'
 description: 'Kirkkonummi osti Lähteelän rannikkokohteen. Se on yksi harvoista paikoista, jonne pääsee myös ilman omaa venettä — nyt se on pysyvästi kaikkien saavutettavissa.'
 publishDate: '2026-04-15'
-updatedDate: '2026-05-15'
+updatedDate: '2026-05-23'
+authors:
+  - name: 'Miisa Jeremejew'
+    role: 'kunnanvaltuutettu (vihr.)'
+    place: 'Kirkkonummi'
+  - name: 'Lauri Lavanti'
+    role: 'kunnanvaltuutettu (vihr.)'
+    place: 'Kirkkonummi'
 tags:
   - kirkkonummi
   - nature

--- a/src/pages/fi/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/index.mdx
+++ b/src/pages/fi/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/index.mdx
@@ -11,8 +11,7 @@ updatedDate: '2026-05-23'
 authors:
   - name: 'Miisa Jeremejew'
     role: 'kunnanvaltuutettu'
-  - name: 'Lauri Lavanti'
-    role: 'kunnanvaltuutettu'
+  - lauri
 tags:
   - kirkkonummi
   - nature

--- a/src/pages/sv/about/index.mdx
+++ b/src/pages/sv/about/index.mdx
@@ -5,8 +5,8 @@ pageTitle: 'I gränslandet mellan teknologi och samhälle'
 title: 'I gränslandet mellan teknologi och samhälle'
 description: 'Lauri Lavanti är ledande mjukvaruutvecklare, fullmäktigeledamot och ordförande för De Grönas grupp. Fokus: ekonomi, företagande och digital självständighet.'
 slug: 'sv/about'
-updatedDate: '2026-05-22'
-type: 'Person'
+updatedDate: '2026-05-23'
+type: 'ProfilePage'
 heroImage: 'Lauri-Lavanti-sitting-in-front-of-a-window'
 alt: 'Lauri Lavanti sittande på en stol framför ett fönster, blicken mot kameran, leende. Han har på sig en vit skjorta med blå blomstermönster och en mörk kavaj. Bilden togs av Juha Jantunen.'
 faq:
@@ -54,6 +54,8 @@ Lauri arbetar där teknologin förändrar samhället – och där beslutsfattand
 Lauri Lavanti är ledande mjukvaruutvecklare, kommunfullmäktigeledamot i Kyrkslätt samt ordförande för De Grönas fullmäktigegrupp. Han är utexaminerad diplomingenjör från Aalto-universitetet och fokuserar på AI, ekonomisk politik, företagande, innovationspolitik samt digital självständighet.
 
 Digitalisering, integritetsskydd och ansvarsfull implementering av artificiell intelligens är delar av samma helhet: hur vi bygger teknologisk utveckling som är både konkurrenskraftig och hållbar för naturen och människorna.
+
+Lauri har också en [Wikipedia-artikel](https://fi.wikipedia.org/wiki/Lauri_Lavanti) (på finska).
 
 ## Expert på digitalisering och integritetsskydd
 

--- a/src/pages/sv/blog/22/ett-steg-fram-tva-steg-tillbaka/index.mdx
+++ b/src/pages/sv/blog/22/ett-steg-fram-tva-steg-tillbaka/index.mdx
@@ -7,7 +7,11 @@ pageTitle: 'Ett steg fram, två steg tillbaka i skolan'
 title: 'Ett steg fram, två steg tillbaka'
 description: 'Regeringen gör nödvändiga reformer för gymnasiet, men de kompenserar inte nedskärningarna på 120 miljoner euro i yrkesutbildningen.'
 publishDate: '2024-11-27'
-updatedDate: '2026-03-02'
+updatedDate: '2026-05-23'
+authors:
+  - name: 'Johanna Fleming'
+  - lauri
+  - name: 'Paula Oittinen'
 tags:
   - kirkkonummi
   - municipal-elections-2025

--- a/src/pages/sv/blog/22/ett-steg-fram-tva-steg-tillbaka/index.mdx
+++ b/src/pages/sv/blog/22/ett-steg-fram-tva-steg-tillbaka/index.mdx
@@ -57,8 +57,6 @@ Som helhet kompenserar alltså dessa steg framåt inte för de steg bakåt som r
 
 Undervisningsministern svarade på vår artikel — och vi svarade tillbaka: [Är utbildningen under särskilt skydd?](/sv/blog/27/ar-utbildningen-under-sarskilt-skydd/) En bredare bild av varför utbildning är kommunens viktigaste uppgift, från småbarnspedagogik till livslångt lärande, finns i [Utbildning är kommunens viktigaste uppgift](/sv/blog/37/utbildning-ar-kommunens-viktigaste-uppgift/). Alla mina utbildningstexter finns i [utbildningskategorin](/sv/category/opetus/).
 
-_Skribenter: Johanna Fleming, Lauri Lavanti och Paula Oittinen._
-
 ---
 
 _Publicerad i Kirkkonummen Sanomat den 27 november 2024._

--- a/src/pages/sv/blog/27/ar-utbildningen-under-sarskilt-skydd/index.mdx
+++ b/src/pages/sv/blog/27/ar-utbildningen-under-sarskilt-skydd/index.mdx
@@ -56,8 +56,6 @@ Regeringen lovade att utbildningen skulle vara under särskilt skydd — det gic
 
 En bredare bild av utbildningens roll i kommunen finns i [Utbildning är kommunens viktigaste uppgift](/sv/blog/37/utbildning-ar-kommunens-viktigaste-uppgift/). Läs mer i [utbildningskategorin](/sv/category/opetus/).
 
-_Skribenter: Johanna Fleming, Lauri Lavanti och Paula Oittinen._
-
 ---
 
 _Publicerad i Kirkkonummen Sanomat den 11 december 2024._

--- a/src/pages/sv/blog/27/ar-utbildningen-under-sarskilt-skydd/index.mdx
+++ b/src/pages/sv/blog/27/ar-utbildningen-under-sarskilt-skydd/index.mdx
@@ -7,7 +7,11 @@ pageTitle: 'Är utbildningen under särskilt skydd?'
 title: 'Är utbildningen under särskilt skydd?'
 description: 'Utbildningen skärs ned kraftigt, trots att regeringen hävdar motsatsen. Indexhöjningar och lagreformer täcker inte hundratals miljoner i nedskärningar.'
 publishDate: '2024-12-12'
-updatedDate: '2026-03-02'
+updatedDate: '2026-05-23'
+authors:
+  - name: 'Johanna Fleming'
+  - lauri
+  - name: 'Paula Oittinen'
 tags:
   - kirkkonummi
   - municipal-elections-2025

--- a/src/pages/sv/blog/41/kollektivtrafiken-kan-inte-bli-dyrare-i-all-oandlighet/index.mdx
+++ b/src/pages/sv/blog/41/kollektivtrafiken-kan-inte-bli-dyrare-i-all-oandlighet/index.mdx
@@ -45,8 +45,6 @@ Med de åtgärder som nu diskuteras är vårt kollektivtrafiksystem på väg att
 
 Kollektivtrafik är också anledningen till att [jag röstade för Kyrkslätts anslutning till Västernabanan](/sv/blog/46/jag-rostade-for-vasternabanan/) — en järnvägsstation i norra Kyrkslätt hade erbjudit ett hållbart alternativ till bilen. Fullmäktiges beslut att dra sig ur projektet har nu lett till besvikelse, vilket jag behandlar i [Västbanan avslöjade problem i Kyrkslätts beslutsfattande](/sv/blog/50/vastbanan-beslutet-avslojat-problem-i-kyrkslatts-langsiktiga-strategiska-utveckling/). Läs mer i [trafikkategorin](/sv/category/liikenne/).
 
-_Skribenter: Ronja Karkinen och Lauri Lavanti._
-
 ---
 
 _Publicerad i Kirkkonummen Sanomat den 20 augusti 2025._

--- a/src/pages/sv/blog/41/kollektivtrafiken-kan-inte-bli-dyrare-i-all-oandlighet/index.mdx
+++ b/src/pages/sv/blog/41/kollektivtrafiken-kan-inte-bli-dyrare-i-all-oandlighet/index.mdx
@@ -7,7 +7,10 @@ pageTitle: 'Kollektivtrafiken kan inte bli dyrare'
 title: 'Kollek­tiv­trafiken kan inte bli dyrare i all oändlighet'
 description: 'HSL, samkommunen som ansvarar för kollektivtrafiken i huvudstadsregionen, planerar avsevärda biljetthöjningar för bussar och tåg under de kommande åren.'
 publishDate: '2025-08-25'
-updatedDate: '2026-03-02'
+updatedDate: '2026-05-23'
+authors:
+  - name: 'Ronja Karkinen'
+  - lauri
 tags:
   - infrastructure
   - kirkkonummi

--- a/src/pages/sv/blog/48/anvandningen-av-biometriska-identifierare-i-pass-far-inte-utvidgas/index.mdx
+++ b/src/pages/sv/blog/48/anvandningen-av-biometriska-identifierare-i-pass-far-inte-utvidgas/index.mdx
@@ -71,8 +71,6 @@ Myndigheterna måste ha tillräckliga medel för att garantera samhällets säke
 
 Om digitala rättigheter och teknologi har jag skrivit mer: [om att riva grundläggande rättigheter](/sv/blog/45/grundlaggande-rattigheter-far-inte-rivas-utan-grund/), [om digital självständighet](/sv/blog/51/digital-sjalvstandighet-ar-en-nodvandighet/) samt [om vad AI kan göra i offentliga tjänster](/sv/blog/44/ai-kan-inte-allt/). Läs mer i [mina texter om teknologi](/sv/category/teknologia/).
 
-_Skribenter: Atte Harjanne och Lauri Lavanti._
-
 ---
 
 _En version av texten publicerad i [Helsingin Sanomat](https://www.hs.fi/mielipide/art-2000011743934.html) den 14 januari 2026 och i [Atte Harjannes blogg](https://atteharjanne.fi/2026/01/15/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/) den 15 januari 2026.*

--- a/src/pages/sv/blog/48/anvandningen-av-biometriska-identifierare-i-pass-far-inte-utvidgas/index.mdx
+++ b/src/pages/sv/blog/48/anvandningen-av-biometriska-identifierare-i-pass-far-inte-utvidgas/index.mdx
@@ -10,6 +10,7 @@ publishDate: '2026-01-23'
 updatedDate: '2026-05-23'
 authors:
   - name: 'Atte Harjanne'
+    role: 'riksdagsledamot'
   - lauri
 tags:
   - technology

--- a/src/pages/sv/blog/48/anvandningen-av-biometriska-identifierare-i-pass-far-inte-utvidgas/index.mdx
+++ b/src/pages/sv/blog/48/anvandningen-av-biometriska-identifierare-i-pass-far-inte-utvidgas/index.mdx
@@ -7,7 +7,10 @@ pageTitle: 'Biometriska identifierare i pass – motstånd'
 title: 'Använd­ningen av biometriska identi­fierare i pass får inte utvidgas'
 description: 'När fingeravtryck infördes i pass skapades ett nationellt biometriskt register i Finland. Nu vill regeringen öppna det för polisens bruk.'
 publishDate: '2026-01-23'
-updatedDate: '2026-05-15'
+updatedDate: '2026-05-23'
+authors:
+  - name: 'Atte Harjanne'
+  - lauri
 tags:
   - technology
   - privacy

--- a/src/pages/sv/blog/56/lahteela-en-gemma-vid-kyrkslaendets-kust/index.mdx
+++ b/src/pages/sv/blog/56/lahteela-en-gemma-vid-kyrkslaendets-kust/index.mdx
@@ -11,8 +11,7 @@ updatedDate: '2026-05-23'
 authors:
   - name: 'Miisa Jeremejew'
     role: 'kommunfullmäktigeledamot'
-  - name: 'Lauri Lavanti'
-    role: 'kommunfullmäktigeledamot'
+  - lauri
 tags:
   - kirkkonummi
   - nature

--- a/src/pages/sv/blog/56/lahteela-en-gemma-vid-kyrkslaendets-kust/index.mdx
+++ b/src/pages/sv/blog/56/lahteela-en-gemma-vid-kyrkslaendets-kust/index.mdx
@@ -7,7 +7,14 @@ pageTitle: 'Lähteelä — en gem vid Kyrksländets kust'
 title: 'Lähteelä — en gem vid Kyrks­ländets kust'
 description: 'Kyrksländ köpte Lähteelä som kustanläggning. En av få platser vid kusten dit man kan ta sig utan egen båt — nu permanent tillgängligt för alla invånare.'
 publishDate: '2026-04-15'
-updatedDate: '2026-05-15'
+updatedDate: '2026-05-23'
+authors:
+  - name: 'Miisa Jeremejew'
+    role: 'kommunfullmäktigeledamot (gröna)'
+    place: 'Kyrkslätt'
+  - name: 'Lauri Lavanti'
+    role: 'kommunfullmäktigeledamot (gröna)'
+    place: 'Kyrkslätt'
 tags:
   - kirkkonummi
   - nature

--- a/src/pages/sv/blog/56/lahteela-en-gemma-vid-kyrkslaendets-kust/index.mdx
+++ b/src/pages/sv/blog/56/lahteela-en-gemma-vid-kyrkslaendets-kust/index.mdx
@@ -10,11 +10,9 @@ publishDate: '2026-04-15'
 updatedDate: '2026-05-23'
 authors:
   - name: 'Miisa Jeremejew'
-    role: 'kommunfullmäktigeledamot (gröna)'
-    place: 'Kyrkslätt'
+    role: 'kommunfullmäktigeledamot'
   - name: 'Lauri Lavanti'
-    role: 'kommunfullmäktigeledamot (gröna)'
-    place: 'Kyrkslätt'
+    role: 'kommunfullmäktigeledamot'
 tags:
   - kirkkonummi
   - nature

--- a/src/pages/sv/blog/56/lahteela-en-gemma-vid-kyrkslaendets-kust/index.mdx
+++ b/src/pages/sv/blog/56/lahteela-en-gemma-vid-kyrkslaendets-kust/index.mdx
@@ -61,6 +61,4 @@ Kyrksländ är en kustkommun. Det är bra att detta också syns i hur havet och 
 
 Jag har skrivit mer om Kyrksländets natur och planläggning: [varför vår natur är vårt trumfkort år efter år](/sv/blog/17/var-natur-ar-vart-trumfkort-ar-efter-ar/), [om att värna närnatur nära skolor och daghem](/sv/blog/12/narnaturen-maste-vardas/) och [om vad en växande kommun behöver för att blomstra](/sv/blog/35/en-vaxande-kommun-behover-ett-livskraftigt-centrum/).
 
-_Skribenter: Miisa Jeremejew och Lauri Lavanti, kommunfullmäktigeledamöter (gröna), Kyrksländ._
-
 _Publicerad i Kirkkonummen Sanomat den 22 april 2026._


### PR DESCRIPTION
> This PR contains AI-generated code. The author has reviewed and is responsible for all AI-generated content.

Closes #1244

## Summary

- Add `src/content/person.ts` — single source of truth for all Person JSON-LD data; includes canonical `@id`, Wikipedia + Wikidata in `sameAs`, localized `knowsAbout`, `worksFor`, `alumniOf`, `hasOccupation`, `affiliation`
- Add `PROFILEPAGE` constant to `src/lib/jsonld.ts`
- Refactor `src/components/Head.astro` — import from `person.ts`, emit canonical `ProfilePage > mainEntity Person` on About pages, emit `author` as `@id` reference array on `BlogPosting`, support optional `authors` prop for co-authored posts
- Add `authors?: AuthorEntry[]` field to `MdxPost` interface
- Update `Head.spec.ts` with full assertions for new schema shape

## Still to do (tracked in issue checklist)

- [ ] Update About page frontmatter: `type: 'Person'` → `'ProfilePage'`
- [ ] Add `id="person"` anchor to fi About page
- [ ] Add Wikipedia link sentence to all three About pages
- [ ] Implement auto-byline in `PostLayout.astro`
- [ ] Migrate 5 co-authored posts (add `authors` frontmatter, remove inline `_Authors:…_` from en versions)

## Test plan

- [x] `npm run test` passes (865 tests)
- [x] `npm run check` passes
- [x] `npm run lint` passes
- [ ] `npm run build && npm run preview` — visual + source verification
- [ ] `npm run test:e2e` after all changes merged