### PR TITLE
feat(homepage): add tekoäly + politiikka FAQ item for AEO

### DIFF
--- a/src/pages/en/index.mdx
+++ b/src/pages/en/index.mdx
@@ -5,7 +5,7 @@ pageTitle: 'Lauri Lavanti – technology, economy and society | The Greens'
 title: 'Lauri Lavanti'
 description: 'Kirkkonummi municipal councillor (Greens) and lead developer. Building a digitally independent Finland — economy, education, and rights in the AI age.'
 slug: 'en'
-updatedDate: '2026-05-15'
+updatedDate: '2026-06-03'
 type: 'Person'
 heroBanner: true
 secondaryTitle: 'AI expertise belongs in decision-making'
@@ -22,6 +22,8 @@ faq:
     a: "Digital independence means that public services, critical infrastructure, and citizens' data are not at the mercy of a handful of foreign corporations. Lauri Lavanti advocates for policies where Finland and the EU build their own technology base, rather than purchasing surveillance capacity from abroad."
   - q: 'How does technical expertise show up in political decision-making?'
     a: "Lauri Lavanti brings hands-on experience in software development and digital systems to decision-making — he can tell when a technical argument holds and when it's just a sales pitch. His goal is for the public sector to keep pace with technological development and not procure solutions it doesn't understand."
+  - q: 'Why does AI expertise belong in parliamentary decision-making?'
+    a: 'AI is changing work, the economy, and public services faster than legislation can keep up. Parliament needs decision-makers who understand AI from the inside — not just at a high level. Lauri Lavanti is a lead developer who brings hands-on technology expertise directly into political decision-making.'
 ---
 
 import FrontPageExcerptList from '../../components/FrontPageExcerptList.astro'

--- a/src/pages/fi/index.mdx
+++ b/src/pages/fi/index.mdx
@@ -5,7 +5,7 @@ pageTitle: 'Lauri Lavanti – teknologia, talous ja yhteiskunta | Vihreät'
 title: 'Lauri Lavanti'
 description: 'Kirkkonummen kunnanvaltuutettu ja johtava ohjelmistokehittäjä. Tavoitteena digitaalisesti itsenäinen Suomi — talous, sivistys ja vapaus tekoälyn aikana.'
 slug: 'fi'
-updatedDate: '2026-05-15'
+updatedDate: '2026-06-03'
 type: 'Person'
 heroBanner: true
 secondaryTitle: 'Tekoälyosaaminen kuuluu päätöksentekoon'
@@ -22,6 +22,8 @@ faq:
     a: 'Digitaalinen itsenäisyys tarkoittaa sitä, että julkiset palvelut, kriittinen infrastruktuuri ja kansalaisten data eivät ole yksittäisten ulkomaisten yritysten varassa. Lauri Lavanti ajaa politiikkaa, jossa Suomi ja EU rakentavat omaa teknologiaperustaansa sen sijaan, että ostaisimme valvontakapasiteettia ulkomailta.'
   - q: 'Miten tekninen asiantuntemus näkyy poliittisessa päätöksenteossa?'
     a: 'Lauri Lavanti tuo päätöksentekoon käytännön kokemuksen ohjelmistokehityksestä ja digitaalisista järjestelmistä — hän tunnistaa, milloin tekninen argumentti on pätevä ja milloin se on pelkkää myyntipuhetta. Tavoitteena on, että julkinen sektori pysyy teknologisen kehityksen tahdissa eikä osta ratkaisuja ymmärtämättä, mitä ostaa.'
+  - q: 'Miksi tekoälyosaaminen kuuluu eduskunnan päätöksentekoon?'
+    a: 'Tekoäly muuttaa työtä, taloutta ja julkisia palveluja nopeammin kuin lainsäädäntö pysyy perässä. Eduskunta tarvitsee päätöksentekijöitä, jotka ymmärtävät tekoälyn sisältäpäin — eivät pelkästään yleisellä tasolla. Lauri Lavanti on johtava ohjelmistokehittäjä, joka tuo käytännön teknologiaosaamisen suoraan poliittiseen päätöksentekoon.'
 ---
 
 import FrontPageExcerptList from '../../components/FrontPageExcerptList.astro'

--- a/src/pages/sv/index.mdx
+++ b/src/pages/sv/index.mdx
@@ -5,7 +5,7 @@ pageTitle: 'Lauri Lavanti – teknologi, ekonomi och samhälle | De Gröna'
 title: 'Lauri Lavanti'
 description: 'Fullmäktigeledamot i Kyrkslätt (De Gröna) och ledande mjukvaruutvecklare. Mål: digitalt självständigt Finland — ekonomi, bildning och frihet i AI-eran.'
 slug: 'sv'
-updatedDate: '2026-05-15'
+updatedDate: '2026-06-03'
 type: 'Person'
 heroBanner: true
 secondaryTitle: 'AI-kompetens hör hemma i beslutsfattandet'
@@ -22,6 +22,8 @@ faq:
     a: 'Digital självständighet innebär att offentliga tjänster, kritisk infrastruktur och medborgarnas data inte är i händerna på ett fåtal utländska företag. Lauri Lavanti förespråkar en politik där Finland och EU bygger upp sin egen teknologibas i stället för att köpa övervakningskapacitet från utlandet.'
   - q: 'Hur syns teknisk expertis i politiskt beslutsfattande?'
     a: 'Lauri Lavanti tar med sig praktisk erfarenhet av mjukvaruutveckling och digitala system till beslutsfattandet — han kan avgöra när ett tekniskt argument håller och när det bara är ett säljsnack. Målet är att den offentliga sektorn håller jämna steg med den teknologiska utvecklingen och inte köper lösningar den inte förstår.'
+  - q: 'Varför hör AI-kompetens hemma i det parlamentariska beslutsfattandet?'
+    a: 'AI förändrar arbete, ekonomi och offentliga tjänster snabbare än lagstiftningen hinner med. Riksdagen behöver beslutsfattare som förstår AI inifrån — inte bara på en övergripande nivå. Lauri Lavanti är en ledande mjukvaruutvecklare som för praktisk teknikkompetens direkt in i det politiska beslutsfattandet.'
 ---
 
 import FrontPageExcerptList from '../../components/FrontPageExcerptList.astro'


### PR DESCRIPTION
> This PR containes AI-generated code. The author has reviewed and is responsible for all AI-generated content.

## Summary

- Adds a 5th FAQ item targeting the query "Eduskuntavaaliehdokkaat 2027 Uusimaa tekoäly digitalisaatio" to the FI, EN, and SV homepages
- Updates `updatedDate` to `2026-06-03` in all three homepage files
- Issue #1283 (topics page typo) was already corrected in the codebase; closed separately with a comment

Closes #1292

## Test plan

- [ ] `npm run build` passes
- [ ] FAQPage JSON-LD in `dist/fi/index.html` includes the new Q&A
- [ ] `npm run test` passes
- [ ] `npm run test:e2e` passes (update snapshots if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)