### PR TITLE
fix(images): add missing intermediate srcset entries for desktop excerpt and mobile hero

### DIFF
--- a/src/components/excerptList/excerpt/Banner.astro
+++ b/src/components/excerptList/excerpt/Banner.astro
@@ -12,7 +12,7 @@ interface Props {
 }
 
 const { alt, image, slug, title } = Astro.props
-const img = image ? getImageSrcset(image, '1x1', [560, 750, 1120]) : undefined
+const img = image ? getImageSrcset(image, '1x1', [400, 560, 750, 1120]) : undefined
 ---
 
 <style define:vars={{ sizes025: sizes[0.25], sizes01875: sizes[0.1875] }}>

--- a/src/components/heroBanner/Images.astro
+++ b/src/components/heroBanner/Images.astro
@@ -13,7 +13,7 @@ interface Props {
 const { alt, backgroundImage, heroImage, mobileHeroImage } = Astro.props
 
 const heroImg = heroImage ? getImageSrcset(heroImage, '1x1', [560, 720, 1120, 1680]) : undefined
-const mobileImg = mobileHeroImage ? getImageSrcset(mobileHeroImage, '1x1', [560, 1120, 1680]) : undefined
+const mobileImg = mobileHeroImage ? getImageSrcset(mobileHeroImage, '1x1', [560, 750, 1120, 1680]) : undefined
 ---
 
 <style define:vars={{ sizes1Negative: `-${sizes[1]}`, sizes14Negative: `-${sizes[14]}` }}>


### PR DESCRIPTION
> This PR containes AI-generated code. The author has reviewed and is responsible for all AI-generated content.

## Summary

Follow-up to #1248. PageSpeed retest revealed two remaining srcset gaps:

- **Excerpt thumbnails (desktop)**: `min(33vw, 380px)` resolves to ~380px on large desktops, but smallest srcset entry was 560w → browser picks 560w. Added `400w` entry so browser picks 400w instead (~40% fewer pixels).
- **Mobile hero image**: `mobileImg` srcset was `[560, 1120, 1680]`. On 412px × 1.75 DPR ≈ 721 device px — browser skipped 560 and picked 1120. Added `750w` entry.

## Test plan

- [ ] `npm run build` passes
- [ ] Excerpt thumbnail srcset contains `400w` entry
- [ ] Mobile hero srcset contains `750w` entry
- [ ] Re-run PageSpeed mobile/desktop — "kuvatiedosto on suurempi" dimension warnings resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)