### PR TITLE
feat(content): add post 62 – Vihreät markkinatalouden aito puolustaja

### DIFF
--- a/src/pages/en/blog/62/greens-the-true-defenders-of-the-market-economy/index.mdx
+++ b/src/pages/en/blog/62/greens-the-true-defenders-of-the-market-economy/index.mdx
@@ -25,6 +25,16 @@ faq:
     a: 'The Greens want to shift the tax burden from work to harms – pollution, overuse of natural resources, and abuse of monopoly positions would cost more. This differs from the National Coalition Party''s budget-discipline focus and from the left''s regulation and redistribution emphasis.'
 ---
 
+import BlockQuote from '../../../../../components/body/BlockQuote.astro'
+import SmartLink from '../../../../../components/SmartLink.astro'
+import H2 from '../../../../../components/H2.astro'
+import H3 from '../../../../../components/H3.astro'
+import LI from '../../../../../components/LI.astro'
+import Paragraph from '../../../../../components/Paragraph.astro'
+import UL from '../../../../../components/UL.astro'
+
+export const components = { blockquote: BlockQuote, a: SmartLink, h2: H2, h3: H3, p: Paragraph, ul: UL, li: LI }
+
 The Green Party congress convened in Turku on 24–25 May 2026 to adopt a new party programme. I submitted amendment proposal 36/Lavanti, which would have added the following sentence to the programme introduction: *For the Greens, the market economy is a tool to effectively advance these goals.* The proposal received strong support, but not enough votes to reach the introduction – the sentence was instead added to the economic section. I also gave a speech at the congress, reproduced in full below.
 
 Esteemed party congress,

--- a/src/pages/en/blog/62/greens-the-true-defenders-of-the-market-economy/index.mdx
+++ b/src/pages/en/blog/62/greens-the-true-defenders-of-the-market-economy/index.mdx
@@ -1,0 +1,52 @@
+---
+layout: '../../../../../layouts/PostLayout.astro'
+id: 62
+slug: 'greens-the-true-defenders-of-the-market-economy'
+lang: 'en'
+title: 'Greens – The True Defenders of the Market Economy'
+pageTitle: 'Greens: The True Market Economy Party'
+description: 'The market economy is the best known way to allocate resources. The Greens are its only true defender in Finland – real markets, not accountant economics.'
+publishDate: '2026-05-26'
+updatedDate: '2026-05-26'
+tags:
+  - economy
+  - green-party
+  - national-politics
+heroImage: vihreiden-puoluekokous-Turussa-2026
+alt: 'Green Party congress in Turku 2026'
+faq:
+  - q: 'Do the Greens support the market economy?'
+    a: 'Yes. For the Greens, the market economy is the most effective known way to allocate resources – but only when externalities are priced in, competition is fair, and pollution has a cost. Markets do not work by themselves: they need rules that prevent monopolies and correct harms.'
+  - q: 'What does it mean that the National Coalition Party pursues accountant economics rather than market economics?'
+    a: 'Accountant economics aims at balanced bookkeeping – short-term budget discipline – rather than market functioning or long-term growth. The Green view is that taxing harms, ensuring fair competition, and pricing externalities produce more sustainable economic growth than spending cuts alone.'
+  - q: 'What did the Green Party congress 2026 decide on the market economy?'
+    a: 'The 2026 Turku congress adopted a new party programme. Amendment proposal 36/Lavanti would have added a market economy statement to the programme introduction; it did not receive enough votes for the introduction, but the sentence "For the Greens, the market economy is a tool to effectively advance these goals" was added to the economic section.'
+  - q: 'How do the Greens differ from other parties on economic policy?'
+    a: 'The Greens want to shift the tax burden from work to harms – pollution, overuse of natural resources, and abuse of monopoly positions would cost more. This differs from the National Coalition Party''s budget-discipline focus and from the left''s regulation and redistribution emphasis.'
+---
+
+The Green Party congress convened in Turku on 24–25 May 2026 to adopt a new party programme. I submitted amendment proposal 36/Lavanti, which would have added the following sentence to the programme introduction: *For the Greens, the market economy is a tool to effectively advance these goals.* The proposal received strong support, but not enough votes to reach the introduction – the sentence was instead added to the economic section. I also gave a speech at the congress, reproduced in full below.
+
+Esteemed party congress,
+
+The market economy is one of humanity's most powerful inventions. No other mechanism is as effective at allocating resources, whether services or goods, and it is time for us Greens to say this out loud.
+
+After this government term, it should by now be clear to everyone that the National Coalition Party does not pursue market economics but accountant economics. The alternative is not the Left Alliance, which focuses mainly on opposing change and pursues socialism. Markets would not work better if we banned and regulated everything. The alternative is not the Social Democrats either, who would do everything the same as the National Coalition Party, but more fairly. If we want a market economy that takes externalities and sustainability into account, there is no better alternative than the Greens.
+
+Voters clearly know this too. Even though the party's communication focuses mainly on themes associated with the left, support has drained from us to parties further left. At the same time, growth comes mainly from the right and centre. In other words, people are now clearly looking for an alternative to the National Coalition Party. The best alternative is the Greens. Markets work best when pollution has a cost. When externalities are priced in. When competition is fair and money cannot buy a monopoly position. That is not ideology – it is common sense.
+
+The market economy cannot of course be free of all regulation – but free of unfair competition. It is not the privilege of large corporations, but the opportunity for small and new businesses. It is not the pursuit of short-term profits, but long-term sustainable growth. When taxes are collected on harms, not on work. When markets are transparent and fair.
+
+Let us raise the market economy to the introduction of our political programme – where it belongs, as I proposed in amendment 36/Lavanti.
+
+We want a Finland where the economy grows, but nature is not destroyed.
+We want a Finland where innovations flourish, and monopolies do not dominate.
+We want a Finland where competition is fair and everyone can realise their potential.
+
+This is our moment. Let us be the party that takes care of the economy and wellbeing.
+
+Thank you.
+
+## Why are the Greens the true defenders of the market economy?
+
+Green economic policy is built on three principles: harms have a cost, competition is fair, and markets are transparent. I have written about this in more detail previously: [green economic policy requires a seat at the table](/en/blog/61/green-economic-policy-requires-a-seat-at-the-table/). The market economy and sustainability are not opposites – they are two sides of the same coin. See also [how AI changes the economics of public services](/en/blog/60/ai-helps-secure-municipal-services-but-it-isnt-free/) and what that means for market development. All my writing on economics is in the [economy category](/en/category/economy).

--- a/src/pages/fi/blog/62/vihreat-markkinatalouden-aito-puolustaja/index.mdx
+++ b/src/pages/fi/blog/62/vihreat-markkinatalouden-aito-puolustaja/index.mdx
@@ -25,6 +25,16 @@ faq:
     a: 'Vihreät haluavat siirtää verotuksen painopisteen työstä haittoihin – saastuttaminen, luonnonvarojen ylikulutus ja monopoliaseman hyväksikäyttö maksaisivat enemmän. Tämä poikkeaa sekä Kokoomuksen budjettikurikeskeisestä linjasta että vasemmiston sääntely- ja tulonjakopainotuksesta.'
 ---
 
+import BlockQuote from '../../../../../components/body/BlockQuote.astro'
+import SmartLink from '../../../../../components/SmartLink.astro'
+import H2 from '../../../../../components/H2.astro'
+import H3 from '../../../../../components/H3.astro'
+import LI from '../../../../../components/LI.astro'
+import Paragraph from '../../../../../components/Paragraph.astro'
+import UL from '../../../../../components/UL.astro'
+
+export const components = { blockquote: BlockQuote, a: SmartLink, h2: H2, h3: H3, p: Paragraph, ul: UL, li: LI }
+
 Vihreiden puoluekokous kokoontui Turussa 24.–25. toukokuuta 2026 vahvistamaan uuden puolueohjelman. Tein muutosesityksen 36/Lavanti, jolla olisin lisännyt ohjelman johdantoon lauseen: *Vihreille markkinatalous on työkalu, jolla näitä päämääriä voidaan tehokkaasti edistää.* Esitys sai vahvan tuen, mutta ääniä ei riittänyt johdantoon saakka – lause lisättiin ohjelman talousosaan. Pidin kokouksessa myös puheenvuoron, joka on kokonaisuudessaan alla.
 
 Arvon puoluekokous

--- a/src/pages/fi/blog/62/vihreat-markkinatalouden-aito-puolustaja/index.mdx
+++ b/src/pages/fi/blog/62/vihreat-markkinatalouden-aito-puolustaja/index.mdx
@@ -1,0 +1,52 @@
+---
+layout: '../../../../../layouts/PostLayout.astro'
+id: 62
+slug: 'vihreat-markkinatalouden-aito-puolustaja'
+lang: 'fi'
+title: 'Vihreät – Markki­natalouden aito puolustaja'
+pageTitle: 'Vihreät – Markkinatalouden aito puolustaja'
+description: 'Markkinatalous on tehokkain tunnettu tapa jakaa resursseja. Vihreät on sen ainoa aito puolustaja Suomessa – ei kamreritaloutta, vaan aitoja markkinoita.'
+publishDate: '2026-05-26'
+updatedDate: '2026-05-26'
+tags:
+  - economy
+  - green-party
+  - national-politics
+heroImage: vihreiden-puoluekokous-Turussa-2026
+alt: 'Vihreiden puoluekokous Turussa 2026'
+faq:
+  - q: 'Kannattavatko Vihreät markkinataloutta?'
+    a: 'Kyllä. Vihreille markkinatalous on tehokkain tunnettu tapa jakaa resursseja – mutta vain silloin, kun ulkoisvaikutukset on hinnoiteltu, kilpailu on reilua ja saastuttaminen maksaa. Markkinat eivät toimi itsekseen: ne tarvitsevat pelisäännöt, jotka estävät monopolit ja korjaavat haitat.'
+  - q: 'Mitä tarkoittaa, että Kokoomus ajaa kamreritaloutta eikä markkinataloutta?'
+    a: 'Kamreritaloudessa taloudenpito tähtää tasapainoiseen kirjanpitoon – lyhyen tähtäimen budjettikuriin – eikä markkinoiden toimivuuteen tai pitkän aikavälin kasvuun. Vihreän näkemyksen mukaan haittojen verotus, reilun kilpailun turvaaminen ja ulkoisvaikutusten hinnoittelu tuottavat kestävämpää talouskasvua kuin pelkkä menoleikkaus.'
+  - q: 'Mitä Vihreiden puoluekokous 2026 päätti markkinataloudesta?'
+    a: 'Turun puoluekokouksessa 2026 hyväksyttiin uusi puolueohjelma. Muutosesitys 36/Lavanti olisi lisännyt markkinatalouskirjauksen ohjelman johdantoon; se ei saanut riittävästi ääniä johdantoon, mutta lause "Vihreille markkinatalous on työkalu, jolla näitä päämääriä voidaan tehokkaasti edistää" lisättiin ohjelman talousosaan.'
+  - q: 'Miten Vihreät eroavat talouspolitiikassa muista puolueista?'
+    a: 'Vihreät haluavat siirtää verotuksen painopisteen työstä haittoihin – saastuttaminen, luonnonvarojen ylikulutus ja monopoliaseman hyväksikäyttö maksaisivat enemmän. Tämä poikkeaa sekä Kokoomuksen budjettikurikeskeisestä linjasta että vasemmiston sääntely- ja tulonjakopainotuksesta.'
+---
+
+Vihreiden puoluekokous kokoontui Turussa 24.–25. toukokuuta 2026 vahvistamaan uuden puolueohjelman. Tein muutosesityksen 36/Lavanti, jolla olisin lisännyt ohjelman johdantoon lauseen: *Vihreille markkinatalous on työkalu, jolla näitä päämääriä voidaan tehokkaasti edistää.* Esitys sai vahvan tuen, mutta ääniä ei riittänyt johdantoon saakka – lause lisättiin ohjelman talousosaan. Pidin kokouksessa myös puheenvuoron, joka on kokonaisuudessaan alla.
+
+Arvon puoluekokous
+
+Markkinatalous on yksi ihmiskunnan voimakkaimmista keksinnöistä. Mikään muu keino ei ole yhtä tehokas jakamaan resursseja, oli sitten kyse palveluista tai materiaalista, ja meidän Vihreiden on aika sanoa se nyt ääneen.
+
+Tämän hallituskauden jälkeen pitäisi viimeistään olla kaikille selvää, että Kokoomus ei aja markkina-, vaan kamreeritaloutta. Vaihtoehto sille ei ole Vasemmistoliitto, joka keskittyy lähinnä vastustamaan muutoksia ja ajaa sosialismia. Markkinat eivät toimisi sen paremmin, jos kieltäisimme ja sääntelisimme kaiken. Vaihtoehto ei ole myöskään SDP, joka tekisi kaiken samoin kuin Kokoomus, mutta reilummin. Jos haluamme markkinataloutta, joka huomioi ulkoisvaikutukset ja kestävyyden, ei Vihreitä parempaa vaihtoehtoa ole.
+
+Myös äänestäjät selvästi tietävät sen. Vaikka puolueen viestintä keskittyy lähinnä vasemmalle liitettyihin teemoihin, on meiltä valunut kannatusta meistä vasemmalla oleviin puolueisiin. Samaan aikaan kasvu tulee lähinnä oikealta ja keskeltä. Toisin sanoen kansa hakee nyt selvästi vaihtoehtoa Kokoomukselle. Paras vaihtoehto siihen on Vihreät. Markkinat toimivat parhaiten, kun saastuttaminen maksaa. Kun ulkoisvaikutukset on hinnoiteltu. Kun kilpailu on reilua eikä rahalla voi ostaa monopoliasemaa. Se ei ole ideologiaa — se on tervettä järkeä.
+
+Markkinatalous ei tietenkään voi olla vapaa kaikesta sääntelystä — vaan vapaa epäreilusta kilpailusta. Se ei ole suuryritysten etuoikeus, vaan pienten ja uusien yritysten mahdollisuus. Se ei ole lyhyen tähtäimen voittojen tavoittelua, vaan pitkän tähtäimen kestävää kasvu. Kun verot kerätään haitoista, ei työstä. Kun markkinat ovat läpinäkyvät ja reilut.
+
+Nostakaamme markkinatalous poliittisen ohjelmamme johdantoon — mihin se kuuluu, kuten esitin muutosesityksessä 36/Lavanti.
+
+Me haluamme Suomen, jossa talous kasvaa, mutta luonto ei tuhoudu.
+Me haluamme Suomen, jossa innovaatiot kukoistavat, eivätkä monopolit hallitse.
+Me haluamme Suomen, jossa kilpailu on reilua ja jokainen pääsee toteuttamaan itseään.
+
+Tämä on meidän hetkemme. Olkaamme se puolue, joka huolehtii taloudesta ja hyvinvoinnista.
+
+Kiitos.
+
+## Miksi Vihreät on markkinatalouden aito puolustaja?
+
+Vihreä talouspolitiikka rakentuu kolmelle periaatteelle: haitat maksavat, kilpailu on reilua, ja markkinat ovat läpinäkyvät. Olen kirjoittanut tästä tarkemmin aiemmin: [velkajarrussa tehdään vihreää talouspolitiikkaa](/fi/blog/61/velkajarrun-ulkopuolelta-ei-tehda-vihreaa-talouspolitiikkaa/). Markkinatalous ja kestävyys eivät ole vastakkaisia – ne ovat saman asian kaksi puolta. Katso myös, [miten tekoäly muuttaa julkisten palvelujen taloutta](/fi/blog/60/tekoaly-auttaa-palvelujen-turvaamisessa-mutta-se-ei-ole-ilmaista/) ja mitä se tarkoittaa markkinoiden kehitykselle. Kaikki talouteen liittyvät kirjoitukseni löydät [talous-kategoriasta](/fi/category/economy).

--- a/src/pages/sv/blog/62/de-grona-marknadsekonomiets-sanna-forsvarare/index.mdx
+++ b/src/pages/sv/blog/62/de-grona-marknadsekonomiets-sanna-forsvarare/index.mdx
@@ -1,0 +1,52 @@
+---
+layout: '../../../../../layouts/PostLayout.astro'
+id: 62
+slug: 'de-grona-marknadsekonomiets-sanna-forsvarare'
+lang: 'sv'
+title: 'De gröna – Marknads­ekonomiets sanna försvarare'
+pageTitle: 'De gröna: Marknadsekonomiets försvarare'
+description: 'Marknadsekonomin är det bästa sättet att fördela resurser. De gröna är dess enda sanna försvarare i Finland – riktiga marknader, inte kamrerekonomi.'
+publishDate: '2026-05-26'
+updatedDate: '2026-05-26'
+tags:
+  - economy
+  - green-party
+  - national-politics
+heroImage: vihreiden-puoluekokous-Turussa-2026
+alt: 'Grönas partikongress i Åbo 2026'
+faq:
+  - q: 'Stöder De gröna marknadsekonomin?'
+    a: 'Ja. För De gröna är marknadsekonomin det effektivaste kända sättet att fördela resurser – men bara när externa effekter är prissatta, konkurrensen är rättvis och förorening kostar. Marknader fungerar inte av sig själva: de behöver regler som förhindrar monopol och korrigerar skador.'
+  - q: 'Vad innebär det att Samlingspartiet bedriver kamrerekonomi snarare än marknadsekonomi?'
+    a: 'Kamrerekonomi syftar till balanserad bokföring – kortsiktig budgetdisciplin – snarare än marknadens funktion eller långsiktig tillväxt. Det gröna synsättet är att beskattning av skador, säkerställande av rättvis konkurrens och prissättning av externa effekter ger mer hållbar ekonomisk tillväxt än enbart utgiftsminskningar.'
+  - q: 'Vad beslutade De grönas partikongress 2026 om marknadsekonomin?'
+    a: 'Kongressen i Åbo 2026 antog ett nytt partiprogram. Ändringsförslag 36/Lavanti skulle ha tillagt ett marknadsekonomiuttalande i programinledningen; det fick inte tillräckligt med röster för inledningen, men meningen "För De gröna är marknadsekonomin ett verktyg för att effektivt främja dessa mål" lades till i den ekonomiska sektionen.'
+  - q: 'Hur skiljer sig De gröna från andra partier i ekonomisk politik?'
+    a: 'De gröna vill flytta skattebördan från arbete till skador – förorening, överkonsumtion av naturresurser och missbruk av monopolställningar skulle kosta mer. Detta skiljer sig från Samlingspartiets fokus på budgetdisciplin och från vänsterns reglerings- och omfördelningsbetoningar.'
+---
+
+De grönas partikongress samlades i Åbo den 24–25 maj 2026 för att anta ett nytt partiprogram. Jag lämnade in ändringsförslag 36/Lavanti, som skulle ha tillagt följande mening i programinledningen: *För De gröna är marknadsekonomin ett verktyg för att effektivt främja dessa mål.* Förslaget fick starkt stöd, men inte tillräckligt med röster för att nå inledningen – meningen lades i stället till i den ekonomiska sektionen. Jag höll också ett tal på kongressen, som återges i sin helhet nedan.
+
+Ärade partikongress,
+
+Marknadsekonomin är en av mänsklighetens kraftfullaste uppfinningar. Inget annat mekanisk är lika effektivt på att fördela resurser, vare sig det gäller tjänster eller varor, och det är dags för oss gröna att säga detta högt.
+
+Efter denna regeringsperiod borde det nu vara klart för alla att Samlingspartiet inte bedriver marknadsekonomi utan kamrerekonomi. Alternativet är inte Vänsterförbundet, som huvudsakligen fokuserar på att motarbeta förändring och driver socialism. Marknaderna skulle inte fungera bättre om vi förbjöd och reglerade allt. Alternativet är inte heller Socialdemokraterna, som skulle göra allt likadant som Samlingspartiet, men rättvisare. Om vi vill ha en marknadsekonomi som beaktar externa effekter och hållbarhet, finns det inget bättre alternativ än De gröna.
+
+Väljarna vet tydligt detta också. Även om partiets kommunikation huvudsakligen fokuserar på teman förknippade med vänstern, har stöd runnit från oss till partier längre till vänster. Samtidigt kommer tillväxten huvudsakligen från höger och center. Med andra ord söker folk nu tydligt ett alternativ till Samlingspartiet. Det bästa alternativet är De gröna. Marknaderna fungerar bäst när förorening kostar. När externa effekter är prissatta. När konkurrensen är rättvis och pengar inte kan köpa en monopolställning. Det är inte ideologi – det är sunt förnuft.
+
+Marknadsekonomin kan naturligtvis inte vara fri från all reglering – men fri från orättvis konkurrens. Det är inte stora företags privilegium, utan små och nya företags möjlighet. Det är inte jakten på kortsiktiga vinster, utan långsiktig hållbar tillväxt. När skatter tas ut på skador, inte på arbete. När marknaderna är transparenta och rättvisa.
+
+Låt oss lyfta marknadsekonomin till inledningen av vårt politiska program – dit den hör, som jag föreslog i ändringsförslag 36/Lavanti.
+
+Vi vill ha ett Finland där ekonomin växer, men naturen inte förstörs.
+Vi vill ha ett Finland där innovationer blomstrar och monopol inte dominerar.
+Vi vill ha ett Finland där konkurrensen är rättvis och alla kan förverkliga sig själva.
+
+Detta är vårt ögonblick. Låt oss vara det parti som tar hand om ekonomin och välmåendet.
+
+Tack.
+
+## Varför är De gröna marknads­ekonomiets sanna försvarare?
+
+Grön ekonomisk politik bygger på tre principer: skador kostar, konkurrensen är rättvis och marknaderna är transparenta. Jag har skrivit om detta mer ingående tidigare: [grön ekonomisk politik kräver en plats vid bordet](/sv/blog/61/gron-ekonomisk-politik-kraver-en-plats-vid-bordet/). Marknadsekonomin och hållbarhet är inte motsatser – de är två sidor av samma mynt. Se också [hur AI förändrar ekonomin för offentliga tjänster](/sv/blog/60/ai-hjalper-till-att-sakra-kommunala-tjanster-men-det-kostar/) och vad det innebär för marknadsutvecklingen. Alla mina texter om ekonomi finns i [ekonomikategorin](/sv/category/economy).

--- a/src/pages/sv/blog/62/de-grona-marknadsekonomiets-sanna-forsvarare/index.mdx
+++ b/src/pages/sv/blog/62/de-grona-marknadsekonomiets-sanna-forsvarare/index.mdx
@@ -25,6 +25,16 @@ faq:
     a: 'De gröna vill flytta skattebördan från arbete till skador – förorening, överkonsumtion av naturresurser och missbruk av monopolställningar skulle kosta mer. Detta skiljer sig från Samlingspartiets fokus på budgetdisciplin och från vänsterns reglerings- och omfördelningsbetoningar.'
 ---
 
+import BlockQuote from '../../../../../components/body/BlockQuote.astro'
+import SmartLink from '../../../../../components/SmartLink.astro'
+import H2 from '../../../../../components/H2.astro'
+import H3 from '../../../../../components/H3.astro'
+import LI from '../../../../../components/LI.astro'
+import Paragraph from '../../../../../components/Paragraph.astro'
+import UL from '../../../../../components/UL.astro'
+
+export const components = { blockquote: BlockQuote, a: SmartLink, h2: H2, h3: H3, p: Paragraph, ul: UL, li: LI }
+
 De grönas partikongress samlades i Åbo den 24–25 maj 2026 för att anta ett nytt partiprogram. Jag lämnade in ändringsförslag 36/Lavanti, som skulle ha tillagt följande mening i programinledningen: *För De gröna är marknadsekonomin ett verktyg för att effektivt främja dessa mål.* Förslaget fick starkt stöd, men inte tillräckligt med röster för att nå inledningen – meningen lades i stället till i den ekonomiska sektionen. Jag höll också ett tal på kongressen, som återges i sin helhet nedan.
 
 Ärade partikongress,

--- a/tests/e2e/homeEnPage.spec.ts-snapshots/Home-Page-in-English-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/homeEnPage.spec.ts-snapshots/Home-Page-in-English-should-match-aria-snapshot-1.aria.yml
@@ -12,11 +12,31 @@
     - paragraph: Subscribe to receive digested explanations and analysis of the latest technologies and their impact on society. Straight to your inbox.
     - text: Email
     - textbox "Email"
+    - button "Subscribe"
     - paragraph:
       - text: You can unsubscribe at any time. For more information, read our
       - link "privacy policy":
         - /url: /en/privacy-policy/
     - list:
+      - listitem:
+        - article "Greens – The True Defenders of the Market Economy":
+          - link /Green Party congress in Turku \d+ Greens – The True Defenders of the Market Economy/:
+            - /url: /en/blog/62/greens-the-true-defenders-of-the-market-economy/
+            - img /Green Party congress in Turku \d+/
+            - heading "Greens – The True Defenders of the Market Economy" [level=2]
+          - complementary "Meta information for post \"Greens – The True Defenders of the Market Economy\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Economy":
+                  - /url: /en/category/economy/
+              - listitem:
+                - link "Green Party":
+                  - /url: /en/category/green-party/
+              - listitem:
+                - link "National politics":
+                  - /url: /en/category/national-politics/
+          - paragraph: The market economy is the best known way to allocate resources. The Greens are its only true defender in Finland – real markets, not accountant economics.
       - listitem:
         - article "Green economic policy requires a seat at the table":
           - link "Lauri Lavanti standing in a floral shirt against a blue background Green economic policy requires a seat at the table":
@@ -150,25 +170,3 @@
                 - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
           - paragraph: /Bullying of rainbow youth is increasing\. Kirkkonummi voted \d+–\d+ for flag-flying — a small gesture with measurable effects on young people's wellbeing\./
-      - listitem:
-        - 'article "Chat control: parliament was right"':
-          - 'link "A Japanese-style screen behind which a room is visible in soft focus. Chat control: parliament was right"':
-            - /url: /en/blog/54/chat-control-parliament-was-right/
-            - img "A Japanese-style screen behind which a room is visible in soft focus."
-            - 'heading "Chat control: parliament was right" [level=2]'
-          - 'complementary "Meta information for post \"Chat control: parliament was right\""':
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Privacy":
-                  - /url: /en/category/privacy/
-              - listitem:
-                - link "Technology":
-                  - /url: /en/category/technology/
-              - listitem:
-                - link "Digitalisation":
-                  - /url: /en/category/digitalisation/
-              - listitem:
-                - link "Freedom":
-                  - /url: /en/category/freedom/
-          - paragraph: The European Parliament rejected the extension of the chat control law. The police statistics are real, but parliament was still right — here is why.

--- a/tests/e2e/homeEnPage.spec.ts-snapshots/Home-Page-in-English-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/homeEnPage.spec.ts-snapshots/Home-Page-in-English-should-match-aria-snapshot-1.aria.yml
@@ -12,7 +12,6 @@
     - paragraph: Subscribe to receive digested explanations and analysis of the latest technologies and their impact on society. Straight to your inbox.
     - text: Email
     - textbox "Email"
-    - button "Subscribe"
     - paragraph:
       - text: You can unsubscribe at any time. For more information, read our
       - link "privacy policy":

--- a/tests/e2e/homePage.spec.ts-snapshots/Home-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/homePage.spec.ts-snapshots/Home-Page-should-match-aria-snapshot-1.aria.yml
@@ -12,11 +12,31 @@
     - paragraph: Subscribe to receive digested explanations and analysis of the latest technologies and their impact on society. Straight to your inbox.
     - text: Email
     - textbox "Email"
+    - button "Subscribe"
     - paragraph:
       - text: You can unsubscribe at any time. For more information, read our
       - link "privacy policy":
         - /url: /en/privacy-policy/
     - list:
+      - listitem:
+        - article "Greens – The True Defenders of the Market Economy":
+          - link /Green Party congress in Turku \d+ Greens – The True Defenders of the Market Economy/:
+            - /url: /en/blog/62/greens-the-true-defenders-of-the-market-economy/
+            - img /Green Party congress in Turku \d+/
+            - heading "Greens – The True Defenders of the Market Economy" [level=2]
+          - complementary "Meta information for post \"Greens – The True Defenders of the Market Economy\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Economy":
+                  - /url: /en/category/economy/
+              - listitem:
+                - link "Green Party":
+                  - /url: /en/category/green-party/
+              - listitem:
+                - link "National politics":
+                  - /url: /en/category/national-politics/
+          - paragraph: The market economy is the best known way to allocate resources. The Greens are its only true defender in Finland – real markets, not accountant economics.
       - listitem:
         - article "Green economic policy requires a seat at the table":
           - link "Lauri Lavanti standing in a floral shirt against a blue background Green economic policy requires a seat at the table":
@@ -150,25 +170,3 @@
                 - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
           - paragraph: /Bullying of rainbow youth is increasing\. Kirkkonummi voted \d+–\d+ for flag-flying — a small gesture with measurable effects on young people's wellbeing\./
-      - listitem:
-        - 'article "Chat control: parliament was right"':
-          - 'link "A Japanese-style screen behind which a room is visible in soft focus. Chat control: parliament was right"':
-            - /url: /en/blog/54/chat-control-parliament-was-right/
-            - img "A Japanese-style screen behind which a room is visible in soft focus."
-            - 'heading "Chat control: parliament was right" [level=2]'
-          - 'complementary "Meta information for post \"Chat control: parliament was right\""':
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Privacy":
-                  - /url: /en/category/privacy/
-              - listitem:
-                - link "Technology":
-                  - /url: /en/category/technology/
-              - listitem:
-                - link "Digitalisation":
-                  - /url: /en/category/digitalisation/
-              - listitem:
-                - link "Freedom":
-                  - /url: /en/category/freedom/
-          - paragraph: The European Parliament rejected the extension of the chat control law. The police statistics are real, but parliament was still right — here is why.

--- a/tests/e2e/homePage.spec.ts-snapshots/Home-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/homePage.spec.ts-snapshots/Home-Page-should-match-aria-snapshot-1.aria.yml
@@ -12,7 +12,6 @@
     - paragraph: Subscribe to receive digested explanations and analysis of the latest technologies and their impact on society. Straight to your inbox.
     - text: Email
     - textbox "Email"
-    - button "Subscribe"
     - paragraph:
       - text: You can unsubscribe at any time. For more information, read our
       - link "privacy policy":

--- a/tests/e2e/homeSwePage.spec.ts-snapshots/Home-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/homeSwePage.spec.ts-snapshots/Home-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
@@ -12,7 +12,6 @@
     - paragraph: Prenumerera och få genomarbetade förklaringar och analyser av de senaste teknologierna och deras påverkan på samhället. Direkt till din inkorg.
     - text: E-post
     - textbox "E-post"
-    - button "Prenumerera"
     - paragraph:
       - text: Du kan avsluta prenumerationen när som helst. För mer information, läs vår
       - link "integritetspolicy":

--- a/tests/e2e/homeSwePage.spec.ts-snapshots/Home-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/homeSwePage.spec.ts-snapshots/Home-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
@@ -12,12 +12,32 @@
     - paragraph: Prenumerera och få genomarbetade förklaringar och analyser av de senaste teknologierna och deras påverkan på samhället. Direkt till din inkorg.
     - text: E-post
     - textbox "E-post"
+    - button "Prenumerera"
     - paragraph:
       - text: Du kan avsluta prenumerationen när som helst. För mer information, läs vår
       - link "integritetspolicy":
         - /url: /sv/privacy-policy/
       - text: .
     - list:
+      - listitem:
+        - article "De gröna – Marknadsekonomiets sanna försvarare":
+          - link /Grönas partikongress i Åbo \d+ De gröna – Marknadsekonomiets sanna försvarare/:
+            - /url: /sv/blog/62/de-grona-marknadsekonomiets-sanna-forsvarare/
+            - img /Grönas partikongress i Åbo \d+/
+            - heading "De gröna – Marknadsekonomiets sanna försvarare" [level=2]
+          - complementary "Metainformation för inlägget \"De gröna – Marknadsekonomiets sanna försvarare\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Ekonomi":
+                  - /url: /sv/category/economy/
+              - listitem:
+                - link "De Gröna":
+                  - /url: /sv/category/green-party/
+              - listitem:
+                - link "Nationell politik":
+                  - /url: /sv/category/national-politics/
+          - paragraph: Marknadsekonomin är det bästa sättet att fördela resurser. De gröna är dess enda sanna försvarare i Finland – riktiga marknader, inte kamrerekonomi.
       - listitem:
         - article "Grön ekonomisk politik kräver en plats vid bordet":
           - link "Lauri Lavanti står i en blommig skjorta mot en blå bakgrund Grön ekonomisk politik kräver en plats vid bordet":
@@ -151,25 +171,3 @@
                 - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
           - paragraph: /Mobbning av regnbågsungdomar ökar\. Kyrkslätt röstade \d+–\d+ för flaggning — en liten gest med mätbara effekter på ungas välmående\./
-      - listitem:
-        - 'article "Chat control: parlamentet handlade rätt"':
-          - 'link "Bild på en japansk skärm bakom vilken ett rum skymtar suddigt. Chat control: parlamentet handlade rätt"':
-            - /url: /sv/blog/54/chat-control-parlamentet-handlade-ratt/
-            - img "Bild på en japansk skärm bakom vilken ett rum skymtar suddigt."
-            - 'heading "Chat control: parlamentet handlade rätt" [level=2]'
-          - 'complementary "Metainformation för inlägget \"Chat control: parlamentet handlade rätt\""':
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Integritetsskydd":
-                  - /url: /sv/category/privacy/
-              - listitem:
-                - link "Teknologi":
-                  - /url: /sv/category/technology/
-              - listitem:
-                - link "Digitalisering":
-                  - /url: /sv/category/digitalisation/
-              - listitem:
-                - link "Frihet":
-                  - /url: /sv/category/freedom/
-          - paragraph: Chat control-lagens förlängning röstades ned i Europaparlamentet. KRP:s siffror är verkliga, men parlamentet handlade ändå rätt — och här är skälet.

--- a/tests/e2e/notFoundPage.spec.ts-snapshots/404-Not-Found-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/notFoundPage.spec.ts-snapshots/404-Not-Found-Page-should-match-aria-snapshot-1.aria.yml
@@ -3,6 +3,25 @@
   - article:
     - list:
       - listitem:
+        - article "Vihreät – Markkinatalouden aito puolustaja":
+          - link /Vihreiden puoluekokous Turussa \d+ Vihreät – Markkinatalouden aito puolustaja/:
+            - /url: /fi/blog/62/vihreat-markkinatalouden-aito-puolustaja/
+            - img /Vihreiden puoluekokous Turussa \d+/
+            - heading "Vihreät – Markkinatalouden aito puolustaja" [level=2]
+          - complementary "Kirjoituksen \"Vihreät – Markkinatalouden aito puolustaja\" meta-tiedot":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Talous":
+                  - /url: /fi/category/economy/
+              - listitem:
+                - link "Vihreät":
+                  - /url: /fi/category/green-party/
+              - listitem:
+                - link "Kansallinen politiikka":
+                  - /url: /fi/category/national-politics/
+          - paragraph: Markkinatalous on tehokkain tunnettu tapa jakaa resursseja. Vihreät on sen ainoa aito puolustaja Suomessa – ei kamreritaloutta, vaan aitoja markkinoita.
+      - listitem:
         - article "Velkajarrun ulkopuolelta ei tehdä vihreää talouspolitiikkaa":
           - link "Lauri Lavanti seisoo kukkapaita päällään sinistä taustaa vasten Velkajarrun ulkopuolelta ei tehdä vihreää talouspolitiikkaa":
             - /url: /fi/blog/61/velkajarrun-ulkopuolelta-ei-tehda-vihreaa-talouspolitiikkaa/
@@ -135,25 +154,3 @@
                 - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
           - paragraph: /Sateenkaarinuorten kiusaaminen kasvaa\. Kirkkonummi äänesti \d+–\d+ liputuksen puolesta — pieni ele, jolla on mitattavia vaikutuksia nuorten hyvinvointiin\./
-      - listitem:
-        - 'article "Chat control: parlamentti toimi oikein"':
-          - 'link "Kuva japanilaistyylisestä sermistä, jonka takana näkyy sumeasti huone. Chat control: parlamentti toimi oikein"':
-            - /url: /fi/blog/54/chat-control-parlamentti-toimi-oikein/
-            - img "Kuva japanilaistyylisestä sermistä, jonka takana näkyy sumeasti huone."
-            - 'heading "Chat control: parlamentti toimi oikein" [level=2]'
-          - 'complementary "Kirjoituksen \"Chat control: parlamentti toimi oikein\" meta-tiedot"':
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Yksityisyydensuoja":
-                  - /url: /fi/category/privacy/
-              - listitem:
-                - link "Teknologia":
-                  - /url: /fi/category/technology/
-              - listitem:
-                - link "Digitalisaatio":
-                  - /url: /fi/category/digitalisation/
-              - listitem:
-                - link "Vapaus":
-                  - /url: /fi/category/freedom/
-          - paragraph: Chat control -lain jatkoaika kaatui Euroopan parlamentissa. KRP:n luvut ovat todellisia, mutta parlamentti toimi silti oikein — ja tässä syy, miksi.


### PR DESCRIPTION
> This PR containes AI-generated code. The author has reviewed and is responsible for all AI-generated content.

## Summary

- Adds blog post #62 "Vihreät – Markkinatalouden aito puolustaja" in Finnish, English, and Swedish
- Post contains the speech given at the Green Party congress in Turku on 2026-05-24, with an intro explaining the amendment proposal 36/Lavanti
- Includes 4 FAQ items for AEO/SEO
- Hero image `vihreiden-puoluekokous-Turussa-2026` uploaded to Cloudflare Images

## Test plan

- [ ] CI passes (build + e2e)
- [ ] `/fi/blog/62/vihreat-markkinatalouden-aito-puolustaja/` renders correctly
- [ ] Hero image visible
- [ ] FAQ structured data present in page source