### PR TITLE
fix(about): align description and H2 framing to Segment C audience

### DIFF
--- a/src/pages/en/about/index.mdx
+++ b/src/pages/en/about/index.mdx
@@ -3,9 +3,9 @@ layout: '../../../layouts/PageLayout.astro'
 lang: en
 pageTitle: 'At the crossroads of technology and society'
 title: 'At the crossroads of technology and society'
-description: 'Lauri Lavanti is a lead developer, Kirkkonummi councillor, and Greens group chair. Focus: economic policy, entrepreneurship and digital independence.'
+description: 'Lauri Lavanti — Kirkkonummi councillor (Greens) and lead software developer (MSc, Aalto). Building a competitive, digitally independent Finland.'
 slug: 'en/about'
-updatedDate: '2026-05-23'
+updatedDate: '2026-06-02'
 type: 'ProfilePage'
 heroImage: 'Lauri-Lavanti-sitting-in-front-of-a-window'
 alt: 'Lauri Lavanti sitting on a stool in front of a window, looking at the camera, smiling. He is wearing a white shirt with blue flower patterns and a dark jacket. Photo was taken by Juha Jantunen.'
@@ -51,13 +51,13 @@ export const components = { a: SmartLink, h2: H2, p: Paragraph }
 
 Lauri works where technology is changing society—and where decision-making should keep pace.
 
-Lauri Lavanti is a lead software developer, municipal councillor in Kirkkonummi, and chair of the Greens council group. He graduated as a Master of Science (Tech.) from Aalto University and focuses on AI, economic policy, entrepreneurship, innovation, and digital independence.
+Lauri Lavanti is a lead software developer, municipal councillor in Kirkkonummi, and chair of the Greens council group. He graduated as a Master of Science (Tech.) from Aalto University and focuses on AI, economic policy, entrepreneurship, and digital independence.
 
 Digitalization, privacy, and the responsible implementation of artificial intelligence are all part of the same whole: how we build technological development that is both competitive and sustainable for nature and people.
 
 Lauri also has a [Wikipedia article](https://fi.wikipedia.org/wiki/Lauri_Lavanti) (in Finnish).
 
-## Expert in digitalization and privacy
+## A technology expert who combines competitiveness and privacy
 
 I work as a lead developer and am responsible for the technical solutions of our team's services. My work focuses on the design, development, and maintenance of demanding systems. I manage technical guidelines and engage in active dialogue with stakeholders to ensure that solutions meet real needs and stand the test of time.
 
@@ -75,7 +75,7 @@ My multidisciplinary background has given me the ability to act smoothly as a br
 
 I serve as a municipal councilor in Kirkkonummi and as chair of the Green council group.
 
-In politics, I focus particularly on digitalization, privacy protection, and the controlled introduction of artificial intelligence. Society is rapidly becoming digitalized, but public administration and decision-making do not always keep pace with developments. **The same challenge applies across Finland.**
+In politics, I focus particularly on AI, economic policy, and digitalisation — and on how Finland can remain competitive while safeguarding privacy and digital independence. Society is rapidly becoming digitalized, but public administration and decision-making do not always keep pace with developments. **The same challenge applies across Finland.**
 
 We need a better understanding of the opportunities and risks presented by technology, as well as the courage to invest in education and high-productivity technological development. It is important that Finland does not fall behind in terms of expertise or competitiveness.
 

--- a/src/pages/en/about/index.mdx
+++ b/src/pages/en/about/index.mdx
@@ -3,7 +3,7 @@ layout: '../../../layouts/PageLayout.astro'
 lang: en
 pageTitle: 'At the crossroads of technology and society'
 title: 'At the crossroads of technology and society'
-description: 'Lauri Lavanti — Kirkkonummi councillor (Greens) and lead software developer (MSc, Aalto). Building a competitive, digitally independent Finland.'
+description: 'Lauri Lavanti is a Kirkkonummi municipal councillor and lead developer building a digitally independent Finland in the age of AI.'
 slug: 'en/about'
 updatedDate: '2026-06-02'
 type: 'ProfilePage'

--- a/src/pages/en/about/index.mdx
+++ b/src/pages/en/about/index.mdx
@@ -51,7 +51,7 @@ export const components = { a: SmartLink, h2: H2, p: Paragraph }
 
 Lauri works where technology is changing society—and where decision-making should keep pace.
 
-Lauri Lavanti is a lead software developer, municipal councillor in Kirkkonummi, and chair of the Greens council group. He graduated as a Master of Science (Tech.) from Aalto University and focuses on AI, economic policy, entrepreneurship, and digital independence.
+Lauri Lavanti is a lead developer, municipal councillor in Kirkkonummi, and chair of the Greens council group. He graduated as a Master of Science (Tech.) from Aalto University and focuses on AI, economic policy, entrepreneurship, and digital independence.
 
 Digitalization, privacy, and the responsible implementation of artificial intelligence are all part of the same whole: how we build technological development that is both competitive and sustainable for nature and people.
 

--- a/src/pages/fi/about/index.mdx
+++ b/src/pages/fi/about/index.mdx
@@ -3,9 +3,9 @@ layout: '../../../layouts/PageLayout.astro'
 lang: fi
 pageTitle: 'Teknologian ja yhteiskunnan rajapinnassa'
 title: 'Teknologian ja yhteis­kunnan raja­pinnassa'
-description: 'Lauri Lavanti on johtava ohjelmistokehittäjä, kunnanvaltuutettu ja Vihreän valtuustoryhmän pj. Painopisteet: talous, yrittäjyys ja digitaalinen riippumattomuus.'
+description: 'Lauri Lavanti — Kirkkonummen kunnanvaltuutettu ja johtava ohjelmistokehittäjä (DI, Aalto). Rakentaa kilpailukykyistä, digitaalisesti itsenäistä Suomea.'
 slug: 'fi/about'
-updatedDate: '2026-05-23'
+updatedDate: '2026-06-02'
 type: 'ProfilePage'
 heroImage: Lauri-Lavanti-sitting-in-front-of-a-window
 alt: 'Lauri Lavanti istumassa tuolilla ikkunan edessä, katse kameraan, hymyillen. Hänellä on päällään valkoinen kauluspaita, jossa on sinisiä kukkakuvioita, sekä tumma pikkutakki. Kuvan otti Juha Jantunen.'
@@ -52,13 +52,13 @@ export const components = { a: SmartLink, h2: H2, p: Paragraph }
 
 Lauri työskentelee siellä, missä teknologia muuttaa yhteiskuntaa – ja missä päätöksenteon pitäisi pysyä mukana.
 
-Lauri Lavanti on johtava ohjelmistokehittäjä, Kirkkonummen kunnanvaltuutettu sekä Vihreän valtuustoryhmän puheenjohtaja. Hän on Aalto-yliopistosta valmistunut diplomi-insinööri ja keskittyy tekoälyyn, talouteen, yrittäjyyteen, innovaatiopolitiikkaan sekä digitaaliseen riippumattomuuteen.
+Lauri Lavanti on johtava ohjelmistokehittäjä, Kirkkonummen kunnanvaltuutettu sekä Vihreän valtuustoryhmän puheenjohtaja. Hän on Aalto-yliopistosta valmistunut diplomi-insinööri ja keskittyy tekoälyyn, talouteen, yrittäjyyteen sekä digitaaliseen itsenäisyyteen.
 
 Digitalisaatio, yksityisyyden suoja ja tekoälyn vastuullinen käyttöönotto ovat osa samaa kokonaisuutta: miten rakennamme teknologista kehitystä, joka on sekä kilpailukykyistä että kestävää niin luonnolle kuin ihmisille.
 
 Laurilla on myös [Wikipedia-artikkeli](https://fi.wikipedia.org/wiki/Lauri_Lavanti).
 
-## Digitalisaation ja yksityisyyden suojan asiantuntija
+## Teknologiaosaaja, joka yhdistää kilpailukyvyn ja yksityisyyden suojan
 
 Toimin johtavana ohjelmistokehittäjänä ja vastaan tiimimme palveluiden teknisistä ratkaisuista. Työni keskiössä ovat vaativien kokonaisuuksien suunnittelu, kehittäminen ja ylläpito. Johdan teknisiä linjauksia ja käyn aktiivista vuoropuhelua sidosryhmien kanssa, jotta ratkaisut vastaavat todellisia tarpeita ja kestävät aikaa.
 
@@ -76,7 +76,7 @@ Monialaisuus on antanut minulle valmiudet toimia sujuvasti sillanrakentajana rak
 
 Toimin Kirkkonummen kunnanvaltuutettuna ja Vihreän valtuustoryhmän puheenjohtajana.
 
-Politiikassa keskityn erityisesti digitalisaatioon, yksityisyyden suojaan ja tekoälyn hallittuun käyttöönottoon. Yhteiskunta digitalisoituu jatkuvasti, mutta julkishallinto ja päätöksenteko eivät aina pysy kehityksen tahdissa. **Sama haaste koskee koko Suomea.**
+Politiikassa keskityn erityisesti tekoälyyn, talouteen ja digitalisaatioon — ja siihen, miten Suomi pysyy kilpailukykyisenä samalla kun varmistamme yksityisyyden suojan ja digitaalisen itsenäisyyden. Yhteiskunta digitalisoituu jatkuvasti, mutta julkishallinto ja päätöksenteko eivät aina pysy kehityksen tahdissa. **Sama haaste koskee koko Suomea.**
 
 Tarvitsemme parempaa ymmärrystä teknologian mahdollisuuksista ja riskeistä sekä rohkeutta panostaa koulutukseen ja korkean tuottavuuden teknologiseen kehitykseen. On tärkeää, ettei Suomi jää jälkeen osaamisessa tai kilpailukyvyssä.
 

--- a/src/pages/fi/about/index.mdx
+++ b/src/pages/fi/about/index.mdx
@@ -3,7 +3,7 @@ layout: '../../../layouts/PageLayout.astro'
 lang: fi
 pageTitle: 'Teknologian ja yhteiskunnan rajapinnassa'
 title: 'Teknologian ja yhteis­kunnan raja­pinnassa'
-description: 'Lauri Lavanti — Kirkkonummen kunnanvaltuutettu ja johtava ohjelmistokehittäjä (DI, Aalto). Rakentaa kilpailukykyistä, digitaalisesti itsenäistä Suomea.'
+description: 'Lauri Lavanti on Kirkkonummelainen kunnanvaltuutettu ja johtava kehittäjä, joka rakentaa digitaalisesti itsenäistä Suomea tekoälyn aikakaudella.'
 slug: 'fi/about'
 updatedDate: '2026-06-02'
 type: 'ProfilePage'

--- a/src/pages/sv/about/index.mdx
+++ b/src/pages/sv/about/index.mdx
@@ -3,9 +3,9 @@ layout: '../../../layouts/PageLayout.astro'
 lang: sv
 pageTitle: 'I gränslandet mellan teknologi och samhälle'
 title: 'I gränslandet mellan teknologi och samhälle'
-description: 'Lauri Lavanti är ledande mjukvaruutvecklare, fullmäktigeledamot och ordförande för De Grönas grupp. Fokus: ekonomi, företagande och digital självständighet.'
+description: 'Lauri Lavanti — fullmäktigeledamot i Kyrkslätt (De Gröna) och ledande mjukvaruutvecklare (DI, Aalto). Fokus: konkurrenskraft och digital självständighet.'
 slug: 'sv/about'
-updatedDate: '2026-05-23'
+updatedDate: '2026-06-02'
 type: 'ProfilePage'
 heroImage: 'Lauri-Lavanti-sitting-in-front-of-a-window'
 alt: 'Lauri Lavanti sittande på en stol framför ett fönster, blicken mot kameran, leende. Han har på sig en vit skjorta med blå blomstermönster och en mörk kavaj. Bilden togs av Juha Jantunen.'
@@ -51,13 +51,13 @@ export const components = { a: SmartLink, h2: H2, p: Paragraph }
 
 Lauri arbetar där teknologin förändrar samhället – och där beslutsfattandet borde hänga med.
 
-Lauri Lavanti är ledande mjukvaruutvecklare, kommunfullmäktigeledamot i Kyrkslätt samt ordförande för De Grönas fullmäktigegrupp. Han är utexaminerad diplomingenjör från Aalto-universitetet och fokuserar på AI, ekonomisk politik, företagande, innovationspolitik samt digital självständighet.
+Lauri Lavanti är ledande mjukvaruutvecklare, kommunfullmäktigeledamot i Kyrkslätt samt ordförande för De Grönas fullmäktigegrupp. Han är utexaminerad diplomingenjör från Aalto-universitetet och fokuserar på AI, ekonomisk politik, företagande samt digital självständighet.
 
 Digitalisering, integritetsskydd och ansvarsfull implementering av artificiell intelligens är delar av samma helhet: hur vi bygger teknologisk utveckling som är både konkurrenskraftig och hållbar för naturen och människorna.
 
 Lauri har också en [Wikipedia-artikel](https://fi.wikipedia.org/wiki/Lauri_Lavanti) (på finska).
 
-## Expert på digitalisering och integritetsskydd
+## En teknologiexpert som förenar konkurrenskraft och integritetsskydd
 
 Jag arbetar som ledande mjukvaruutvecklare och ansvarar för de tekniska lösningarna i vårt teams tjänster. I mitt arbete står planering, utveckling och underhåll av krävande helheter i centrum. Jag leder tekniska riktlinjer och för en aktiv dialog med intressenter för att säkerställa att lösningarna motsvarar verkliga behov och håller över tid.
 
@@ -75,7 +75,7 @@ Mångdisciplinariteten har gett mig förmågan att smidigt fungera som brobyggar
 
 Jag är kommunfullmäktigeledamot i Kyrkslätt och ordförande för Gröna fullmäktigegruppen.
 
-I politiken fokuserar jag särskilt på digitalisering, integritetsskydd och kontrollerad implementering av artificiell intelligens. Samhället digitaliseras kontinuerligt, men den offentliga förvaltningen och beslutsfattandet hänger inte alltid med i utvecklingen. **Samma utmaning gäller hela Finland.**
+I politiken fokuserar jag särskilt på AI, ekonomisk politik och digitalisering — och på hur Finland kan förbli konkurrenskraftigt samtidigt som vi säkerställer integritetsskydd och digital självständighet. Samhället digitaliseras kontinuerligt, men den offentliga förvaltningen och beslutsfattandet hänger inte alltid med i utvecklingen. **Samma utmaning gäller hela Finland.**
 
 Vi behöver bättre förståelse för teknologins möjligheter och risker samt mod att satsa på utbildning och högproduktiv teknologisk utveckling. Det är viktigt att Finland inte halkar efter i kompetens eller konkurrenskraft.
 

--- a/src/pages/sv/about/index.mdx
+++ b/src/pages/sv/about/index.mdx
@@ -3,7 +3,7 @@ layout: '../../../layouts/PageLayout.astro'
 lang: sv
 pageTitle: 'I gränslandet mellan teknologi och samhälle'
 title: 'I gränslandet mellan teknologi och samhälle'
-description: 'Lauri Lavanti — fullmäktigeledamot i Kyrkslätt (De Gröna) och ledande mjukvaruutvecklare (DI, Aalto). Fokus: konkurrenskraft och digital självständighet.'
+description: 'Lauri Lavanti är fullmäktigeledamot i Kyrkslätt och ledande utvecklare som bygger ett digitalt självständigt Finland i AI-tidsåldern.'
 slug: 'sv/about'
 updatedDate: '2026-06-02'
 type: 'ProfilePage'

--- a/src/pages/sv/about/index.mdx
+++ b/src/pages/sv/about/index.mdx
@@ -51,7 +51,7 @@ export const components = { a: SmartLink, h2: H2, p: Paragraph }
 
 Lauri arbetar där teknologin förändrar samhället – och där beslutsfattandet borde hänga med.
 
-Lauri Lavanti är ledande mjukvaruutvecklare, kommunfullmäktigeledamot i Kyrkslätt samt ordförande för De Grönas fullmäktigegrupp. Han är utexaminerad diplomingenjör från Aalto-universitetet och fokuserar på AI, ekonomisk politik, företagande samt digital självständighet.
+Lauri Lavanti är ledande utvecklare, kommunfullmäktigeledamot i Kyrkslätt samt ordförande för De Grönas fullmäktigegrupp. Han är utexaminerad diplomingenjör från Aalto-universitetet och fokuserar på AI, ekonomisk politik, företagande samt digital självständighet.
 
 Digitalisering, integritetsskydd och ansvarsfull implementering av artificiell intelligens är delar av samma helhet: hur vi bygger teknologisk utveckling som är både konkurrenskraftig och hållbar för naturen och människorna.
 

--- a/tests/e2e/aboutEnPage.spec.ts-snapshots/About-Page-in-english-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/aboutEnPage.spec.ts-snapshots/About-Page-in-english-should-match-aria-snapshot-1.aria.yml
@@ -13,9 +13,14 @@
         - listitem: » Focuses on digitalization, privacy, and the responsible adoption of AI.
       - button "More"
     - paragraph: Lauri works where technology is changing society—and where decision-making should keep pace.
-    - paragraph: Lauri Lavanti is a lead software developer, municipal councillor in Kirkkonummi, and chair of the Greens council group. He graduated as a Master of Science (Tech.) from Aalto University and focuses on AI, economic policy, entrepreneurship, innovation, and digital independence.
+    - paragraph: Lauri Lavanti is a lead developer, municipal councillor in Kirkkonummi, and chair of the Greens council group. He graduated as a Master of Science (Tech.) from Aalto University and focuses on AI, economic policy, entrepreneurship, and digital independence.
     - paragraph: "Digitalization, privacy, and the responsible implementation of artificial intelligence are all part of the same whole: how we build technological development that is both competitive and sustainable for nature and people."
-    - heading "Expert in digitalization and privacy" [level=2]
+    - paragraph:
+      - text: Lauri also has a
+      - link "Wikipedia article":
+        - /url: https://fi.wikipedia.org/wiki/Lauri_Lavanti
+      - text: (in Finnish).
+    - heading "A technology expert who combines competitiveness and privacy" [level=2]
     - paragraph: I work as a lead developer and am responsible for the technical solutions of our team’s services. My work focuses on the design, development, and maintenance of demanding systems. I manage technical guidelines and engage in active dialogue with stakeholders to ensure that solutions meet real needs and stand the test of time.
     - paragraph: For me, digitalization is not just a technical issue, but also a social and ethical one. I make sure that solutions are not only functional today, but also secure and maintainable tomorrow. Technology must be safe, functional, and serve people.
     - paragraph: Finland has been a model country for high technology for decades. AI is reshaping work, services, and trust in digital systems. We need people in decision-making who understand technology in practice — not just comment on it from the sidelines.
@@ -25,7 +30,7 @@
     - heading "Why politics?" [level=2]
     - paragraph: I serve as a municipal councilor in Kirkkonummi and as chair of the Green council group.
     - paragraph:
-      - text: In politics, I focus particularly on digitalization, privacy protection, and the controlled introduction of artificial intelligence. Society is rapidly becoming digitalized, but public administration and decision-making do not always keep pace with developments.
+      - text: In politics, I focus particularly on AI, economic policy, and digitalisation — and on how Finland can remain competitive while safeguarding privacy and digital independence. Society is rapidly becoming digitalized, but public administration and decision-making do not always keep pace with developments.
       - strong: The same challenge applies across Finland.
     - paragraph: We need a better understanding of the opportunities and risks presented by technology, as well as the courage to invest in education and high-productivity technological development. It is important that Finland does not fall behind in terms of expertise or competitiveness.
     - heading "At home and off duty" [level=2]

--- a/tests/e2e/aboutPage.spec.ts-snapshots/About-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/aboutPage.spec.ts-snapshots/About-Page-should-match-aria-snapshot-1.aria.yml
@@ -13,9 +13,14 @@
         - listitem: » Keskittyy digitalisaatioon, yksityisyyden suojaan ja tekoälyn vastuulliseen käyttöönottoon.
       - button "Lisää"
     - paragraph: Lauri työskentelee siellä, missä teknologia muuttaa yhteiskuntaa – ja missä päätöksenteon pitäisi pysyä mukana.
-    - paragraph: Lauri Lavanti on johtava ohjelmistokehittäjä, Kirkkonummen kunnanvaltuutettu sekä Vihreän valtuustoryhmän puheenjohtaja. Hän on Aalto-yliopistosta valmistunut diplomi-insinööri ja keskittyy tekoälyyn, talouteen, yrittäjyyteen, innovaatiopolitiikkaan sekä digitaaliseen riippumattomuuteen.
+    - paragraph: Lauri Lavanti on johtava ohjelmistokehittäjä, Kirkkonummen kunnanvaltuutettu sekä Vihreän valtuustoryhmän puheenjohtaja. Hän on Aalto-yliopistosta valmistunut diplomi-insinööri ja keskittyy tekoälyyn, talouteen, yrittäjyyteen sekä digitaaliseen itsenäisyyteen.
     - paragraph: "Digitalisaatio, yksityisyyden suoja ja tekoälyn vastuullinen käyttöönotto ovat osa samaa kokonaisuutta: miten rakennamme teknologista kehitystä, joka on sekä kilpailukykyistä että kestävää niin luonnolle kuin ihmisille."
-    - heading "Digitalisaation ja yksityisyyden suojan asiantuntija" [level=2]
+    - paragraph:
+      - text: Laurilla on myös
+      - link "Wikipedia-artikkeli":
+        - /url: https://fi.wikipedia.org/wiki/Lauri_Lavanti
+      - text: .
+    - heading "Teknologiaosaaja, joka yhdistää kilpailukyvyn ja yksityisyyden suojan" [level=2]
     - paragraph: Toimin johtavana ohjelmistokehittäjänä ja vastaan tiimimme palveluiden teknisistä ratkaisuista. Työni keskiössä ovat vaativien kokonaisuuksien suunnittelu, kehittäminen ja ylläpito. Johdan teknisiä linjauksia ja käyn aktiivista vuoropuhelua sidosryhmien kanssa, jotta ratkaisut vastaavat todellisia tarpeita ja kestävät aikaa.
     - paragraph: Digitalisaatio ei ole minulle vain tekninen kysymys, vaan myös yhteiskunnallinen ja eettinen. Huolehdin siitä, että ratkaisut eivät ole vain toimivia tänään, vaan myös turvallisia ja ylläpidettäviä huomenna. Teknologian tulee olla turvallista, toimivaa ja ihmistä palvelevaa.
     - paragraph: Suomi on ollut korkean teknologian mallimaa vuosikymmeniä. Tekoäly muuttaa työtä, palveluita ja luottamusta digitaalisiin järjestelmiin. Tarvitsemme päätöksentekoon ihmisiä, jotka ymmärtävät teknologiaa käytännössä — eivät vain kommentoi sitä sivusta.
@@ -25,7 +30,7 @@
     - heading "Miksi politiikka?" [level=2]
     - paragraph: Toimin Kirkkonummen kunnanvaltuutettuna ja Vihreän valtuustoryhmän puheenjohtajana.
     - paragraph:
-      - text: Politiikassa keskityn erityisesti digitalisaatioon, yksityisyyden suojaan ja tekoälyn hallittuun käyttöönottoon. Yhteiskunta digitalisoituu jatkuvasti, mutta julkishallinto ja päätöksenteko eivät aina pysy kehityksen tahdissa.
+      - text: Politiikassa keskityn erityisesti tekoälyyn, talouteen ja digitalisaatioon — ja siihen, miten Suomi pysyy kilpailukykyisenä samalla kun varmistamme yksityisyyden suojan ja digitaalisen itsenäisyyden. Yhteiskunta digitalisoituu jatkuvasti, mutta julkishallinto ja päätöksenteko eivät aina pysy kehityksen tahdissa.
       - strong: Sama haaste koskee koko Suomea.
     - paragraph: Tarvitsemme parempaa ymmärrystä teknologian mahdollisuuksista ja riskeistä sekä rohkeutta panostaa koulutukseen ja korkean tuottavuuden teknologiseen kehitykseen. On tärkeää, ettei Suomi jää jälkeen osaamisessa tai kilpailukyvyssä.
     - heading "Kotona ja vapaalla" [level=2]

--- a/tests/e2e/aboutSwePage.spec.ts-snapshots/About-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/aboutSwePage.spec.ts-snapshots/About-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
@@ -13,9 +13,14 @@
         - listitem: » Fokuserar på digitalisering, integritetsskydd och ansvarsfull implementering av AI.
       - button "Mer"
     - paragraph: Lauri arbetar där teknologin förändrar samhället – och där beslutsfattandet borde hänga med.
-    - paragraph: Lauri Lavanti är ledande mjukvaruutvecklare, kommunfullmäktigeledamot i Kyrkslätt samt ordförande för De Grönas fullmäktigegrupp. Han är utexaminerad diplomingenjör från Aalto-universitetet och fokuserar på AI, ekonomisk politik, företagande, innovationspolitik samt digital självständighet.
+    - paragraph: Lauri Lavanti är ledande utvecklare, kommunfullmäktigeledamot i Kyrkslätt samt ordförande för De Grönas fullmäktigegrupp. Han är utexaminerad diplomingenjör från Aalto-universitetet och fokuserar på AI, ekonomisk politik, företagande samt digital självständighet.
     - paragraph: "Digitalisering, integritetsskydd och ansvarsfull implementering av artificiell intelligens är delar av samma helhet: hur vi bygger teknologisk utveckling som är både konkurrenskraftig och hållbar för naturen och människorna."
-    - heading "Expert på digitalisering och integritetsskydd" [level=2]
+    - paragraph:
+      - text: Lauri har också en
+      - link "Wikipedia-artikel":
+        - /url: https://fi.wikipedia.org/wiki/Lauri_Lavanti
+      - text: (på finska).
+    - heading "En teknologiexpert som förenar konkurrenskraft och integritetsskydd" [level=2]
     - paragraph: Jag arbetar som ledande mjukvaruutvecklare och ansvarar för de tekniska lösningarna i vårt teams tjänster. I mitt arbete står planering, utveckling och underhåll av krävande helheter i centrum. Jag leder tekniska riktlinjer och för en aktiv dialog med intressenter för att säkerställa att lösningarna motsvarar verkliga behov och håller över tid.
     - paragraph: Digitalisering är inte bara en teknisk fråga för mig, utan också en samhällelig och etisk. Jag ser till att lösningarna inte bara fungerar idag, utan också är säkra och underhållbara imorgon. Teknologin ska vara säker, funktionell och tjäna människan.
     - paragraph: Finland har varit ett föregångsland inom högteknologi i decennier. AI förändrar arbete, tjänster och förtroendet för digitala system. Vi behöver människor i beslutsfattandet som förstår teknologi i praktiken — inte bara kommenterar den från sidan.
@@ -25,7 +30,7 @@
     - heading "Varför politik?" [level=2]
     - paragraph: Jag är kommunfullmäktigeledamot i Kyrkslätt och ordförande för Gröna fullmäktigegruppen.
     - paragraph:
-      - text: I politiken fokuserar jag särskilt på digitalisering, integritetsskydd och kontrollerad implementering av artificiell intelligens. Samhället digitaliseras kontinuerligt, men den offentliga förvaltningen och beslutsfattandet hänger inte alltid med i utvecklingen.
+      - text: I politiken fokuserar jag särskilt på AI, ekonomisk politik och digitalisering — och på hur Finland kan förbli konkurrenskraftigt samtidigt som vi säkerställer integritetsskydd och digital självständighet. Samhället digitaliseras kontinuerligt, men den offentliga förvaltningen och beslutsfattandet hänger inte alltid med i utvecklingen.
       - strong: Samma utmaning gäller hela Finland.
     - paragraph: Vi behöver bättre förståelse för teknologins möjligheter och risker samt mod att satsa på utbildning och högproduktiv teknologisk utveckling. Det är viktigt att Finland inte halkar efter i kompetens eller konkurrenskraft.
     - heading "Hemma och på fritiden" [level=2]


### PR DESCRIPTION
> This PR contains AI-generated code. The author has reviewed and is responsible for all AI-generated content.

Aligns About page description, H2, and "Why politics?" opening across FI/EN/SV to lead with professional expertise + AI-as-economic-competitiveness (Segment C primary audience). Privacy repositioned as explicit differentiator after the competitiveness anchor — not the lead.

Changes across all three language variants:
- `description` — name-first, AI anchor, 120–160 chars
- H2 — competitiveness + privacy instead of privacy-only
- Body intro — drop "innovaatiopolitiikka" (FI) / "innovation" (EN/SV)
- "Why politics?" opening — AI/economy first, privacy as governance argument
- `updatedDate` → 2026-06-02

Closes #1272