### PR TITLE
fix(images): optimise image delivery — format=auto, srcset gaps, lazy loading

### DIFF
--- a/.agents/specs/images/spec.md
+++ b/.agents/specs/images/spec.md
@@ -11,7 +11,9 @@ Images are stored in Cloudflare Images, uploaded via `scripts/upload-to-cf-image
 - `getImage(slug, variant): CFImageResult` — returns `{ src, width, height }` for a single size
 - `getImageSrcset(slug, variant, widths[]): { src, srcset, width, height }` — returns responsive srcset entries
 
-URL format: `https://laurilavanti.fi/images/{slug}/w={w},h={h},fit={fit},gravity={gravity}`
+URL format: `https://laurilavanti.fi/images/{slug}/w={w},h={h},fit={fit},gravity={gravity},format=auto`
+
+`format=auto` is always appended — CF Images returns WebP or AVIF for browsers that support it, falling back to JPEG. Never omit it.
 
 **Valid `fit` values:** `crop`, `cover`, `contain`, `pad`, `scale-down` — note: `scale-crop` is NOT valid and will cause CF to return the unresized original.
 
@@ -29,12 +31,12 @@ URL format: `https://laurilavanti.fi/images/{slug}/w={w},h={h},fit={fit},gravity
 
 | Component | Variant | `widths` / `sizes` | Notes |
 |---|---|---|---|
-| `heroBanner/images/BackgroundImage.astro` | `background` | `[960,1920]` / `100vw` | Decorative — `alt=""`. Desktop-only (hidden < 1200px). |
+| `heroBanner/images/BackgroundImage.astro` | `background` | `[960,1920]` / `100vw` | Decorative — `alt=""`. Desktop-only (hidden < 1200px). No `fetchpriority`. |
 | `titleBanner/Image.astro` | `hero` | `[864,1728]` / `(max-width:1199px) 100vw, 50vw` | Fills `50vw × 45rem` box via `object-fit: cover`. |
-| `heroBanner/Images.astro` | `1x1` (hero + mobile) | `[560,1120,1680]` / `50vw` (desktop), `100vw` (mobile) | Transparent cutout — must stay 1:1 to preserve full figure. |
-| `excerptList/excerpt/Banner.astro` | `1x1` | `[560,1120]` / `(max-width:1199px) 100vw, 33vw` | Square thumbnail; 3-column grid on desktop. |
-| `body/ImageWithCaption.astro` | `body` | `[400,800,1200]` / `(max-width:640px) 100vw, 800px` | Inline image with `<figcaption>`. `aria-label` from `caption` prop. |
-| `recommendations/Recommendation.astro` | `1x1` | `[448,896]` / `448px` | Circular portrait via CSS `border-radius:50%`. |
+| `heroBanner/Images.astro` | `1x1` (hero + mobile) | `[560,720,1120,1680]` / `(max-width:1199px) 100vw, min(50vw, 600px)` (desktop) | Transparent cutout — must stay 1:1 to preserve full figure. |
+| `excerptList/excerpt/Banner.astro` | `1x1` | `[560,750,1120]` / `(max-width:1199px) 100vw, min(33vw, 380px)` | Square thumbnail; 3-column grid on desktop. `loading="lazy"`. |
+| `body/ImageWithCaption.astro` | `body` | `[400,800,1200]` / `(max-width:640px) 100vw, 800px` | Inline image with `<figcaption>`. `aria-label` from `caption` prop. `loading="lazy"`. |
+| `recommendations/Recommendation.astro` | `1x1` | `[448,896]` / `448px` | Circular portrait via CSS `border-radius:50%`. `loading="lazy"`. |
 | Layouts (og:image) | `og` | — | `getImage(heroImage, 'og').src` — URL string passed to `Head.astro`. |
 | `person.ts` (JSON-LD) | `og` | — | `getPersonImageUrl()` sync function called in `Head.astro`. |
 
@@ -50,7 +52,9 @@ URL format: `https://laurilavanti.fi/images/{slug}/w={w},h={h},fit={fit},gravity
 - Excerpt thumbnails: `alt` from post frontmatter (falls back to `""` if absent)
 - Inline body images (`ImageWithCaption`): `alt` prop + visible `figcaption`
 
-**`fetchpriority="high"`** on above-the-fold images (`BackgroundImage`, `heroBanner/Images`, `titleBanner/Image`).
+**`fetchpriority="high"`** on above-the-fold images that are visible immediately (`heroBanner/Images`, `titleBanner/Image`). Not on `BackgroundImage` — it is `display:none` on mobile, so a high-priority fetch wastes bandwidth.
+
+**`loading="lazy"`** on all below-the-fold images: excerpt thumbnails, inline body images, recommendation portraits.
 
 **Adding a new image:**
 1. Drop original JPEG/PNG into `src/images/originals/{slug}.jpg`
@@ -67,6 +71,10 @@ URL format: `https://laurilavanti.fi/images/{slug}/w={w},h={h},fit={fit},gravity
 - Do not set a non-empty `alt` on `BackgroundImage` — it is decorative
 - Do not use Astro `<Image>` from `astro:assets` for CF Images — use plain `<img>` with `getImageSrcset()`
 - Do not use `gravity=face` with `fit` other than `crop` — face detection only works with crop
+- Do not omit `format=auto` from CF Images URLs — without it browsers always receive JPEG
+- Do not set `fetchpriority="high"` on `BackgroundImage` — it is `display:none` on mobile
+- Do not add `loading="lazy"` to above-the-fold images (`heroBanner/Images`, `titleBanner/Image`)
+- When choosing srcset widths, avoid large gaps: a gap from Xw to 2Xw means high-DPR mobile picks 2Xw for a slot that only needs ~1.75Xw. Add an intermediate entry.
 
 ---
 

--- a/src/components/body/ImageWithCaption.astro
+++ b/src/components/body/ImageWithCaption.astro
@@ -46,6 +46,7 @@ const img = image ? getImageSrcset(image, 'body', [400, 800, 1200]) : undefined
             <img
                 alt={alt ?? ''}
                 height={img.height}
+                loading="lazy"
                 sizes="(max-width: 640px) 100vw, 800px"
                 src={img.src}
                 srcset={img.srcset}

--- a/src/components/excerptList/excerpt/Banner.astro
+++ b/src/components/excerptList/excerpt/Banner.astro
@@ -12,7 +12,7 @@ interface Props {
 }
 
 const { alt, image, slug, title } = Astro.props
-const img = image ? getImageSrcset(image, '1x1', [560, 1120]) : undefined
+const img = image ? getImageSrcset(image, '1x1', [560, 750, 1120]) : undefined
 ---
 
 <style define:vars={{ sizes025: sizes[0.25], sizes01875: sizes[0.1875] }}>
@@ -52,7 +52,8 @@ const img = image ? getImageSrcset(image, '1x1', [560, 1120]) : undefined
                 alt={alt ?? ''}
                 class="excerpt-image"
                 height={img.height}
-                sizes="(max-width: 1199px) 100vw, 33vw"
+                loading="lazy"
+                sizes="(max-width: 1199px) 100vw, min(33vw, 380px)"
                 src={img.src}
                 srcset={img.srcset}
                 width={img.width}

--- a/src/components/heroBanner/Images.astro
+++ b/src/components/heroBanner/Images.astro
@@ -12,7 +12,7 @@ interface Props {
 
 const { alt, backgroundImage, heroImage, mobileHeroImage } = Astro.props
 
-const heroImg = heroImage ? getImageSrcset(heroImage, '1x1', [560, 1120, 1680]) : undefined
+const heroImg = heroImage ? getImageSrcset(heroImage, '1x1', [560, 720, 1120, 1680]) : undefined
 const mobileImg = mobileHeroImage ? getImageSrcset(mobileHeroImage, '1x1', [560, 1120, 1680]) : undefined
 ---
 
@@ -85,7 +85,7 @@ const mobileImg = mobileHeroImage ? getImageSrcset(mobileHeroImage, '1x1', [560,
                     class="image image-desktop"
                     fetchpriority="high"
                     height={heroImg.height}
-                    sizes="50vw"
+                    sizes="(max-width: 1199px) 100vw, min(50vw, 600px)"
                     src={heroImg.src}
                     srcset={heroImg.srcset}
                     width={heroImg.width}

--- a/src/components/heroBanner/images/BackgroundImage.astro
+++ b/src/components/heroBanner/images/BackgroundImage.astro
@@ -41,7 +41,6 @@ const img = image ? getImageSrcset(image, 'background', [960, 1920]) : undefined
             <div>
                 <img
                     alt=""
-                    fetchpriority="high"
                     height={img.height}
                     sizes="100vw"
                     src={img.src}

--- a/src/components/recommendations/Recommendation.astro
+++ b/src/components/recommendations/Recommendation.astro
@@ -82,6 +82,7 @@ const img = image ? getImageSrcset(image, '1x1', [448, 896]) : undefined
                 <img
                     alt={alt}
                     height={img.height}
+                    loading="lazy"
                     sizes="(max-width: 600px) 100vw, 448px"
                     src={img.src}
                     srcset={img.srcset}

--- a/src/lib/images.spec.ts
+++ b/src/lib/images.spec.ts
@@ -9,21 +9,21 @@ const BASE = 'https://laurilavanti.fi/images'
 describe('getImage', () => {
     it('returns correct URL for 1x1 variant', () => {
         const result = getImage('test-slug', '1x1')
-        expect(result.src).toBe(`${BASE}/test-slug/w=1680,h=1680,fit=crop,gravity=face`)
+        expect(result.src).toBe(`${BASE}/test-slug/w=1680,h=1680,fit=crop,gravity=face,format=auto`)
         expect(result.width).toBe(1680)
         expect(result.height).toBe(1680)
     })
 
     it('returns correct URL for og variant', () => {
         const result = getImage('test-slug', 'og')
-        expect(result.src).toBe(`${BASE}/test-slug/w=1200,h=630,fit=crop,gravity=face`)
+        expect(result.src).toBe(`${BASE}/test-slug/w=1200,h=630,fit=crop,gravity=face,format=auto`)
         expect(result.width).toBe(1200)
         expect(result.height).toBe(630)
     })
 
     it('returns correct URL for hero variant', () => {
         const result = getImage('test-slug', 'hero')
-        expect(result.src).toBe(`${BASE}/test-slug/w=1728,h=1320,fit=crop,gravity=face`)
+        expect(result.src).toBe(`${BASE}/test-slug/w=1728,h=1320,fit=crop,gravity=face,format=auto`)
         expect(result.width).toBe(1728)
         expect(result.height).toBe(1320)
     })
@@ -42,11 +42,11 @@ describe('getImageSrcset', () => {
     it('returns correct srcset for 1x1 variant', () => {
         const result = getImageSrcset('test-slug', '1x1', [560, 1120, 1680])
         expect(result.srcset).toBe(
-            `${BASE}/test-slug/w=560,h=560,fit=crop,gravity=face 560w, ${BASE}/test-slug/w=1120,h=1120,fit=crop,gravity=face 1120w, ${BASE}/test-slug/w=1680,h=1680,fit=crop,gravity=face 1680w`
+            `${BASE}/test-slug/w=560,h=560,fit=crop,gravity=face,format=auto 560w, ${BASE}/test-slug/w=1120,h=1120,fit=crop,gravity=face,format=auto 1120w, ${BASE}/test-slug/w=1680,h=1680,fit=crop,gravity=face,format=auto 1680w`
         )
         expect(result.width).toBe(1680)
         expect(result.height).toBe(1680)
-        expect(result.src).toBe(`${BASE}/test-slug/w=1680,h=1680,fit=crop,gravity=face`)
+        expect(result.src).toBe(`${BASE}/test-slug/w=1680,h=1680,fit=crop,gravity=face,format=auto`)
     })
 
     it('computes correct heights for non-square variants', () => {

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -26,7 +26,7 @@ export function getImage(slug: string, variant: string): CFImageResult {
     if (!v) throw new Error(`Unknown image variant: ${variant}`)
     return {
         height: v.h,
-        src: `${BASE}/${encodeURIComponent(slug)}/w=${v.w},h=${v.h},fit=${v.fit},gravity=${v.gravity}`,
+        src: `${BASE}/${encodeURIComponent(slug)}/w=${v.w},h=${v.h},fit=${v.fit},gravity=${v.gravity},format=auto`,
         width: v.w,
     }
 }
@@ -42,7 +42,7 @@ export function getImageSrcset(
     const entries = widths.map((w) => {
         const h = Math.round(w * ratio)
 
-        return `${BASE}/${encodeURIComponent(slug)}/w=${w},h=${h},fit=${v.fit},gravity=${v.gravity} ${w}w`
+        return `${BASE}/${encodeURIComponent(slug)}/w=${w},h=${h},fit=${v.fit},gravity=${v.gravity},format=auto ${w}w`
     })
 
     return {


### PR DESCRIPTION
> This PR containes AI-generated code. The author has reviewed and is responsible for all AI-generated content.

## Summary

- Add `format=auto` to all CF Images URLs so browsers receive WebP/AVIF instead of JPEG (~60–70% size reduction)
- Fix srcset gaps in excerpt thumbnails and desktop hero image (add intermediate widths to prevent browser from overshooting to a larger entry)
- Fix `sizes` hints on excerpt thumbnails and hero image to not overshoot on constrained desktop layout
- Add `loading="lazy"` to all below-fold images (excerpts, body inline, recommendations)
- Remove `fetchpriority="high"` from decorative background image that is `display:none` on mobile

Closes #N/A — addresses PageSpeed Insights "Paranna kuvien toimitusta" audit: 828 KiB savings on mobile, 384 KiB on desktop.

## Test plan

- [ ] `npm run build` passes
- [ ] `npm run test` passes
- [ ] All `<img>` src/srcset URLs contain `,format=auto`
- [ ] Excerpt `<img>`: `loading="lazy"`, srcset has `750w`, sizes has `min(33vw, 380px)`
- [ ] Hero desktop `<img>`: srcset has `720w`, sizes has `min(50vw, 600px)`
- [ ] `BackgroundImage`: no `fetchpriority` attribute
- [ ] CF Images returns `Content-Type: image/webp` in DevTools Network tab
- [ ] Re-run PageSpeed mobile — savings drop from 828 KiB toward zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)