### PR TITLE
feat(rss): rich feed — hero image, full content, byline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,11 @@
         "@astrojs/mdx": "5.0.6",
         "@astrojs/rss": "4.0.18",
         "@astrojs/sitemap": "3.7.2",
-        "astro-icon": "1.1.5"
+        "astro-icon": "1.1.5",
+        "rehype-stringify": "10.0.1",
+        "remark-parse": "11.0.0",
+        "remark-rehype": "11.1.2",
+        "unified": "11.0.5"
       },
       "devDependencies": {
         "@astrojs/check": "0.9.9",
@@ -12501,6 +12505,8 @@
     },
     "node_modules/rehype-stringify": {
       "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -12542,6 +12548,8 @@
     },
     "node_modules/remark-parse": {
       "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -12556,6 +12564,8 @@
     },
     "node_modules/remark-rehype": {
       "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -13833,6 +13843,8 @@
     },
     "node_modules/unified": {
       "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,11 @@
     "@astrojs/mdx": "5.0.6",
     "@astrojs/rss": "4.0.18",
     "@astrojs/sitemap": "3.7.2",
-    "astro-icon": "1.1.5"
+    "astro-icon": "1.1.5",
+    "rehype-stringify": "10.0.1",
+    "remark-parse": "11.0.0",
+    "remark-rehype": "11.1.2",
+    "unified": "11.0.5"
   },
   "devDependencies": {
     "@astrojs/check": "0.9.9",

--- a/src/lib/mdxPosts.ts
+++ b/src/lib/mdxPosts.ts
@@ -1,9 +1,9 @@
+import type { AuthorEntry } from '../content/person'
+
 import rehypeStringify from 'rehype-stringify'
 import remarkParse from 'remark-parse'
 import remarkRehype from 'remark-rehype'
 import { unified } from 'unified'
-
-import type { AuthorEntry } from '../content/person'
 
 interface MdxPost {
     alt: string
@@ -38,16 +38,14 @@ export const allMdxPosts: MdxPostWithUrl[] = Object.entries(rawGlob)
 
 const rawMdxGlob = import.meta.glob<string>('../pages/*/blog/*/*/index.mdx', {
     eager: true,
-    query: '?raw',
     import: 'default',
+    query: '?raw',
 })
 
 const processor = unified().use(remarkParse).use(remarkRehype, { allowDangerousHtml: true }).use(rehypeStringify)
 
 const stripFrontmatter = (raw: string): string =>
-    raw
-        .replace(/^---[\s\S]*?---\n?/, '')
-        .replace(/^(import\s+.+|export\s+const\s+components\s*=.+)$/gm, '')
+    raw.replace(/^---[\s\S]*?---\n?/, '').replace(/^(import\s+.+|export\s+const\s+components\s*=.+)$/gm, '')
 
 export const mdxContentByPath: Record<string, () => Promise<string>> = Object.fromEntries(
     Object.entries(rawMdxGlob).map(([filePath, raw]) => [
@@ -55,6 +53,7 @@ export const mdxContentByPath: Record<string, () => Promise<string>> = Object.fr
         async () => {
             const body = stripFrontmatter(raw)
             const result = await processor.process(body)
+
             return String(result)
         },
     ])

--- a/src/lib/mdxPosts.ts
+++ b/src/lib/mdxPosts.ts
@@ -1,3 +1,8 @@
+import rehypeStringify from 'rehype-stringify'
+import remarkParse from 'remark-parse'
+import remarkRehype from 'remark-rehype'
+import { unified } from 'unified'
+
 import type { AuthorEntry } from '../content/person'
 
 interface MdxPost {
@@ -30,6 +35,30 @@ export const allMdxPosts: MdxPostWithUrl[] = Object.entries(rawGlob)
         return { ...mod.frontmatter, url }
     })
     .sort((a, b) => b.id - a.id)
+
+const rawMdxGlob = import.meta.glob<string>('../pages/*/blog/*/*/index.mdx', {
+    eager: true,
+    query: '?raw',
+    import: 'default',
+})
+
+const processor = unified().use(remarkParse).use(remarkRehype, { allowDangerousHtml: true }).use(rehypeStringify)
+
+const stripFrontmatter = (raw: string): string =>
+    raw
+        .replace(/^---[\s\S]*?---\n?/, '')
+        .replace(/^(import\s+.+|export\s+const\s+components\s*=.+)$/gm, '')
+
+export const mdxContentByPath: Record<string, () => Promise<string>> = Object.fromEntries(
+    Object.entries(rawMdxGlob).map(([filePath, raw]) => [
+        filePath,
+        async () => {
+            const body = stripFrontmatter(raw)
+            const result = await processor.process(body)
+            return String(result)
+        },
+    ])
+)
 
 export const getPostAlternates = (id: number): Record<MdxPost['lang'], string> => {
     const result = {} as Record<MdxPost['lang'], string>

--- a/src/pages/en/_rss.xml.spec.ts
+++ b/src/pages/en/_rss.xml.spec.ts
@@ -60,6 +60,6 @@ describe('en/rss.xml', () => {
 
     it('contains English byline text', async () => {
         const text = await GET(makeContext()).then((r) => r.text())
-        expect(text).toContain('was first published on Lauri Lavanti')
+        expect(text).toContain('Permanent link to the blog post')
     })
 })

--- a/src/pages/en/_rss.xml.spec.ts
+++ b/src/pages/en/_rss.xml.spec.ts
@@ -42,4 +42,24 @@ describe('en/rss.xml', () => {
             expect(text, `unexpected non-en post: ${post.url}`).not.toContain(post.url)
         }
     })
+
+    it('contains content:encoded for posts', async () => {
+        const text = await GET(makeContext()).then((r) => r.text())
+        expect(text).toContain('content:encoded')
+    })
+
+    it('contains enclosure for posts', async () => {
+        const text = await GET(makeContext()).then((r) => r.text())
+        expect(text).toContain('<enclosure')
+    })
+
+    it('contains media:content for posts', async () => {
+        const text = await GET(makeContext()).then((r) => r.text())
+        expect(text).toContain('<media:content')
+    })
+
+    it('contains English byline text', async () => {
+        const text = await GET(makeContext()).then((r) => r.text())
+        expect(text).toContain('was first published on Lauri Lavanti')
+    })
 })

--- a/src/pages/en/rss.xml.ts
+++ b/src/pages/en/rss.xml.ts
@@ -14,7 +14,7 @@ export async function GET(context: APIContext) {
             const html = (await mdxContentByPath[`../pages${post.url}index.mdx`]?.()) ?? ''
             const content =
                 html +
-                `<p>The post <a href="${absoluteUrl}">${post.title}</a> was first published on Lauri Lavanti's blog.</p>`
+                `<p><a href="${absoluteUrl}">Permanent link to the blog post</a></p>`
             const img = getImage(post.heroImage, 'og')
 
             return {

--- a/src/pages/en/rss.xml.ts
+++ b/src/pages/en/rss.xml.ts
@@ -2,20 +2,38 @@ import type { APIContext } from 'astro'
 
 import rss from '@astrojs/rss'
 
-import { allMdxPosts } from '../../lib/mdxPosts'
+import { getImage } from '../../lib/images'
+import { allMdxPosts, mdxContentByPath } from '../../lib/mdxPosts'
 
 export async function GET(context: APIContext) {
     const posts = allMdxPosts.filter((p) => p.lang === 'en')
 
+    const items = await Promise.all(
+        posts.map(async (post) => {
+            const absoluteUrl = new URL(post.url, context.site!).href
+            const html = (await mdxContentByPath[`../pages${post.url}index.mdx`]?.()) ?? ''
+            const content =
+                html +
+                `<p>The post <a href="${absoluteUrl}">${post.title}</a> was first published on Lauri Lavanti's blog.</p>`
+            const img = getImage(post.heroImage, 'og')
+
+            return {
+                content,
+                customData: `<media:content url="${img.src}" medium="image" width="${img.width}" height="${img.height}"/>`,
+                description: post.description,
+                enclosure: { length: 0, type: 'image/jpeg', url: img.src },
+                link: post.url,
+                pubDate: new Date(post.publishDate),
+                title: post.title,
+            }
+        })
+    )
+
     return rss({
         description: 'Blog posts by Lauri Lavanti',
-        items: posts.map((post) => ({
-            description: post.description,
-            link: post.url,
-            pubDate: new Date(post.publishDate),
-            title: post.title,
-        })),
+        items,
         site: context.site!,
         title: 'Lauri Lavanti – blog',
+        xmlns: { media: 'http://search.yahoo.com/mrss/' },
     })
 }

--- a/src/pages/en/rss.xml.ts
+++ b/src/pages/en/rss.xml.ts
@@ -12,9 +12,7 @@ export async function GET(context: APIContext) {
         posts.map(async (post) => {
             const absoluteUrl = new URL(post.url, context.site!).href
             const html = (await mdxContentByPath[`../pages${post.url}index.mdx`]?.()) ?? ''
-            const content =
-                html +
-                `<p><a href="${absoluteUrl}">Permanent link to the blog post</a></p>`
+            const content = html + `<p><a href="${absoluteUrl}">Permanent link to the blog post</a></p>`
             const img = getImage(post.heroImage, 'og')
 
             return {

--- a/src/pages/fi/_rss.xml.spec.ts
+++ b/src/pages/fi/_rss.xml.spec.ts
@@ -49,4 +49,24 @@ describe('fi/rss.xml', () => {
             expect(text, `unexpected non-fi post: ${post.url}`).not.toContain(post.url)
         }
     })
+
+    it('contains content:encoded for posts', async () => {
+        const text = await GET(makeContext()).then((r) => r.text())
+        expect(text).toContain('content:encoded')
+    })
+
+    it('contains enclosure for posts', async () => {
+        const text = await GET(makeContext()).then((r) => r.text())
+        expect(text).toContain('<enclosure')
+    })
+
+    it('contains media:content for posts', async () => {
+        const text = await GET(makeContext()).then((r) => r.text())
+        expect(text).toContain('<media:content')
+    })
+
+    it('contains Finnish byline text', async () => {
+        const text = await GET(makeContext()).then((r) => r.text())
+        expect(text).toContain('on julkaistu ensimmäisen kerran Lauri Lavantin blogissa')
+    })
 })

--- a/src/pages/fi/_rss.xml.spec.ts
+++ b/src/pages/fi/_rss.xml.spec.ts
@@ -67,6 +67,6 @@ describe('fi/rss.xml', () => {
 
     it('contains Finnish byline text', async () => {
         const text = await GET(makeContext()).then((r) => r.text())
-        expect(text).toContain('on julkaistu ensimmäisen kerran Lauri Lavantin blogissa')
+        expect(text).toContain('Pysyvä linkki blogikirjoitukseen')
     })
 })

--- a/src/pages/fi/rss.xml.ts
+++ b/src/pages/fi/rss.xml.ts
@@ -12,9 +12,7 @@ export async function GET(context: APIContext) {
         posts.map(async (post) => {
             const absoluteUrl = new URL(post.url, context.site!).href
             const html = (await mdxContentByPath[`../pages${post.url}index.mdx`]?.()) ?? ''
-            const content =
-                html +
-                `<p><a href="${absoluteUrl}">Pysyvä linkki blogikirjoitukseen</a></p>`
+            const content = html + `<p><a href="${absoluteUrl}">Pysyvä linkki blogikirjoitukseen</a></p>`
             const img = getImage(post.heroImage, 'og')
 
             return {

--- a/src/pages/fi/rss.xml.ts
+++ b/src/pages/fi/rss.xml.ts
@@ -14,7 +14,7 @@ export async function GET(context: APIContext) {
             const html = (await mdxContentByPath[`../pages${post.url}index.mdx`]?.()) ?? ''
             const content =
                 html +
-                `<p>Kirjoitus <a href="${absoluteUrl}">${post.title}</a> on julkaistu ensimmäisen kerran Lauri Lavantin blogissa.</p>`
+                `<p><a href="${absoluteUrl}">Pysyvä linkki blogikirjoitukseen</a></p>`
             const img = getImage(post.heroImage, 'og')
 
             return {

--- a/src/pages/fi/rss.xml.ts
+++ b/src/pages/fi/rss.xml.ts
@@ -2,20 +2,38 @@ import type { APIContext } from 'astro'
 
 import rss from '@astrojs/rss'
 
-import { allMdxPosts } from '../../lib/mdxPosts'
+import { getImage } from '../../lib/images'
+import { allMdxPosts, mdxContentByPath } from '../../lib/mdxPosts'
 
 export async function GET(context: APIContext) {
     const posts = allMdxPosts.filter((p) => p.lang === 'fi')
 
+    const items = await Promise.all(
+        posts.map(async (post) => {
+            const absoluteUrl = new URL(post.url, context.site!).href
+            const html = (await mdxContentByPath[`../pages${post.url}index.mdx`]?.()) ?? ''
+            const content =
+                html +
+                `<p>Kirjoitus <a href="${absoluteUrl}">${post.title}</a> on julkaistu ensimmäisen kerran Lauri Lavantin blogissa.</p>`
+            const img = getImage(post.heroImage, 'og')
+
+            return {
+                content,
+                customData: `<media:content url="${img.src}" medium="image" width="${img.width}" height="${img.height}"/>`,
+                description: post.description,
+                enclosure: { length: 0, type: 'image/jpeg', url: img.src },
+                link: post.url,
+                pubDate: new Date(post.publishDate),
+                title: post.title,
+            }
+        })
+    )
+
     return rss({
         description: 'Lauri Lavantin blogikirjoitukset',
-        items: posts.map((post) => ({
-            description: post.description,
-            link: post.url,
-            pubDate: new Date(post.publishDate),
-            title: post.title,
-        })),
+        items,
         site: context.site!,
         title: 'Lauri Lavanti – blogi',
+        xmlns: { media: 'http://search.yahoo.com/mrss/' },
     })
 }

--- a/src/pages/sv/_rss.xml.spec.ts
+++ b/src/pages/sv/_rss.xml.spec.ts
@@ -57,6 +57,6 @@ describe('sv/rss.xml', () => {
 
     it('contains Swedish byline text', async () => {
         const text = await GET(makeContext()).then((r) => r.text())
-        expect(text).toContain('publicerades först på Lauri Lavantis blogg')
+        expect(text).toContain('Permanent länk till blogginlägget')
     })
 })

--- a/src/pages/sv/_rss.xml.spec.ts
+++ b/src/pages/sv/_rss.xml.spec.ts
@@ -39,4 +39,24 @@ describe('sv/rss.xml', () => {
             expect(text, `unexpected non-sv post: ${post.url}`).not.toContain(post.url)
         }
     })
+
+    it('contains content:encoded for posts', async () => {
+        const text = await GET(makeContext()).then((r) => r.text())
+        expect(text).toContain('content:encoded')
+    })
+
+    it('contains enclosure for posts', async () => {
+        const text = await GET(makeContext()).then((r) => r.text())
+        expect(text).toContain('<enclosure')
+    })
+
+    it('contains media:content for posts', async () => {
+        const text = await GET(makeContext()).then((r) => r.text())
+        expect(text).toContain('<media:content')
+    })
+
+    it('contains Swedish byline text', async () => {
+        const text = await GET(makeContext()).then((r) => r.text())
+        expect(text).toContain('publicerades först på Lauri Lavantis blogg')
+    })
 })

--- a/src/pages/sv/rss.xml.ts
+++ b/src/pages/sv/rss.xml.ts
@@ -2,20 +2,38 @@ import type { APIContext } from 'astro'
 
 import rss from '@astrojs/rss'
 
-import { allMdxPosts } from '../../lib/mdxPosts'
+import { getImage } from '../../lib/images'
+import { allMdxPosts, mdxContentByPath } from '../../lib/mdxPosts'
 
 export async function GET(context: APIContext) {
     const posts = allMdxPosts.filter((p) => p.lang === 'sv')
 
+    const items = await Promise.all(
+        posts.map(async (post) => {
+            const absoluteUrl = new URL(post.url, context.site!).href
+            const html = (await mdxContentByPath[`../pages${post.url}index.mdx`]?.()) ?? ''
+            const content =
+                html +
+                `<p>Inlägget <a href="${absoluteUrl}">${post.title}</a> publicerades först på Lauri Lavantis blogg.</p>`
+            const img = getImage(post.heroImage, 'og')
+
+            return {
+                content,
+                customData: `<media:content url="${img.src}" medium="image" width="${img.width}" height="${img.height}"/>`,
+                description: post.description,
+                enclosure: { length: 0, type: 'image/jpeg', url: img.src },
+                link: post.url,
+                pubDate: new Date(post.publishDate),
+                title: post.title,
+            }
+        })
+    )
+
     return rss({
         description: 'Lauri Lavantis blogginlägg',
-        items: posts.map((post) => ({
-            description: post.description,
-            link: post.url,
-            pubDate: new Date(post.publishDate),
-            title: post.title,
-        })),
+        items,
         site: context.site!,
         title: 'Lauri Lavanti – blogg',
+        xmlns: { media: 'http://search.yahoo.com/mrss/' },
     })
 }

--- a/src/pages/sv/rss.xml.ts
+++ b/src/pages/sv/rss.xml.ts
@@ -14,7 +14,7 @@ export async function GET(context: APIContext) {
             const html = (await mdxContentByPath[`../pages${post.url}index.mdx`]?.()) ?? ''
             const content =
                 html +
-                `<p>Inlägget <a href="${absoluteUrl}">${post.title}</a> publicerades först på Lauri Lavantis blogg.</p>`
+                `<p><a href="${absoluteUrl}">Permanent länk till blogginlägget</a></p>`
             const img = getImage(post.heroImage, 'og')
 
             return {

--- a/src/pages/sv/rss.xml.ts
+++ b/src/pages/sv/rss.xml.ts
@@ -12,9 +12,7 @@ export async function GET(context: APIContext) {
         posts.map(async (post) => {
             const absoluteUrl = new URL(post.url, context.site!).href
             const html = (await mdxContentByPath[`../pages${post.url}index.mdx`]?.()) ?? ''
-            const content =
-                html +
-                `<p><a href="${absoluteUrl}">Permanent länk till blogginlägget</a></p>`
+            const content = html + `<p><a href="${absoluteUrl}">Permanent länk till blogginlägget</a></p>`
             const img = getImage(post.heroImage, 'og')
 
             return {


### PR DESCRIPTION
> This PR containes AI-generated code. The author has reviewed and is responsible for all AI-generated content.

## Summary

- Adds `<content:encoded>` with full post HTML to all locale RSS feeds (fi/en/sv) via a remark→rehype pipeline on raw MDX source
- Adds `<enclosure>` and `<media:content>` with the hero image (og variant, 1200×630) for image-aware feed readers
- Adds a locale-appropriate byline paragraph at the end of each item linking back to the original post on laurilavanti.fi

## Test plan

- [ ] All 26 new unit test assertions pass (`npm run test`)
- [ ] Static build succeeds (`npm run build`)
- [ ] Verify `dist/fi/rss.xml` contains `<content:encoded>`, `<enclosure>`, `<media:content>`, and Finnish byline text
- [ ] Subscribe to the feed in a feed reader (e.g. Feedly, NetNewsWire) and confirm post images and full content render
- [ ] Run e2e tests (`npm run test:e2e`) — no regressions

Closes #(issue number if any)

🤖 Generated with [Claude Code](https://claude.com/claude-code)