### PR TITLE
ci: parallelize validate-content loops + cache .astro/ build dir

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,11 @@ jobs:
           cache-dependency-path: "package-lock.json"
       - name: Install dependencies
         run: npm ci
+      - uses: actions/cache@v4
+        with:
+          path: .astro
+          key: astro-${{ runner.os }}-${{ hashFiles('astro.config.*', 'src/**', 'public/**') }}
+          restore-keys: astro-${{ runner.os }}-
       - name: build it
         run: npm run build
       - uses: actions/upload-artifact@v7


### PR DESCRIPTION
> This PR containes AI-generated code. The author has reviewed and is responsible for all AI-generated content.

## Summary

- **validate-content**: replace sequential `while read` loops with `xargs -P 4` — seo, aeo, content, and style-fi checks now run 4 files concurrently instead of one at a time
- **build**: add `actions/cache@v4` for `.astro/` keyed on source file hashes — Astro's incremental build cache survives between runs when content is unchanged

Closes #1263

## Test plan

- [ ] CI passes on this PR
- [ ] Compare build job duration vs baseline after merge
- [ ] Compare validate-content job duration vs baseline after merge