### PR TITLE
fix(homepage): align meta descriptions with canonical bio

### DIFF
--- a/src/pages/en/index.mdx
+++ b/src/pages/en/index.mdx
@@ -3,7 +3,7 @@ layout: '../../layouts/FrontPageLayout.astro'
 lang: en
 pageTitle: 'Lauri Lavanti – technology, economy and society | The Greens'
 title: 'Lauri Lavanti'
-description: 'Master of Science in Technology and lead software developer, combining technology expertise, economic thinking, and social responsibility.'
+description: 'Kirkkonummi municipal councillor (Greens) and lead developer. Building a digitally independent Finland — economy, education, and rights in the AI age.'
 slug: 'en'
 updatedDate: '2026-05-15'
 type: 'Person'

--- a/src/pages/fi/index.mdx
+++ b/src/pages/fi/index.mdx
@@ -3,7 +3,7 @@ layout: '../../layouts/FrontPageLayout.astro'
 lang: fi
 pageTitle: 'Lauri Lavanti – teknologia, talous ja yhteiskunta | Vihreät'
 title: 'Lauri Lavanti'
-description: 'Diplomi-insinööri ja johtava ohjelmistokehittäjä, joka yhdistää teknologiaosaamisen, talousajattelun ja yhteiskunnallisen vastuun.'
+description: 'Kirkkonummen kunnanvaltuutettu ja johtava ohjelmistokehittäjä. Tavoitteena digitaalisesti itsenäinen Suomi — talous, sivistys ja vapaus tekoälyn aikana.'
 slug: 'fi'
 updatedDate: '2026-05-15'
 type: 'Person'

--- a/src/pages/sv/index.mdx
+++ b/src/pages/sv/index.mdx
@@ -3,7 +3,7 @@ layout: '../../layouts/FrontPageLayout.astro'
 lang: sv
 pageTitle: 'Lauri Lavanti – teknologi, ekonomi och samhälle | De Gröna'
 title: 'Lauri Lavanti'
-description: 'Diplomingenjör och ledande mjukvaruutvecklare som kombinerar teknologiexpertis, ekonomiskt tänkande och samhällsansvar — De Gröna i Kyrkslätt.'
+description: 'Fullmäktigeledamot i Kyrkslätt (De Gröna) och ledande mjukvaruutvecklare. Mål: digitalt självständigt Finland — ekonomi, bildning och frihet i AI-eran.'
 slug: 'sv'
 updatedDate: '2026-05-15'
 type: 'Person'


### PR DESCRIPTION
> This PR containes AI-generated code. The author has reviewed and is responsible for all AI-generated content.

## Summary

- Replace outdated credential-listing `description` frontmatter on all three homepage locales (fi, sv, en)
- New descriptions match the canonical bio framing used across the site
- Trimmed to fit the 120–160 char validator limit (proposed strings in issue were ~190–220 chars)

## Changes

| Locale | Old | New (chars) |
|--------|-----|-------------|
| fi | Diplomi-insinööri ja johtava ohjelmistokehittäjä… | Kirkkonummen kunnanvaltuutettu… (158) |
| sv | Diplomingenjör och ledande mjukvaruutvecklare… | Fullmäktigeledamot i Kyrkslätt… (159) |
| en | Master of Science in Technology… | Kirkkonummi municipal councillor… (152) |

Closes #1279

## Test plan

- [ ] `npm run build` passes
- [ ] `npm run check` passes
- [ ] Inspect built HTML for `/fi/`, `/sv/`, `/en/` — `<meta name="description">` matches new copy
- [ ] `npm run test:e2e` — no snapshot regressions