### PR TITLE
feat: SEO/AEO improvements — article:tag, inLanguage, wordCount, reading time, updated date

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -47,9 +47,11 @@ interface Props {
     ogImage?: string
     ogImageAlt?: string
     slug?: string
+    tags?: string[]
     title: string
     type?: JsonLdType
     updatedAt?: string
+    wordCount?: number
 }
 
 const {
@@ -60,6 +62,7 @@ const {
     lang: rawLang = 'fi',
     langAlternates,
     noindex,
+    tags,
     title,
     type,
     slug,
@@ -67,6 +70,7 @@ const {
     ogImageAlt,
     createdAt,
     updatedAt,
+    wordCount,
 } = Astro.props
 
 const lang: Lang = rawLang
@@ -180,10 +184,13 @@ const jsonLd = JSON.stringify(
                             : {}),
                         dateModified: updatedAt ?? createdAt,
                         datePublished: createdAt,
+                        inLanguage: lang,
                         mainEntityOfPage: {
                             '@id': canonical,
                             '@type': WEBPAGE,
+                            inLanguage: lang,
                         },
+                        ...(wordCount ? { wordCount } : {}),
                     }
                   : {}),
               ...(type === WEBSITE
@@ -243,6 +250,8 @@ const breadcrumbJsonLd =
 {isArticle && articleAuthorNames.map((n: string) => <meta content={n} property="article:author" />)}
 {isArticle && <meta content={createdAt} property="article:published_time" />}
 {isArticle && updatedAt && <meta content={updatedAt} property="article:modified_time" />}
+{isArticle && tags && tags.length > 0 && <meta content={tags[0]} property="article:section" />}
+{isArticle && tags && tags.map((tag: string) => <meta content={tag} property="article:tag" />)}
 <meta content="@laurilavanti@mastodon.social" name="fediverse:creator" />
 {
     canonical && (

--- a/src/components/Head.spec.ts
+++ b/src/components/Head.spec.ts
@@ -763,4 +763,82 @@ describe('<Head />', () => {
         expect(jsonLd.dateModified).toBe('2024-06-01')
         expect(jsonLd.mainEntityOfPage['@type']).toBe('WebPage')
     })
+
+    it('should emit inLanguage on BlogPosting and mainEntityOfPage JSON-LD', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                createdAt: '2024-01-01',
+                lang: 'fi',
+                title: 'Test Blog Post',
+                type: 'BlogPosting',
+            },
+        })
+
+        const jsonLdScript = result.querySelector('script[type="application/ld+json"]')
+        const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
+        expect(jsonLd.inLanguage).toBe('fi')
+        expect(jsonLd.mainEntityOfPage.inLanguage).toBe('fi')
+    })
+
+    it('should emit wordCount in BlogPosting JSON-LD when provided', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                createdAt: '2024-01-01',
+                title: 'Test Blog Post',
+                type: 'BlogPosting',
+                wordCount: 850,
+            },
+        })
+
+        const jsonLdScript = result.querySelector('script[type="application/ld+json"]')
+        const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
+        expect(jsonLd.wordCount).toBe(850)
+    })
+
+    it('should not emit wordCount in BlogPosting JSON-LD when absent', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                createdAt: '2024-01-01',
+                title: 'Test Blog Post',
+                type: 'BlogPosting',
+            },
+        })
+
+        const jsonLdScript = result.querySelector('script[type="application/ld+json"]')
+        const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
+        expect(jsonLd.wordCount).toBeUndefined()
+    })
+
+    it('should emit article:section and article:tag meta tags for BlogPosting with tags', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                createdAt: '2024-01-01',
+                tags: ['kirkkonummi', 'lansirata', 'kuntavaalit2025'],
+                title: 'Test Blog Post',
+                type: 'BlogPosting',
+            },
+        })
+
+        const section = result.querySelector('meta[property="article:section"]')
+        expect(section?.getAttribute('content')).toBe('kirkkonummi')
+
+        const tagMetas = Array.from(result.querySelectorAll('meta[property="article:tag"]'))
+        expect(tagMetas).toHaveLength(3)
+        const contents = tagMetas.map((m) => m.getAttribute('content'))
+        expect(contents).toContain('kirkkonummi')
+        expect(contents).toContain('lansirata')
+        expect(contents).toContain('kuntavaalit2025')
+    })
+
+    it('should not emit article:section or article:tag for non-article pages', async () => {
+        const result = await renderAstroComponent(Head, {
+            props: {
+                tags: ['kirkkonummi'],
+                title: 'Some Page',
+            },
+        })
+
+        expect(result.querySelector('meta[property="article:section"]')).toBeNull()
+        expect(result.querySelector('meta[property="article:tag"]')).toBeNull()
+    })
 })

--- a/src/components/Meta.astro
+++ b/src/components/Meta.astro
@@ -8,16 +8,25 @@ interface Props {
     bigDateTime?: boolean
     date: string
     lang?: 'en' | 'fi' | 'sv'
+    readingTime?: number
     tags: string[]
+    updatedDate?: string
 }
 
-const { ariaLabel, bigDateTime, date, lang = 'fi', tags } = Astro.props
+const { ariaLabel, bigDateTime, date, lang = 'fi', readingTime, tags, updatedDate } = Astro.props
 
 const tagBasePaths = { en: '/en/category', fi: '/fi/category', sv: '/sv/category' }
 
 const [dateOnly] = date.split('T')
 const [year, month, day] = dateOnly.split('-')
 const dateToDisplay = `${day}.${month}.${year}`
+
+const readingTimeLabel: Record<'en' | 'fi' | 'sv', string> = { en: 'min read', fi: 'min', sv: 'min' }
+const updatedLabel: Record<'en' | 'fi' | 'sv', string> = { en: 'Updated', fi: 'Päivitetty', sv: 'Uppdaterad' }
+
+const showUpdated = updatedDate && updatedDate !== dateOnly
+const [updYear, updMonth, updDay] = showUpdated ? updatedDate.split('-') : []
+const updatedDateToDisplay = showUpdated ? `${updDay}.${updMonth}.${updYear}` : ''
 
 const tagsToRender = tags
     .map((tagId) => ({ id: tagId, name: getTagName(tagId, lang) }))
@@ -49,6 +58,8 @@ const tagsToRender = tags
 </style>
 <aside aria-label={ariaLabel}>
     <time datetime={dateOnly} style={{ ...(bigDateTime ? typographics.ingress : {}) }}>{dateToDisplay}</time>
+    {readingTime && readingTime > 0 && <span>{readingTime} {readingTimeLabel[lang]}</span>}
+    {showUpdated && <time datetime={updatedDate}>{updatedLabel[lang]}: {updatedDateToDisplay}</time>}
     {
         tags.length > 0 && (
             <ul>

--- a/src/components/Meta.astro
+++ b/src/components/Meta.astro
@@ -21,7 +21,7 @@ const [dateOnly] = date.split('T')
 const [year, month, day] = dateOnly.split('-')
 const dateToDisplay = `${day}.${month}.${year}`
 
-const readingTimeLabel: Record<'en' | 'fi' | 'sv', string> = { en: 'min read', fi: 'min', sv: 'min' }
+const readingTimeLabel: Record<'en' | 'fi' | 'sv', string> = { en: 'min read', fi: 'min lukuaika', sv: 'min' }
 const updatedLabel: Record<'en' | 'fi' | 'sv', string> = { en: 'Updated', fi: 'Päivitetty', sv: 'Uppdaterad' }
 
 const showUpdated = updatedDate && updatedDate !== dateOnly

--- a/src/components/Meta.astro
+++ b/src/components/Meta.astro
@@ -58,8 +58,20 @@ const tagsToRender = tags
 </style>
 <aside aria-label={ariaLabel}>
     <time datetime={dateOnly} style={{ ...(bigDateTime ? typographics.ingress : {}) }}>{dateToDisplay}</time>
-    {readingTime && readingTime > 0 && <span>{readingTime} {readingTimeLabel[lang]}</span>}
-    {showUpdated && <time datetime={updatedDate}>{updatedLabel[lang]}: {updatedDateToDisplay}</time>}
+    {
+        readingTime && readingTime > 0 && (
+            <span>
+                {readingTime} {readingTimeLabel[lang]}
+            </span>
+        )
+    }
+    {
+        showUpdated && (
+            <time datetime={updatedDate}>
+                {updatedLabel[lang]}: {updatedDateToDisplay}
+            </time>
+        )
+    }
     {
         tags.length > 0 && (
             <ul>

--- a/src/components/TitleBanner.astro
+++ b/src/components/TitleBanner.astro
@@ -51,7 +51,14 @@ const { alt, createdAt, heroImage, lang, readingTime, tags, title, updatedDate }
 </style>
 <div class="container">
     <div class="content">
-        <Title createdAt={createdAt} lang={lang} readingTime={readingTime} tags={tags} title={title} updatedDate={updatedDate} />
+        <Title
+            createdAt={createdAt}
+            lang={lang}
+            readingTime={readingTime}
+            tags={tags}
+            title={title}
+            updatedDate={updatedDate}
+        />
         <Image alt={alt} heroImage={heroImage} />
     </div>
 </div>

--- a/src/components/TitleBanner.astro
+++ b/src/components/TitleBanner.astro
@@ -8,11 +8,13 @@ interface Props {
     createdAt?: string
     heroImage?: string
     lang?: 'en' | 'fi' | 'sv'
+    readingTime?: number
     tags?: string[]
     title: string
+    updatedDate?: string
 }
 
-const { alt, createdAt, heroImage, lang, tags, title } = Astro.props
+const { alt, createdAt, heroImage, lang, readingTime, tags, title, updatedDate } = Astro.props
 ---
 
 <style
@@ -49,7 +51,7 @@ const { alt, createdAt, heroImage, lang, tags, title } = Astro.props
 </style>
 <div class="container">
     <div class="content">
-        <Title createdAt={createdAt} lang={lang} tags={tags} title={title} />
+        <Title createdAt={createdAt} lang={lang} readingTime={readingTime} tags={tags} title={title} updatedDate={updatedDate} />
         <Image alt={alt} heroImage={heroImage} />
     </div>
 </div>

--- a/src/components/titleBanner/Title.astro
+++ b/src/components/titleBanner/Title.astro
@@ -6,11 +6,13 @@ import H1 from './title/H1.astro'
 interface Props {
     createdAt?: string
     lang?: 'en' | 'fi' | 'sv'
+    readingTime?: number
     tags?: string[]
     title: string
+    updatedDate?: string
 }
 
-const { createdAt, lang, tags, title } = Astro.props
+const { createdAt, lang, readingTime, tags, title, updatedDate } = Astro.props
 ---
 
 <style
@@ -54,7 +56,9 @@ const { createdAt, lang, tags, title } = Astro.props
                 bigDateTime
                 date={createdAt}
                 lang={lang}
+                readingTime={readingTime}
                 tags={tags}
+                updatedDate={updatedDate}
             />
         )
     }

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -29,9 +29,11 @@ interface Props {
     ogImage?: string
     ogImageAlt?: string
     slug?: string
+    tags?: string[]
     title: string
     type?: JsonLdType
     updatedAt?: string
+    wordCount?: number
 }
 
 const {
@@ -46,9 +48,11 @@ const {
     ogImage,
     ogImageAlt,
     slug,
+    tags,
     title,
     type,
     updatedAt,
+    wordCount,
 } = Astro.props
 ---
 
@@ -67,9 +71,11 @@ const {
             ogImage={ogImage}
             ogImageAlt={ogImageAlt}
             slug={slug}
+            tags={tags}
             title={title}
             type={type}
             updatedAt={updatedAt}
+            wordCount={wordCount}
         />
     </head>
     <body>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -10,7 +10,7 @@ import SocialShare from '../components/SocialShare.astro'
 import TitleBanner from '../components/TitleBanner.astro'
 import { getImage } from '../lib/images'
 import { BLOGPOSTING, type BreadcrumbItem } from '../lib/jsonld'
-import { getPostAlternates } from '../lib/mdxPosts'
+import { allMdxPosts, getPostAlternates } from '../lib/mdxPosts'
 import { gridTemplateColumnsArticle, sizes } from '../lib/styles'
 import BaseLayout from './BaseLayout.astro'
 
@@ -52,6 +52,9 @@ const {
 const canonicalSlug = `${lang}/blog/${id}/${slug}`
 const shareUrl = `https://laurilavanti.fi/${canonicalSlug}/`
 const langAlternates = getPostAlternates(id)
+const postMeta = allMdxPosts.find((p) => p.url === `/${canonicalSlug}/`)
+const readingTime = postMeta?.readingTime ?? 0
+const wordCount = postMeta?.wordCount ?? 0
 
 const i18n = {
     en: {
@@ -108,18 +111,22 @@ const breadcrumbs: BreadcrumbItem[] = [
     ogImage={ogImage}
     ogImageAlt={alt}
     slug={canonicalSlug}
+    tags={tags}
     title={pageTitle}
     type={BLOGPOSTING}
     updatedAt={updatedDate}
+    wordCount={wordCount}
 >
     <TitleBanner
         alt={alt}
         createdAt={publishDate}
         heroImage={heroImage}
         lang={lang}
+        readingTime={readingTime}
         slot="banner"
         tags={tags}
         title={title}
+        updatedDate={updatedDate}
     />
     <slot />
     <Byline authors={authors ?? ['lauri']} externalPublications={externalPublications} lang={lang} />

--- a/src/lib/mdxPosts.ts
+++ b/src/lib/mdxPosts.ts
@@ -23,20 +23,11 @@ interface MdxPost {
     updatedDate: string
 }
 
-type MdxPostWithUrl = MdxPost & { url: string }
+type MdxPostWithUrl = MdxPost & { readingTime: number; url: string; wordCount: number }
 
 type GlobResult = { frontmatter: MdxPost }
 
 const rawGlob = import.meta.glob<GlobResult>('../pages/*/blog/*/*/index.mdx', { eager: true })
-
-export const allMdxPosts: MdxPostWithUrl[] = Object.entries(rawGlob)
-    .map(([filePath, mod]) => {
-        /* '../pages/fi/blog/1/kotihoidon-tuen-kuntalisa/index.mdx' → '/fi/blog/1/kotihoidon-tuen-kuntalisa/' */
-        const url = filePath.replace('../pages', '').replace('index.mdx', '')
-
-        return { ...mod.frontmatter, url }
-    })
-    .sort((a, b) => b.id - a.id)
 
 const rawMdxGlob = import.meta.glob<string>('../pages/*/blog/*/*/index.mdx', {
     eager: true,
@@ -44,10 +35,27 @@ const rawMdxGlob = import.meta.glob<string>('../pages/*/blog/*/*/index.mdx', {
     query: '?raw',
 })
 
-const processor = unified().use(remarkParse).use(remarkRehype, { allowDangerousHtml: true }).use(rehypeStringify)
-
 const stripFrontmatter = (raw: string): string =>
     raw.replace(/^---[\s\S]*?---\n?/, '').replace(/^(import\s+.+|export\s+const\s+components\s*=.+)$/gm, '')
+
+const wordCountByPath: Record<string, number> = Object.fromEntries(
+    Object.entries(rawMdxGlob).map(([filePath, raw]) => [
+        filePath,
+        stripFrontmatter(raw).trim().split(/\s+/).filter(Boolean).length,
+    ])
+)
+
+export const allMdxPosts: MdxPostWithUrl[] = Object.entries(rawGlob)
+    .map(([filePath, mod]) => {
+        const url = filePath.replace('../pages', '').replace('index.mdx', '')
+        const wordCount = wordCountByPath[filePath] ?? 0
+        const readingTime = Math.ceil(wordCount / 200)
+
+        return { ...mod.frontmatter, readingTime, url, wordCount }
+    })
+    .sort((a, b) => b.id - a.id)
+
+const processor = unified().use(remarkParse).use(remarkRehype, { allowDangerousHtml: true }).use(rehypeStringify)
 
 export const mdxContentByPath: Record<string, () => Promise<string>> = Object.fromEntries(
     Object.entries(rawMdxGlob).map(([filePath, raw]) => [

--- a/tests/__snapshots__/components/TitleBanner.spec.ts.snap
+++ b/tests/__snapshots__/components/TitleBanner.spec.ts.snap
@@ -39,7 +39,7 @@ exports[`<TitleBanner /> > should render 1`] = `
         >
           01.01.2026
         </time>
-         
+           
         <ul
           data-astro-cid-k4jemuzu=""
           style="--sizes05: 0.5rem;"

--- a/tests/__snapshots__/components/titleBanner/Title.spec.ts.snap
+++ b/tests/__snapshots__/components/titleBanner/Title.spec.ts.snap
@@ -27,7 +27,7 @@ exports[`<Title /> > should render 1`] = `
     >
       01.01.2026
     </time>
-     
+       
     <ul
       data-astro-cid-k4jemuzu=""
       style="--sizes05: 0.5rem;"


### PR DESCRIPTION
> This PR containes AI-generated code. The author has reviewed and is responsible for all AI-generated content.

## Summary

- **OG meta**: `article:section` (first tag) and `article:tag` (one per tag) added to BlogPosting pages
- **JSON-LD**: `inLanguage` on `BlogPosting` and `mainEntityOfPage` (WebPage) schemas; `wordCount` in BlogPosting
- **Reading time**: computed from word count (÷200, rounded up) in `mdxPosts.ts`; displayed in post title banner metadata area
- **Updated date**: displayed in post title banner when `updatedDate` differs from `publishDate`, with localised "Päivitetty/Updated/Uppdaterad" label

Closes #1262

## Test plan

- [ ] `npm run test` passes (927 tests incl. 5 new Head tests)
- [ ] Build succeeds: `npm run build`
- [ ] Post page shows reading time and updated date in title banner metadata
- [ ] Google Rich Results Test shows `inLanguage` and `wordCount` on a blog post