### PR TITLE
fix(schema): align structured data description and topic list with canonical site copy

### DIFF
--- a/src/components/Head.spec.ts
+++ b/src/components/Head.spec.ts
@@ -377,7 +377,7 @@ describe('<Head />', () => {
         expect(jsonLd.memberOf['@type']).toBe('PoliticalParty')
         expect(jsonLd.memberOf.name).toBe('Vihreä liitto')
         expect(jsonLd.memberOf.url).toBe('https://www.vihreat.fi')
-        expect(jsonLd.knowsAbout).toHaveLength(9)
+        expect(jsonLd.knowsAbout).toHaveLength(14)
         expect(jsonLd.knowsAbout).toContain('Talouspolitiikka')
         expect(jsonLd.worksFor).toEqual({ '@type': 'Organization', name: 'OP', url: 'https://www.op.fi/' })
         expect(jsonLd.alumniOf).toHaveLength(3)
@@ -398,7 +398,7 @@ describe('<Head />', () => {
 
         const jsonLdScript = result.querySelector('script[type="application/ld+json"]')
         const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
-        expect(jsonLd.jobTitle).toBe('Municipal councillor & Lead Developer')
+        expect(jsonLd.jobTitle).toBe('Municipal councillor & lead developer')
         expect(jsonLd.knowsAbout).toContain('Economic policy')
         expect(jsonLd.knowsAbout).not.toContain('Talouspolitiikka')
     })
@@ -414,7 +414,7 @@ describe('<Head />', () => {
 
         const jsonLdScript = result.querySelector('script[type="application/ld+json"]')
         const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
-        expect(jsonLd.jobTitle).toBe('Kommunfullmäktigeledamot och ledande mjukvarutvecklare')
+        expect(jsonLd.jobTitle).toBe('Kommunfullmäktigeledamot och ledande mjukvaruutvecklare')
         expect(jsonLd.knowsAbout).toContain('Ekonomisk politik')
         expect(jsonLd.knowsAbout).not.toContain('Talouspolitiikka')
     })

--- a/src/content/person.ts
+++ b/src/content/person.ts
@@ -29,50 +29,65 @@ export const personSameAs = [
 ]
 
 export const personJobTitle: Record<Lang, string> = {
-    en: 'Municipal councillor & Lead Developer',
+    en: 'Municipal councillor & lead developer',
     fi: 'Kunnanvaltuutettu ja johtava ohjelmistokehittäjä',
-    sv: 'Kommunfullmäktigeledamot och ledande mjukvarutvecklare',
+    sv: 'Kommunfullmäktigeledamot och ledande mjukvaruutvecklare',
 }
 
 export const personDescription: Record<Lang, string> = {
-    en: 'Municipal councillor in Kirkkonummi (Greens) and lead software developer. Focused on economics, entrepreneurship, digital independence, and responsible AI policy.',
-    fi: 'Kirkkonummen kunnanvaltuutettu (Vihreät) ja johtava ohjelmistokehittäjä. Keskittyy talouteen, yrittäjyyteen, digitaaliseen itsenäisyyteen ja vastuulliseen tekoälypolitiikkaan. Seuraa eduskuntavaaleja.',
-    sv: 'Kommunfullmäktigeledamot i Kyrkslätt (De Gröna) och ledande mjukvarutvecklare. Fokuserar på ekonomi, företagande, digital självständighet och ansvarsfull AI-politik. Följer riksdagsvalen.',
+    en: 'Kirkkonummi municipal councillor (Greens) and lead developer (MSc, Aalto). He works to build a digitally independent Finland where the economy, education, and rights work together in the age of AI.',
+    fi: 'Kirkkonummen kunnanvaltuutettu ja johtava ohjelmistokehittäjä (DI, Aalto). Hänen tavoitteenaan on digitaalisesti itsenäinen Suomi, jossa talous, sivistys ja vapaus toimivat yhdessä tekoälyn aikakaudella.',
+    sv: 'Fullmäktigeledamot i Kyrkslätt (De Gröna) och ledande mjukvaruutvecklare (DI, Aalto-universitetet). Hans mål är ett digitalt självständigt Finland där ekonomi, bildning och frihet fungerar tillsammans i AI-tidsåldern.',
 }
 
 export const personKnowsAbout: Record<Lang, string[]> = {
     en: [
         'Economic policy',
         'Entrepreneurship',
-        'Innovation policy',
         'Digital independence',
-        'Digital sovereignty',
         'Artificial intelligence',
         'Responsible AI',
-        'Green transition',
         'Parliamentary elections',
+        'Market economy',
+        'Education',
+        'Fundamental rights',
+        'Privacy',
+        'Finnish-language AI models',
+        'Public procurement portability',
+        'Foundation-owned companies',
+        'Public administration',
     ],
     fi: [
         'Talouspolitiikka',
         'Yrittäjyys',
-        'Innovaatiopolitiikka',
         'Digitaalinen itsenäisyys',
-        'Digitaalinen riippumattomuus',
         'Tekoäly',
         'Vastuullinen tekoäly',
-        'Vihreä siirtymä',
         'Eduskuntavaalit',
+        'Markkinatalous',
+        'Sivistys',
+        'Perusoikeudet',
+        'Yksityisyys',
+        'Suomenkieliset tekoälymallit',
+        'Julkishankintojen siirrettävyys',
+        'Säätiö-omisteiset yhtiöt',
+        'Julkishallinto',
     ],
     sv: [
         'Ekonomisk politik',
         'Företagande',
-        'Innovationspolitik',
         'Digital självständighet',
-        'Digitalt oberoende',
         'Artificiell intelligens',
         'Ansvarsfull AI',
-        'Grön omställning',
         'Riksdagsval',
+        'Marknadsekonomi',
+        'Bildning',
+        'Grundläggande rättigheter',
+        'Integritet',
+        'Finskspråkiga AI-modeller',
+        'Överförbarhet av offentliga upphandlingar',
+        'Stiftelseägda bolag',
+        'Offentlig förvaltning',
     ],
 }
 
@@ -140,7 +155,7 @@ export const personHasOccupation: Record<Lang, object[]> = {
         },
         {
             '@type': 'Occupation',
-            name: 'Ledande mjukvarutvecklare',
+            name: 'Ledande mjukvaruutvecklare',
             skills: 'Artificiell intelligens, programvaruarkitektur, digital självständighet, säker mjukvaruutveckling',
         },
     ],


### PR DESCRIPTION
> This PR containes AI-generated code. The author has reviewed and is responsible for all AI-generated content.

## Summary

- Update `personJobTitle` EN/SV casing and SV spelling (`mjukvarutvecklare` → `mjukvaruutvecklare`)
- Align `personDescription` all three locales with canonical bio (adds MSc/DI Aalto credential, mission framing)
- Replace deprecated `personKnowsAbout` topics (Innovation policy, Digital sovereignty, Green transition) with updated terms across EN/FI/SV
- Fix `personHasOccupation` SV occupation name spelling

Closes #1278

## Test plan
- [ ] `npm run test` — 944 tests pass
- [ ] `npm run check` — no errors
- [ ] `grep "mjukvarutvecklare" src/content/person.ts` → 0 hits
- [ ] `grep "riippumattomuus\|siirtymä" src/content/person.ts` → 0 hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)