### PR TITLE
fix(contact): fix terminology and heading style across all locales

### DIFF
--- a/src/pages/en/contact/index.mdx
+++ b/src/pages/en/contact/index.mdx
@@ -25,9 +25,9 @@ import UL from '../../../components/UL.astro'
 
 export const components = { a: SmartLink, h2: H2, p: Paragraph, ul: UL, li: LI }
 
-Welcome to get in touch! I write and speak about digital sovereignty, artificial intelligence, and a sustainable future. I am interested in hearing your thoughts and ideas on these topics.
+Welcome to get in touch! I write and speak about digital independence, artificial intelligence, and economic policy. I am interested in hearing your thoughts and ideas on these topics.
 
-## Why get in touch?
+## Get in touch
 
 I believe that the best solutions emerge together. That's why I want to hear from you, whether you're an expert, journalist, collaboration partner, or just interested in a discussion. I'm happy to respond to all messages.
 
@@ -37,7 +37,7 @@ Send a message to one of my social media accounts or directly via email.
 
 Subscribe to <Link href="/en/newsletter/">my newsletter</Link> to receive my thoughts directly in your inbox.
 
-## Contact details
+## Where can you reach me?
 
 Phone: 040 761 7605
 

--- a/src/pages/fi/contact/index.mdx
+++ b/src/pages/fi/contact/index.mdx
@@ -25,9 +25,9 @@ import UL from '../../../components/UL.astro'
 
 export const components = { a: SmartLink, h2: H2, p: Paragraph, ul: UL, li: LI }
 
-Tervetuloa ottamaan yhteyttä! Kirjoitan ja puhun digitaalisesta itsenäisyydestä, tekoälystä ja kestävästä tulevaisuudesta. Olen kiinnostunut kuulemaan ajatuksiasi ja ideoitasi näistä teemoista.
+Tervetuloa ottamaan yhteyttä! Kirjoitan ja puhun digitaalisesta itsenäisyydestä, tekoälystä ja taloudesta. Olen kiinnostunut kuulemaan ajatuksiasi ja ideoitasi näistä teemoista.
 
-## Miksi ottaa yhteyttä?
+## Ollaan yhteydessä
 
 Uskon, että parhaat ratkaisut syntyvät yhdessä. Siksi haluan kuulla sinulta, olitpa sitten asiantuntija, toimittaja, yhteistyökumppani tai vain kiinnostunut keskustelusta. Vastaan mielelläni kaikkiin viesteihin.
 
@@ -38,7 +38,7 @@ Lähetä viesti jollekin sosiaalisen median tileistäni tai suoraan sähköposti
 
 Tilaa <Link href="/fi/newsletter/">uutiskirjeeni</Link> ja saat ajatukseni suoraan sähköpostiisi.
 
-## Yhteystiedot
+## Mistä minut saa kiinni?
 
 Puhelin: 040 761 7605
 

--- a/src/pages/sv/contact/index.mdx
+++ b/src/pages/sv/contact/index.mdx
@@ -25,9 +25,9 @@ import UL from '../../../components/UL.astro'
 
 export const components = { a: SmartLink, h2: H2, p: Paragraph, ul: UL, li: LI }
 
-Välkommen att kontakta mig! Jag skriver och talar om digital suveränitet, artificiell intelligens och en hållbar framtid. Jag är intresserad av att höra dina tankar och idéer om dessa ämnen.
+Välkommen att kontakta mig! Jag skriver och talar om digital självständighet, artificiell intelligens och ekonomi. Jag är intresserad av att höra dina tankar och idéer om dessa ämnen.
 
-## Varför kontakta mig?
+## Kontakta mig
 
 Jag tror att de bästa lösningarna uppstår tillsammans. Därför vill jag höra från dig, oavsett om du är expert, journalist, samarbetspartner eller bara intresserad av diskussion. Jag svarar gärna på alla meddelanden.
 
@@ -37,7 +37,7 @@ Skicka ett meddelande till någon av mina sociala mediekonton eller direkt via e
 
 Prenumerera på <Link href="/sv/newsletter/">mitt nyhetsbrev</Link> och få mina tankar direkt till din e-post.
 
-## Kontaktuppgifter
+## Var når du mig?
 
 Telefon: 040 761 7605
 

--- a/tests/e2e/contactEnPage.spec.ts-snapshots/Contact-Page-in-English-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/contactEnPage.spec.ts-snapshots/Contact-Page-in-English-should-match-aria-snapshot-1.aria.yml
@@ -2,8 +2,8 @@
   - heading "Contact Lauri Lavanti" [level=1]
   - img "Lauri Lavanti leaning on a column with a portrait in the background, looking at the camera, smiling. He is wearing a white shirt with blue flower patterns and a dark jacket. Photo was taken by Juha Jantunen."
   - article:
-    - paragraph: Welcome to get in touch! I write and speak about digital sovereignty, artificial intelligence, and a sustainable future. I am interested in hearing your thoughts and ideas on these topics.
-    - heading "Why get in touch?" [level=2]
+    - paragraph: Welcome to get in touch! I write and speak about digital independence, artificial intelligence, and economic policy. I am interested in hearing your thoughts and ideas on these topics.
+    - heading "Get in touch" [level=2]
     - paragraph: I believe that the best solutions emerge together. That’s why I want to hear from you, whether you’re an expert, journalist, collaboration partner, or just interested in a discussion. I’m happy to respond to all messages.
     - paragraph: Send a message to one of my social media accounts or directly via email.
     - heading "Newsletter" [level=2]
@@ -12,7 +12,7 @@
       - link "my newsletter":
         - /url: /en/newsletter/
       - text: to receive my thoughts directly in your inbox.
-    - heading "Contact details" [level=2]
+    - heading "Where can you reach me?" [level=2]
     - paragraph: "/Phone: \\d+ \\d+ \\d+/"
     - paragraph:
       - text: "Email:"

--- a/tests/e2e/contactPage.spec.ts-snapshots/Contact-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/contactPage.spec.ts-snapshots/Contact-Page-should-match-aria-snapshot-1.aria.yml
@@ -2,8 +2,8 @@
   - heading "Ota yhteyttä Lauri Lavantiin" [level=1]
   - img "Lauri Lavanti nojaa pylvääseen, taustalla muotokuva, katsoo kameraan, hymyillen. Hänellä on päällään valkoinen kauluspaita sinisillä kukkakuvioilla ja tumma pikkutakki. Kuvan otti Juha Jantunen."
   - article:
-    - paragraph: Tervetuloa ottamaan yhteyttä! Kirjoitan ja puhun digitaalisesta itsenäisyydestä, tekoälystä ja kestävästä tulevaisuudesta. Olen kiinnostunut kuulemaan ajatuksiasi ja ideoitasi näistä teemoista.
-    - heading "Miksi ottaa yhteyttä?" [level=2]
+    - paragraph: Tervetuloa ottamaan yhteyttä! Kirjoitan ja puhun digitaalisesta itsenäisyydestä, tekoälystä ja taloudesta. Olen kiinnostunut kuulemaan ajatuksiasi ja ideoitasi näistä teemoista.
+    - heading "Ollaan yhteydessä" [level=2]
     - paragraph: Uskon, että parhaat ratkaisut syntyvät yhdessä. Siksi haluan kuulla sinulta, olitpa sitten asiantuntija, toimittaja, yhteistyökumppani tai vain kiinnostunut keskustelusta. Vastaan mielelläni kaikkiin viesteihin.
     - paragraph: Lähetä viesti jollekin sosiaalisen median tileistäni tai suoraan sähköpostiini.
     - heading "Uutiskirje" [level=2]
@@ -12,7 +12,7 @@
       - link "uutiskirjeeni":
         - /url: /fi/newsletter/
       - text: ja saat ajatukseni suoraan sähköpostiisi.
-    - heading "Yhteystiedot" [level=2]
+    - heading "Mistä minut saa kiinni?" [level=2]
     - paragraph: "/Puhelin: \\d+ \\d+ \\d+/"
     - paragraph:
       - text: "Sähköposti:"

--- a/tests/e2e/contactSwePage.spec.ts-snapshots/Contact-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/contactSwePage.spec.ts-snapshots/Contact-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
@@ -2,8 +2,8 @@
   - heading "Ta kontakt med Lauri Lavanti" [level=1]
   - img "Lauri Lavanti lutar sig mot en pelare med ett porträtt i bakgrunden, blicken mot kameran, leende. Han har på sig en vit skjorta med blå blomstermönster och en mörk kavaj. Bilden togs av Juha Jantunen."
   - article:
-    - paragraph: Välkommen att kontakta mig! Jag skriver och talar om digital suveränitet, artificiell intelligens och en hållbar framtid. Jag är intresserad av att höra dina tankar och idéer om dessa ämnen.
-    - heading "Varför kontakta mig?" [level=2]
+    - paragraph: Välkommen att kontakta mig! Jag skriver och talar om digital självständighet, artificiell intelligens och ekonomi. Jag är intresserad av att höra dina tankar och idéer om dessa ämnen.
+    - heading "Kontakta mig" [level=2]
     - paragraph: Jag tror att de bästa lösningarna uppstår tillsammans. Därför vill jag höra från dig, oavsett om du är expert, journalist, samarbetspartner eller bara intresserad av diskussion. Jag svarar gärna på alla meddelanden.
     - paragraph: Skicka ett meddelande till någon av mina sociala mediekonton eller direkt via e-post.
     - heading "Nyhetsbrev" [level=2]
@@ -12,7 +12,7 @@
       - link "mitt nyhetsbrev":
         - /url: /sv/newsletter/
       - text: och få mina tankar direkt till din e-post.
-    - heading "Kontaktuppgifter" [level=2]
+    - heading "Var når du mig?" [level=2]
     - paragraph: "/Telefon: \\d+ \\d+ \\d+/"
     - paragraph:
       - text: "E-post:"


### PR DESCRIPTION
> This PR containes AI-generated code. The author has reviewed and is responsible for all AI-generated content.

## Summary

- Replace non-canonical terminology in body copy (fi/sv/en): "kestävästä tulevaisuudesta" → "taloudesta", "digital suveränitet" → "digital självständighet", "digital sovereignty" → "digital independence"
- Replace question-style H2s ("Why get in touch?") with statement headings
- Add question-format H2 for "contact details" section in all locales to satisfy AEO check

Closes #1282