### PR TITLE
ci: cache Playwright browsers and increase CI worker count to 4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -198,7 +198,13 @@ jobs:
           cache-dependency-path: "package-lock.json"
       - name: Install dependencies
         run: npm ci
+      - uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npm run test:e2e:setup
       - name: Run snapshot tests
         env:
@@ -230,7 +236,13 @@ jobs:
           cache-dependency-path: "package-lock.json"
       - name: Install dependencies
         run: npm ci
+      - uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npm run test:e2e:setup
       - name: Run screenshot tests
         env:
@@ -262,7 +274,13 @@ jobs:
           cache-dependency-path: "package-lock.json"
       - name: Install dependencies
         run: npm ci
+      - uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npm run test:e2e:setup
       - name: Run axe accessibility tests
         env:
@@ -294,7 +312,13 @@ jobs:
           cache-dependency-path: "package-lock.json"
       - name: Install dependencies
         run: npm ci
+      - uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npm run test:e2e:setup
       - name: Run SiteImprove tests
         env:
@@ -326,7 +350,13 @@ jobs:
           cache-dependency-path: "package-lock.json"
       - name: Install dependencies
         run: npm ci
+      - uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npm run test:e2e:setup
       - name: Run other tests
         env:
@@ -358,7 +388,13 @@ jobs:
           cache-dependency-path: "package-lock.json"
       - name: Install dependencies
         run: npm ci
+      - uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npm run test:e2e:setup
       - name: Run horizontal scroll tests
         env:
@@ -390,7 +426,13 @@ jobs:
           cache-dependency-path: "package-lock.json"
       - name: Install dependencies
         run: npm ci
+      - uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npm run test:e2e:setup
       - name: Run screenshot tests against production
         env:
@@ -422,7 +464,13 @@ jobs:
           cache-dependency-path: "package-lock.json"
       - name: Install dependencies
         run: npm ci
+      - uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npm run test:e2e:setup
       - name: Run screenshot tests against production
         env:
@@ -454,7 +502,13 @@ jobs:
           cache-dependency-path: "package-lock.json"
       - name: Install dependencies
         run: npm ci
+      - uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npm run test:e2e:setup
       - name: Run axe accessibility tests against production
         env:
@@ -486,7 +540,13 @@ jobs:
           cache-dependency-path: "package-lock.json"
       - name: Install dependencies
         run: npm ci
+      - uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npm run test:e2e:setup
       - name: Run SiteImprove tests against production
         env:
@@ -518,7 +578,13 @@ jobs:
           cache-dependency-path: "package-lock.json"
       - name: Install dependencies
         run: npm ci
+      - uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npm run test:e2e:setup
       - name: Run other tests against production
         env:
@@ -550,7 +616,13 @@ jobs:
           cache-dependency-path: "package-lock.json"
       - name: Install dependencies
         run: npm ci
+      - uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npm run test:e2e:setup
       - name: Run horizontal scroll tests against production
         env:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -88,7 +88,7 @@ export default defineConfig({
         trace: 'on-first-retry',
     },
     /* Opt out of parallel tests on CI. */
-    workers: process.env.CI ? 1 : undefined,
+    workers: process.env.CI ? 4 : undefined,
 
     /* Run your local dev server before starting the tests */
     webServer: {


### PR DESCRIPTION
> This PR containes AI-generated code. The author has reviewed and is responsible for all AI-generated content.

Closes #1260

## Summary

- Add `actions/cache@v4` for `~/.cache/ms-playwright` in all 12 E2E CI jobs, keyed on `package-lock.json` hash — browser install is skipped on cache hit (estimated saving: 12–24 min per PR run)
- Increase `workers` from 1 to 4 in `playwright.config.ts` for CI — tests are already `fullyParallel: true`, so single-worker was the bottleneck

## Test plan

- [ ] Merge to trigger CI run — confirm first run installs browsers (cache miss), subsequent run uses cache
- [ ] Confirm all E2E tests still pass with 4 workers
- [ ] Check GitHub Actions run time before/after in pipeline summary