### PR TITLE
fix(about): reframe about page for Segment C and human voice (FI/EN/SV)

### DIFF
--- a/src/pages/en/about/index.mdx
+++ b/src/pages/en/about/index.mdx
@@ -44,14 +44,14 @@ export const components = { a: SmartLink, h2: H2, p: Paragraph }
         'Municipal councillor in Kirkkonummi, chair of the Green council group.',
         'Master of Science (Tech.), Information Networks, Aalto University.',
         'Four children — three daughters and a son.',
-        'Focuses on digital independence, privacy, and the responsible adoption of AI.',
+        'Advocates for digital independence, privacy, and the sensible use of AI.',
     ]}
     title="Lauri in TL;DR -format"
 />
 
-A lead developer who understands what code means for society — not just what it does as a technical solution. Lauri works where technology is changing society, and where decision-making should keep pace.
+Lauri Lavanti builds software at a bank and makes decisions on the municipal council. His view of technology is grounded in practical experience and expertise — not hype or theory.
 
-Lauri Lavanti is a lead developer, municipal councillor in Kirkkonummi, and chair of the Greens council group. He graduated as a Master of Science (Tech.) from Aalto University and focuses on AI, economic policy, entrepreneurship, and digital independence. Digital independence, privacy, and the responsible adoption of AI are all part of the same whole: how we build technological development that is both competitive and sustainable for nature and people.
+He is a lead developer, municipal councillor in Kirkkonummi, and chair of the Greens council group. He graduated as a Master of Science (Tech.) from Aalto University and focuses on AI, economic policy, entrepreneurship, and digital independence. Digital independence, privacy, and the responsible adoption of AI are all part of the same whole: how we build technological development that is both competitive and sustainable.
 
 Lauri also has a [Wikipedia article](https://fi.wikipedia.org/wiki/Lauri_Lavanti) (in Finnish).
 
@@ -65,9 +65,9 @@ Finland has been a model country for high technology for decades. AI is reshapin
 
 ## Why did I get into politics?
 
-I serve as a municipal councilor in Kirkkonummi and as chair of the Green council group.
+In politics, I focus particularly on AI, economic policy, and digitalisation — and on how Finland can remain competitive while safeguarding privacy and digital independence. Society is rapidly becoming digitalized, but public administration and decision-making do not always keep pace with developments. The same challenge applies across Finland.
 
-In politics, I focus particularly on AI, economic policy, and digitalisation — and on how Finland can remain competitive while safeguarding privacy and digital independence. Society is rapidly becoming digitalized, but public administration and decision-making do not always keep pace with developments. **The same challenge applies across Finland.**
+I serve as a municipal councillor in Kirkkonummi and as chair of the Green council group.
 
 We need a better understanding of the opportunities and risks presented by technology, as well as the courage to invest in education and high-productivity technological development. It is important that Finland does not fall behind in terms of expertise or competitiveness.
 
@@ -75,13 +75,13 @@ We need a better understanding of the opportunities and risks presented by techn
 
 I am the initiator and primary contact of the Digital Independence citizen initiative. The initiative calls for legislation ensuring that critical public digital services and data remain in the hands of Finnish and European actors, on servers located in the EU/EEA area.
 
-Digital independence strengthens democracy, protects citizens' rights, and supports European technological development. It is not an ideology but a practical prerequisite for a functioning society.
+Digital independence supports European technological development, reduces dependence on individual vendors, and creates better conditions for domestic software development. It is not an ideology but a practical prerequisite for a functioning society — and it also strengthens democracy and citizens' rights.
 
 ## Multidisciplinarity and a broad perspective
 
 By training, I am a Master of Science (Tech.) from the study programme of information networks. The program is based on information technology, but it also covers other subjects such as aesthetics and philosophy. The program taught me to view systems as both technical and humane entities.
 
-My multidisciplinary background has given me the ability to act smoothly as a bridge builder, fostering mutual understanding between different professional groups. I also always examine technology from the perspective of its significance, impact, and responsibility.
+My multidisciplinary background has given me the ability to act smoothly as a bridge builder, fostering mutual understanding between different professional groups. I also always examine technology from the perspective of its significance, impact, and responsibility. In practice, that means I can speak with both technical experts and business units — and make sure they understand each other.
 
 ## At home and off duty
 

--- a/src/pages/fi/about/index.mdx
+++ b/src/pages/fi/about/index.mdx
@@ -19,9 +19,9 @@ faq:
   - q: 'Mihin Lauri Lavanti erikoistuu politiikassa?'
     a: 'Lauri Lavanti erikoistuu digitalisaatioon, yksityisyyden suojaan ja tekoälyn hallittuun käyttöönottoon. Hän tarkastelee teknologiaa sekä teknisinä kokonaisuuksina että niiden yhteiskunnallisten vaikutusten kautta.'
   - q: 'Miksi teknologiaosaamisella on merkitystä politiikassa?'
-    a: 'Teknologia muuttaa yhteiskuntaa nopeammin kuin päätöksenteko pysyy mukana. Lauri Lavanti tuo valtuustoon käytännön ohjelmistokehityskokemuksen, joka auttaa erottamaan aidon teknologisen tarpeen myyntipuheesta — ja varmistamaan, ettei julkinen sektori osta ratkaisuja ymmärtämättä, mitä ostaa.'
+    a: 'Teknologia muuttaa yhteiskuntaa nopeammin kuin päätöksenteko pysyy mukana. Lauri Lavanti tuo valtuustoon käytännön ohjelmistokehityskokemuksen, joka auttaa erottamaan aidon teknologisen tarpeen myyntipuheesta – ja varmistamaan, ettei julkinen sektori osta ratkaisuja ymmärtämättä, mitä ostaa.'
   - q: 'Miksi Suomi tarvitsee teknologiaosaamista päätöksenteossa?'
-    a: 'Suomi on ollut korkean teknologian mallimaa vuosikymmeniä. Tekoäly muuttaa työtä, palveluita ja luottamusta digitaalisiin järjestelmiin. Tarvitsemme päätöksentekoon ihmisiä, jotka ymmärtävät teknologiaa käytännössä — eivät vain kommentoi sitä sivusta.'
+    a: 'Suomi on ollut korkean teknologian mallimaa vuosikymmeniä. Tekoäly muuttaa työtä, palveluita ja luottamusta digitaalisiin järjestelmiin. Tarvitsemme päätöksentekoon ihmisiä, jotka ymmärtävät teknologiaa käytännössä – eivät vain kommentoi sitä sivusta.'
   - q: 'Mitä Lauri Lavanti ajattelee Suomen taloudesta?'
     a: 'Lauri Lavanti katsoo, että Suomen talouskasvu nojaa korkean tuottavuuden osaamiseen: teknologiaan, koulutukseen ja kasvuhaluiseen yrittäjyyteen. Hän vastustaa byrokratiaa, joka jarruttaa pk-yrityksiä, ja ajaa digitaalisia toimintaedellytyksiä, jotka pitävät Suomen kilpailukykyisenä kansainvälisillä markkinoilla.'
 ---
@@ -44,15 +44,15 @@ export const components = { a: SmartLink, h2: H2, p: Paragraph }
         'Yli vuosikymmenen kokemus turvallisten ohjelmistojen kehittämisestä, johtava ohjelmistokehittäjä pankissa.',
         'Kunnanvaltuutettu Kirkkonummella, Vihreän valtuustoryhmän puheenjohtaja.',
         'Informaatioverkostojen diplomi-insinööri Aalto-yliopistosta.',
-        'Neljä lasta — kolme tytärtä ja yksi poika.',
-        'Keskittyy digitaaliseen itsenäisyyteen, yksityisyyden suojaan ja tekoälyn vastuulliseen käyttöönottoon.',
+        'Neljä lasta – kolme tytärtä ja yksi poika.',
+        'Ajaa digitaalista itsenäisyyttä, yksityisyyden suojaa ja tekoälyn järkevää käyttöä.',
     ]}
     title="Lauri lyhyesti"
 />
 
-Johtava ohjelmistokehittäjä, joka ymmärtää mitä koodi tarkoittaa yhteiskunnalle – ei vain mitä se tekee teknisenä ratkaisuna. Lauri työskentelee siellä, missä teknologia muuttaa yhteiskuntaa, ja missä päätöksenteon pitäisi pysyä mukana.
+Lauri Lavanti rakentaa ohjelmistoja pankissa ja tekee päätöksiä kunnanvaltuustossa. Hänen näkemyksensä teknologiasta ei pohjaa hypeen tai teoriaan, vaan käytännön kokemukseen ja osaamiseen.
 
-Lauri Lavanti on johtava ohjelmistokehittäjä, Kirkkonummen kunnanvaltuutettu sekä Vihreän valtuustoryhmän puheenjohtaja. Hän on Aalto-yliopistosta valmistunut diplomi-insinööri ja keskittyy tekoälyyn, talouteen, yrittäjyyteen sekä digitaaliseen itsenäisyyteen. Digitaalinen itsenäisyys, yksityisyyden suoja ja tekoälyn vastuullinen käyttöönotto ovat osa samaa kokonaisuutta: miten rakennamme teknologista kehitystä, joka on sekä kilpailukykyistä että kestävää niin luonnolle kuin ihmisille.
+Hän on johtava ohjelmistokehittäjä, Kirkkonummen kunnanvaltuutettu sekä Vihreän valtuustoryhmän puheenjohtaja. Hän on Aalto-yliopistosta valmistunut diplomi-insinööri ja keskittyy tekoälyyn, talouteen, yrittäjyyteen sekä digitaaliseen itsenäisyyteen. Digitaalinen itsenäisyys, yksityisyyden suoja ja tekoälyn vastuullinen käyttöönotto ovat osa samaa kokonaisuutta: miten rakennamme teknologista kehitystä, joka on sekä kilpailukykyistä että kestävää.
 
 Laurista on myös [Wikipedia-artikkeli](https://fi.wikipedia.org/wiki/Lauri_Lavanti).
 
@@ -62,13 +62,13 @@ Toimin johtavana ohjelmistokehittäjänä ja vastaan tiimimme palveluiden teknis
 
 Digitalisaatio ei ole minulle vain tekninen kysymys, vaan myös yhteiskunnallinen ja eettinen. Huolehdin siitä, että ratkaisut eivät ole vain toimivia tänään, vaan myös turvallisia ja ylläpidettäviä huomenna. Teknologian tulee olla turvallista, toimivaa ja ihmistä palvelevaa.
 
-Suomi on ollut korkean teknologian mallimaa vuosikymmeniä. Tekoäly muuttaa työtä, palveluita ja luottamusta digitaalisiin järjestelmiin. Tarvitsemme päätöksentekoon ihmisiä, jotka ymmärtävät teknologiaa käytännössä — eivät vain kommentoi sitä sivusta.
+Suomi on ollut korkean teknologian mallimaa vuosikymmeniä. Tekoäly muuttaa työtä, palveluita ja luottamusta digitaalisiin järjestelmiin. Tarvitsemme päätöksentekoon ihmisiä, jotka ymmärtävät teknologiaa käytännössä – eivät vain kommentoi sitä sivusta.
 
 ## Miksi olen mukana politiikassa?
 
-Toimin Kirkkonummen kunnanvaltuutettuna ja Vihreän valtuustoryhmän puheenjohtajana.
+Politiikassa keskityn erityisesti tekoälyyn, talouteen ja digitalisaatioon – ja siihen, miten Suomi pysyy kilpailukykyisenä samalla kun varmistamme yksityisyyden suojan ja digitaalisen itsenäisyyden. Yhteiskunta digitalisoituu jatkuvasti, mutta julkishallinto ja päätöksenteko eivät aina pysy kehityksen tahdissa. Sama haaste koskee koko Suomea.
 
-Politiikassa keskityn erityisesti tekoälyyn, talouteen ja digitalisaatioon — ja siihen, miten Suomi pysyy kilpailukykyisenä samalla kun varmistamme yksityisyyden suojan ja digitaalisen itsenäisyyden. Yhteiskunta digitalisoituu jatkuvasti, mutta julkishallinto ja päätöksenteko eivät aina pysy kehityksen tahdissa. **Sama haaste koskee koko Suomea.**
+Toimin Kirkkonummen kunnanvaltuutettuna ja Vihreän valtuustoryhmän puheenjohtajana.
 
 Tarvitsemme parempaa ymmärrystä teknologian mahdollisuuksista ja riskeistä sekä rohkeutta panostaa koulutukseen ja korkean tuottavuuden teknologiseen kehitykseen. On tärkeää, ettei Suomi jää jälkeen osaamisessa tai kilpailukyvyssä.
 
@@ -76,13 +76,13 @@ Tarvitsemme parempaa ymmärrystä teknologian mahdollisuuksista ja riskeistä se
 
 Olen Digitaalinen itsenäisyys -kansalaisaloitteen alullepanija ja pääyhteyshenkilö. Aloite vaatii, että julkishallinnon kriittiset digitaaliset palvelut ja tiedot pysyvät suomalaisten ja eurooppalaisten toimijoiden käsissä – EU/ETA-alueen palvelimilla.
 
-Digitaalinen itsenäisyys vahvistaa demokratiaa, suojaa kansalaisten oikeuksia ja tukee eurooppalaista teknologista kehitystä. Se ei ole ideologia vaan käytännön edellytys toimivalle yhteiskunnalle.
+Digitaalinen itsenäisyys tukee eurooppalaista teknologista kehitystä, vähentää riippuvuutta yksittäisistä toimittajista ja luo paremmat edellytykset kotimaiselle ohjelmistokehitykselle. Se ei ole ideologia vaan käytännön edellytys toimivalle yhteiskunnalle – ja se vahvistaa myös demokratiaa ja kansalaisten oikeuksia.
 
 ## Monialaisuus ja laaja-alainen näkemys
 
 Olen koulutukseltani informaatioverkostojen diplomi-insinööri. Koulutusohjelma rakentuu tietotekniikan pohjalle, mutta laajentuu tekniikasta muun muassa estetiikkaan ja filosofiaan. Koulutus opetti katsomaan järjestelmiä sekä teknisinä että inhimillisinä kokonaisuuksina.
 
-Monialaisuus on antanut minulle valmiudet toimia sujuvasti sillanrakentajana rakentamassa yhteistä ymmärrystä eri ammattiryhmien kanssa. Tarkastelen teknologiaa myös aina merkitysten, vaikutusten ja vastuullisuuden näkökulmasta.
+Monialaisuus on antanut minulle valmiudet toimia sujuvasti sillanrakentajana rakentamassa yhteistä ymmärrystä eri ammattiryhmien kanssa. Tarkastelen teknologiaa myös aina merkitysten, vaikutusten ja vastuullisuuden näkökulmasta. Käytännössä se tarkoittaa, että pystyn puhumaan sekä teknisten asiantuntijoiden että liiketoimintojen kanssa – ja varmistamaan, että ne ymmärtävät toisiaan.
 
 ## Kotona ja vapaalla
 

--- a/src/pages/sv/about/index.mdx
+++ b/src/pages/sv/about/index.mdx
@@ -19,9 +19,9 @@ faq:
   - q: 'Vad specialiserar sig Lauri Lavanti på politiskt?'
     a: 'Lauri Lavanti specialiserar sig på digitalisering, integritetsskydd och kontrollerad implementering av artificiell intelligens. Han granskar teknologi både som tekniska system och ur perspektivet av deras samhälleliga konsekvenser.'
   - q: 'Varför är teknisk expertis viktig i politiken?'
-    a: 'Teknologin förändrar samhället snabbare än beslutsfattandet hinner med. Lauri Lavanti tar med sig praktisk erfarenhet av mjukvaruutveckling in i fullmäktige, vilket hjälper till att skilja ett genuint teknologibehov från ett säljsnack — och säkerställa att den offentliga sektorn inte köper lösningar utan att förstå vad den köper.'
+    a: 'Teknologin förändrar samhället snabbare än beslutsfattandet hinner med. Lauri Lavanti tar med sig praktisk erfarenhet av mjukvaruutveckling in i fullmäktige, vilket hjälper till att skilja ett genuint teknologibehov från ett säljsnack – och säkerställa att den offentliga sektorn inte köper lösningar utan att förstå vad den köper.'
   - q: 'Varför behöver Finland teknologisk kompetens i beslutsfattandet?'
-    a: 'Finland har varit ett föregångsland inom högteknologi i decennier. AI förändrar arbete, tjänster och förtroendet för digitala system. Vi behöver människor i beslutsfattandet som förstår teknologi i praktiken — inte bara kommenterar den från sidan.'
+    a: 'Finland har varit ett föregångsland inom högteknologi i decennier. AI förändrar arbete, tjänster och förtroendet för digitala system. Vi behöver människor i beslutsfattandet som förstår teknologi i praktiken – inte bara kommenterar den från sidan.'
   - q: 'Vad anser Lauri Lavanti om Finlands ekonomi?'
     a: 'Lauri Lavanti anser att Finlands ekonomiska tillväxt bygger på högproduktiv kompetens: teknologi, utbildning och tillväxtorienterat företagande. Han motarbetar byråkrati som bromsar SMF-företag och driver för tydliga digitala verksamhetsförutsättningar som håller Finland konkurrenskraftigt på internationella marknader.'
 ---
@@ -43,15 +43,15 @@ export const components = { a: SmartLink, h2: H2, p: Paragraph }
         'Över ett decennium av erfarenhet av att bygga säker mjukvara, ledande mjukvaruutvecklare på en bank.',
         'Kommunfullmäktigeledamot i Kyrkslätt, ordförande för Gröna fullmäktigegruppen.',
         'Diplomingenjör i informationsnätverk, Aalto-universitetet.',
-        'Fyra barn — tre döttrar och en son.',
-        'Fokuserar på digital självständighet, integritetsskydd och ansvarsfull implementering av AI.',
+        'Fyra barn – tre döttrar och en son.',
+        'Driver för digital självständighet, integritetsskydd och ett förnuftigt användande av AI.',
     ]}
     title="Lauri i korthet"
 />
 
-En ledande mjukvaruutvecklare som förstår vad kod betyder för samhället – inte bara vad den gör som teknisk lösning. Lauri arbetar där teknologin förändrar samhället, och där beslutsfattandet borde hänga med.
+Lauri Lavanti bygger mjukvara på en bank och fattar beslut i kommunfullmäktige. Hans syn på teknologi är grundad i praktisk erfarenhet och kompetens – inte i hype eller teori.
 
-Lauri Lavanti är ledande mjukvaruutvecklare, kommunfullmäktigeledamot i Kyrkslätt samt ordförande för De Grönas fullmäktigegrupp. Han är utexaminerad diplomingenjör från Aalto-universitetet och fokuserar på AI, ekonomisk politik, företagande samt digital självständighet. Digital självständighet, integritetsskydd och ansvarsfull implementering av AI är delar av samma helhet: hur vi bygger teknologisk utveckling som är både konkurrenskraftig och hållbar för naturen och människorna.
+Han är ledande mjukvaruutvecklare, kommunfullmäktigeledamot i Kyrkslätt samt ordförande för De Grönas fullmäktigegrupp. Han är utexaminerad diplomingenjör från Aalto-universitetet och fokuserar på AI, ekonomisk politik, företagande samt digital självständighet. Digital självständighet, integritetsskydd och ansvarsfull implementering av AI är delar av samma helhet: hur vi bygger teknologisk utveckling som är både konkurrenskraftig och hållbar.
 
 Lauri har också en [Wikipedia-artikel](https://fi.wikipedia.org/wiki/Lauri_Lavanti) (på finska).
 
@@ -61,27 +61,27 @@ Jag arbetar som ledande mjukvaruutvecklare och ansvarar för de tekniska lösnin
 
 Digitalisering är inte bara en teknisk fråga för mig, utan också en samhällelig och etisk. Jag ser till att lösningarna inte bara fungerar idag, utan också är säkra och underhållbara imorgon. Teknologin ska vara säker, funktionell och tjäna människan.
 
-Finland har varit ett föregångsland inom högteknologi i decennier. AI förändrar arbete, tjänster och förtroendet för digitala system. Vi behöver människor i beslutsfattandet som förstår teknologi i praktiken — inte bara kommenterar den från sidan.
+Finland har varit ett föregångsland inom högteknologi i decennier. AI förändrar arbete, tjänster och förtroendet för digitala system. Vi behöver människor i beslutsfattandet som förstår teknologi i praktiken – inte bara kommenterar den från sidan.
 
 ## Varför gick jag in i politiken?
 
-Jag är kommunfullmäktigeledamot i Kyrkslätt och ordförande för Gröna fullmäktigegruppen.
+I politiken fokuserar jag särskilt på AI, ekonomisk politik och digitalisering – och på hur Finland kan förbli konkurrenskraftigt samtidigt som vi säkerställer integritetsskydd och digital självständighet. Samhället digitaliseras kontinuerligt, men den offentliga förvaltningen och beslutsfattandet hänger inte alltid med i utvecklingen. Samma utmaning gäller hela Finland.
 
-I politiken fokuserar jag särskilt på AI, ekonomisk politik och digitalisering — och på hur Finland kan förbli konkurrenskraftigt samtidigt som vi säkerställer integritetsskydd och digital självständighet. Samhället digitaliseras kontinuerligt, men den offentliga förvaltningen och beslutsfattandet hänger inte alltid med i utvecklingen. **Samma utmaning gäller hela Finland.**
+Jag är kommunfullmäktigeledamot i Kyrkslätt och ordförande för Gröna fullmäktigegruppen.
 
 Vi behöver bättre förståelse för teknologins möjligheter och risker samt mod att satsa på utbildning och högproduktiv teknologisk utveckling. Det är viktigt att Finland inte halkar efter i kompetens eller konkurrenskraft.
 
 ## Digital självständighet och medborgarinitiativ
 
-Jag är initiativtagare och primär kontaktperson för medborgarinitiativet för digital självständighet. Initiativet kräver lagstiftning som säkerställer att kritiska offentliga digitala tjänster och data förblir i händerna på finska och europeiska aktörer — på servrar inom EU/EES-området.
+Jag är initiativtagare och primär kontaktperson för medborgarinitiativet för digital självständighet. Initiativet kräver lagstiftning som säkerställer att kritiska offentliga digitala tjänster och data förblir i händerna på finska och europeiska aktörer – på servrar inom EU/EES-området.
 
-Digital självständighet stärker demokratin, skyddar medborgarnas rättigheter och stöder europeisk teknologisk utveckling. Det är inte en ideologi utan en praktisk förutsättning för ett fungerande samhälle.
+Digital självständighet stöder europeisk teknologisk utveckling, minskar beroendet av enskilda leverantörer och skapar bättre förutsättningar för inhemsk mjukvaruutveckling. Det är inte en ideologi utan en praktisk förutsättning för ett fungerande samhälle – och det stärker också demokratin och medborgarnas rättigheter.
 
 ## Mångdisciplinär och bred syn
 
 Jag är utbildad diplomingenjör i informationsnätverk. Utbildningsprogrammet bygger på datateknik, men breddas från teknik till bland annat estetik och filosofi. Utbildningen lärde mig att se system som både tekniska och mänskliga helheter.
 
-Mångdisciplinariteten har gett mig förmågan att smidigt fungera som brobyggare och bygga gemensam förståelse med olika yrkesgrupper. Jag granskar teknologin alltid också ur perspektiven av betydelse, påverkan och ansvar.
+Mångdisciplinariteten har gett mig förmågan att smidigt fungera som brobyggare och bygga gemensam förståelse med olika yrkesgrupper. Jag granskar teknologin alltid också ur perspektiven av betydelse, påverkan och ansvar. I praktiken innebär det att jag kan kommunicera med både tekniska experter och verksamheter – och säkerställa att de förstår varandra.
 
 ## Hemma och på fritiden
 

--- a/tests/e2e/aboutEnPage.spec.ts-snapshots/About-Page-in-english-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/aboutEnPage.spec.ts-snapshots/About-Page-in-english-should-match-aria-snapshot-1.aria.yml
@@ -10,10 +10,10 @@
         - listitem: » Municipal councillor in Kirkkonummi, chair of the Green council group.
         - listitem: » Master of Science (Tech.), Information Networks, Aalto University.
         - listitem: » Four children — three daughters and a son.
-        - listitem: » Focuses on digital independence, privacy, and the responsible adoption of AI.
+        - listitem: » Advocates for digital independence, privacy, and the sensible use of AI.
       - button "More"
-    - paragraph: A lead developer who understands what code means for society — not just what it does as a technical solution. Lauri works where technology is changing society, and where decision-making should keep pace.
-    - paragraph: "Lauri Lavanti is a lead developer, municipal councillor in Kirkkonummi, and chair of the Greens council group. He graduated as a Master of Science (Tech.) from Aalto University and focuses on AI, economic policy, entrepreneurship, and digital independence. Digital independence, privacy, and the responsible adoption of AI are all part of the same whole: how we build technological development that is both competitive and sustainable for nature and people."
+    - paragraph: Lauri Lavanti builds software at a bank and makes decisions on the municipal council. His view of technology is grounded in practical experience and expertise — not hype or theory.
+    - paragraph: "He is a lead developer, municipal councillor in Kirkkonummi, and chair of the Greens council group. He graduated as a Master of Science (Tech.) from Aalto University and focuses on AI, economic policy, entrepreneurship, and digital independence. Digital independence, privacy, and the responsible adoption of AI are all part of the same whole: how we build technological development that is both competitive and sustainable."
     - paragraph:
       - text: Lauri also has a
       - link "Wikipedia article":
@@ -24,17 +24,15 @@
     - paragraph: For me, digitalization is not just a technical issue, but also a social and ethical one. I make sure that solutions are not only functional today, but also secure and maintainable tomorrow. Technology must be safe, functional, and serve people.
     - paragraph: Finland has been a model country for high technology for decades. AI is reshaping work, services, and trust in digital systems. We need people in decision-making who understand technology in practice — not just comment on it from the sidelines.
     - heading "Why did I get into politics?" [level=2]
-    - paragraph: I serve as a municipal councilor in Kirkkonummi and as chair of the Green council group.
-    - paragraph:
-      - text: In politics, I focus particularly on AI, economic policy, and digitalisation — and on how Finland can remain competitive while safeguarding privacy and digital independence. Society is rapidly becoming digitalized, but public administration and decision-making do not always keep pace with developments.
-      - strong: The same challenge applies across Finland.
+    - paragraph: In politics, I focus particularly on AI, economic policy, and digitalisation — and on how Finland can remain competitive while safeguarding privacy and digital independence. Society is rapidly becoming digitalized, but public administration and decision-making do not always keep pace with developments. The same challenge applies across Finland.
+    - paragraph: I serve as a municipal councillor in Kirkkonummi and as chair of the Green council group.
     - paragraph: We need a better understanding of the opportunities and risks presented by technology, as well as the courage to invest in education and high-productivity technological development. It is important that Finland does not fall behind in terms of expertise or competitiveness.
     - heading "Digital independence and civic action" [level=2]
     - paragraph: I am the initiator and primary contact of the Digital Independence citizen initiative. The initiative calls for legislation ensuring that critical public digital services and data remain in the hands of Finnish and European actors, on servers located in the EU/EEA area.
-    - paragraph: Digital independence strengthens democracy, protects citizens’ rights, and supports European technological development. It is not an ideology but a practical prerequisite for a functioning society.
+    - paragraph: Digital independence supports European technological development, reduces dependence on individual vendors, and creates better conditions for domestic software development. It is not an ideology but a practical prerequisite for a functioning society — and it also strengthens democracy and citizens’ rights.
     - heading "Multidisciplinarity and a broad perspective" [level=2]
     - paragraph: By training, I am a Master of Science (Tech.) from the study programme of information networks. The program is based on information technology, but it also covers other subjects such as aesthetics and philosophy. The program taught me to view systems as both technical and humane entities.
-    - paragraph: My multidisciplinary background has given me the ability to act smoothly as a bridge builder, fostering mutual understanding between different professional groups. I also always examine technology from the perspective of its significance, impact, and responsibility.
+    - paragraph: My multidisciplinary background has given me the ability to act smoothly as a bridge builder, fostering mutual understanding between different professional groups. I also always examine technology from the perspective of its significance, impact, and responsibility. In practice, that means I can speak with both technical experts and business units — and make sure they understand each other.
     - heading "At home and off duty" [level=2]
     - paragraph: My four children are the focus of my free time. Everyday life consists of hobbies, excursions, and moments spent together. Parenting teaches me a lot about emotional skills, interaction, and continuous practice and development.
     - paragraph: Board games, video games, literature, and team sports have been a part of my life for a long time. Even though my busy schedule limits my time, I think it’s important to make room for these interests—and I replace team sports with active jogging.

--- a/tests/e2e/aboutPage.spec.ts-snapshots/About-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/aboutPage.spec.ts-snapshots/About-Page-should-match-aria-snapshot-1.aria.yml
@@ -9,11 +9,11 @@
         - listitem: » Yli vuosikymmenen kokemus turvallisten ohjelmistojen kehittämisestä, johtava ohjelmistokehittäjä pankissa.
         - listitem: » Kunnanvaltuutettu Kirkkonummella, Vihreän valtuustoryhmän puheenjohtaja.
         - listitem: » Informaatioverkostojen diplomi-insinööri Aalto-yliopistosta.
-        - listitem: » Neljä lasta — kolme tytärtä ja yksi poika.
-        - listitem: » Keskittyy digitaaliseen itsenäisyyteen, yksityisyyden suojaan ja tekoälyn vastuulliseen käyttöönottoon.
+        - listitem: » Neljä lasta – kolme tytärtä ja yksi poika.
+        - listitem: » Ajaa digitaalista itsenäisyyttä, yksityisyyden suojaa ja tekoälyn järkevää käyttöä.
       - button "Lisää"
-    - paragraph: Johtava ohjelmistokehittäjä, joka ymmärtää mitä koodi tarkoittaa yhteiskunnalle – ei vain mitä se tekee teknisenä ratkaisuna. Lauri työskentelee siellä, missä teknologia muuttaa yhteiskuntaa, ja missä päätöksenteon pitäisi pysyä mukana.
-    - paragraph: "Lauri Lavanti on johtava ohjelmistokehittäjä, Kirkkonummen kunnanvaltuutettu sekä Vihreän valtuustoryhmän puheenjohtaja. Hän on Aalto-yliopistosta valmistunut diplomi-insinööri ja keskittyy tekoälyyn, talouteen, yrittäjyyteen sekä digitaaliseen itsenäisyyteen. Digitaalinen itsenäisyys, yksityisyyden suoja ja tekoälyn vastuullinen käyttöönotto ovat osa samaa kokonaisuutta: miten rakennamme teknologista kehitystä, joka on sekä kilpailukykyistä että kestävää niin luonnolle kuin ihmisille."
+    - paragraph: Lauri Lavanti rakentaa ohjelmistoja pankissa ja tekee päätöksiä kunnanvaltuustossa. Hänen näkemyksensä teknologiasta ei pohjaa hypeen tai teoriaan, vaan käytännön kokemukseen ja osaamiseen.
+    - paragraph: "Hän on johtava ohjelmistokehittäjä, Kirkkonummen kunnanvaltuutettu sekä Vihreän valtuustoryhmän puheenjohtaja. Hän on Aalto-yliopistosta valmistunut diplomi-insinööri ja keskittyy tekoälyyn, talouteen, yrittäjyyteen sekä digitaaliseen itsenäisyyteen. Digitaalinen itsenäisyys, yksityisyyden suoja ja tekoälyn vastuullinen käyttöönotto ovat osa samaa kokonaisuutta: miten rakennamme teknologista kehitystä, joka on sekä kilpailukykyistä että kestävää."
     - paragraph:
       - text: Laurista on myös
       - link "Wikipedia-artikkeli":
@@ -22,19 +22,17 @@
     - heading "Teknologiaosaaja, joka yhdistää kilpailukyvyn ja yksityisyyden suojan" [level=2]
     - paragraph: Toimin johtavana ohjelmistokehittäjänä ja vastaan tiimimme palveluiden teknisistä ratkaisuista. Työni keskiössä ovat vaativien kokonaisuuksien suunnittelu, kehittäminen ja ylläpito. Johdan teknisiä linjauksia ja käyn aktiivista vuoropuhelua sidosryhmien kanssa, jotta ratkaisut vastaavat todellisia tarpeita ja kestävät aikaa.
     - paragraph: Digitalisaatio ei ole minulle vain tekninen kysymys, vaan myös yhteiskunnallinen ja eettinen. Huolehdin siitä, että ratkaisut eivät ole vain toimivia tänään, vaan myös turvallisia ja ylläpidettäviä huomenna. Teknologian tulee olla turvallista, toimivaa ja ihmistä palvelevaa.
-    - paragraph: Suomi on ollut korkean teknologian mallimaa vuosikymmeniä. Tekoäly muuttaa työtä, palveluita ja luottamusta digitaalisiin järjestelmiin. Tarvitsemme päätöksentekoon ihmisiä, jotka ymmärtävät teknologiaa käytännössä — eivät vain kommentoi sitä sivusta.
+    - paragraph: Suomi on ollut korkean teknologian mallimaa vuosikymmeniä. Tekoäly muuttaa työtä, palveluita ja luottamusta digitaalisiin järjestelmiin. Tarvitsemme päätöksentekoon ihmisiä, jotka ymmärtävät teknologiaa käytännössä – eivät vain kommentoi sitä sivusta.
     - heading "Miksi olen mukana politiikassa?" [level=2]
+    - paragraph: Politiikassa keskityn erityisesti tekoälyyn, talouteen ja digitalisaatioon – ja siihen, miten Suomi pysyy kilpailukykyisenä samalla kun varmistamme yksityisyyden suojan ja digitaalisen itsenäisyyden. Yhteiskunta digitalisoituu jatkuvasti, mutta julkishallinto ja päätöksenteko eivät aina pysy kehityksen tahdissa. Sama haaste koskee koko Suomea.
     - paragraph: Toimin Kirkkonummen kunnanvaltuutettuna ja Vihreän valtuustoryhmän puheenjohtajana.
-    - paragraph:
-      - text: Politiikassa keskityn erityisesti tekoälyyn, talouteen ja digitalisaatioon — ja siihen, miten Suomi pysyy kilpailukykyisenä samalla kun varmistamme yksityisyyden suojan ja digitaalisen itsenäisyyden. Yhteiskunta digitalisoituu jatkuvasti, mutta julkishallinto ja päätöksenteko eivät aina pysy kehityksen tahdissa.
-      - strong: Sama haaste koskee koko Suomea.
     - paragraph: Tarvitsemme parempaa ymmärrystä teknologian mahdollisuuksista ja riskeistä sekä rohkeutta panostaa koulutukseen ja korkean tuottavuuden teknologiseen kehitykseen. On tärkeää, ettei Suomi jää jälkeen osaamisessa tai kilpailukyvyssä.
     - heading "Digitaalinen itsenäisyys ja kansalaistoiminta" [level=2]
     - paragraph: Olen Digitaalinen itsenäisyys -kansalaisaloitteen alullepanija ja pääyhteyshenkilö. Aloite vaatii, että julkishallinnon kriittiset digitaaliset palvelut ja tiedot pysyvät suomalaisten ja eurooppalaisten toimijoiden käsissä – EU/ETA-alueen palvelimilla.
-    - paragraph: Digitaalinen itsenäisyys vahvistaa demokratiaa, suojaa kansalaisten oikeuksia ja tukee eurooppalaista teknologista kehitystä. Se ei ole ideologia vaan käytännön edellytys toimivalle yhteiskunnalle.
+    - paragraph: Digitaalinen itsenäisyys tukee eurooppalaista teknologista kehitystä, vähentää riippuvuutta yksittäisistä toimittajista ja luo paremmat edellytykset kotimaiselle ohjelmistokehitykselle. Se ei ole ideologia vaan käytännön edellytys toimivalle yhteiskunnalle – ja se vahvistaa myös demokratiaa ja kansalaisten oikeuksia.
     - heading "Monialaisuus ja laaja-alainen näkemys" [level=2]
     - paragraph: Olen koulutukseltani informaatioverkostojen diplomi-insinööri. Koulutusohjelma rakentuu tietotekniikan pohjalle, mutta laajentuu tekniikasta muun muassa estetiikkaan ja filosofiaan. Koulutus opetti katsomaan järjestelmiä sekä teknisinä että inhimillisinä kokonaisuuksina.
-    - paragraph: Monialaisuus on antanut minulle valmiudet toimia sujuvasti sillanrakentajana rakentamassa yhteistä ymmärrystä eri ammattiryhmien kanssa. Tarkastelen teknologiaa myös aina merkitysten, vaikutusten ja vastuullisuuden näkökulmasta.
+    - paragraph: Monialaisuus on antanut minulle valmiudet toimia sujuvasti sillanrakentajana rakentamassa yhteistä ymmärrystä eri ammattiryhmien kanssa. Tarkastelen teknologiaa myös aina merkitysten, vaikutusten ja vastuullisuuden näkökulmasta. Käytännössä se tarkoittaa, että pystyn puhumaan sekä teknisten asiantuntijoiden että liiketoimintojen kanssa – ja varmistamaan, että ne ymmärtävät toisiaan.
     - heading "Kotona ja vapaalla" [level=2]
     - paragraph: Vapaa-ajallani keskiössä ovat neljä lastani. Arki koostuu harrastuksista, retkistä ja yhteisistä hetkistä. Vanhemmuus opettaa minulle paljon tunnetaidoista, vuorovaikutuksesta ja jatkuvasta harjoittelusta ja kehittymisestä.
     - paragraph: Lautapelit, videopelit, kirjallisuus ja joukkueurheilu ovat kulkeneet mukanani pitkään. Vaikka ruuhkavuodet rajaavat aikaa, pidän tärkeänä säilyttää tilaa myös näille kiinnostuksen kohteille, olenkin korvannut joukkueurheilua aktiivisella lenkkeilyllä.

--- a/tests/e2e/aboutSwePage.spec.ts-snapshots/About-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/aboutSwePage.spec.ts-snapshots/About-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
@@ -9,11 +9,11 @@
         - listitem: » Över ett decennium av erfarenhet av att bygga säker mjukvara, ledande mjukvaruutvecklare på en bank.
         - listitem: » Kommunfullmäktigeledamot i Kyrkslätt, ordförande för Gröna fullmäktigegruppen.
         - listitem: » Diplomingenjör i informationsnätverk, Aalto-universitetet.
-        - listitem: » Fyra barn — tre döttrar och en son.
-        - listitem: » Fokuserar på digital självständighet, integritetsskydd och ansvarsfull implementering av AI.
+        - listitem: » Fyra barn – tre döttrar och en son.
+        - listitem: » Driver för digital självständighet, integritetsskydd och ett förnuftigt användande av AI.
       - button "Mer"
-    - paragraph: En ledande mjukvaruutvecklare som förstår vad kod betyder för samhället – inte bara vad den gör som teknisk lösning. Lauri arbetar där teknologin förändrar samhället, och där beslutsfattandet borde hänga med.
-    - paragraph: "Lauri Lavanti är ledande mjukvaruutvecklare, kommunfullmäktigeledamot i Kyrkslätt samt ordförande för De Grönas fullmäktigegrupp. Han är utexaminerad diplomingenjör från Aalto-universitetet och fokuserar på AI, ekonomisk politik, företagande samt digital självständighet. Digital självständighet, integritetsskydd och ansvarsfull implementering av AI är delar av samma helhet: hur vi bygger teknologisk utveckling som är både konkurrenskraftig och hållbar för naturen och människorna."
+    - paragraph: Lauri Lavanti bygger mjukvara på en bank och fattar beslut i kommunfullmäktige. Hans syn på teknologi är grundad i praktisk erfarenhet och kompetens – inte i hype eller teori.
+    - paragraph: "Han är ledande mjukvaruutvecklare, kommunfullmäktigeledamot i Kyrkslätt samt ordförande för De Grönas fullmäktigegrupp. Han är utexaminerad diplomingenjör från Aalto-universitetet och fokuserar på AI, ekonomisk politik, företagande samt digital självständighet. Digital självständighet, integritetsskydd och ansvarsfull implementering av AI är delar av samma helhet: hur vi bygger teknologisk utveckling som är både konkurrenskraftig och hållbar."
     - paragraph:
       - text: Lauri har också en
       - link "Wikipedia-artikel":
@@ -22,19 +22,17 @@
     - heading "En teknologiexpert som förenar konkurrenskraft och integritetsskydd" [level=2]
     - paragraph: Jag arbetar som ledande mjukvaruutvecklare och ansvarar för de tekniska lösningarna i vårt teams tjänster. I mitt arbete står planering, utveckling och underhåll av krävande helheter i centrum. Jag leder tekniska riktlinjer och för en aktiv dialog med intressenter för att säkerställa att lösningarna motsvarar verkliga behov och håller över tid.
     - paragraph: Digitalisering är inte bara en teknisk fråga för mig, utan också en samhällelig och etisk. Jag ser till att lösningarna inte bara fungerar idag, utan också är säkra och underhållbara imorgon. Teknologin ska vara säker, funktionell och tjäna människan.
-    - paragraph: Finland har varit ett föregångsland inom högteknologi i decennier. AI förändrar arbete, tjänster och förtroendet för digitala system. Vi behöver människor i beslutsfattandet som förstår teknologi i praktiken — inte bara kommenterar den från sidan.
+    - paragraph: Finland har varit ett föregångsland inom högteknologi i decennier. AI förändrar arbete, tjänster och förtroendet för digitala system. Vi behöver människor i beslutsfattandet som förstår teknologi i praktiken – inte bara kommenterar den från sidan.
     - heading "Varför gick jag in i politiken?" [level=2]
+    - paragraph: I politiken fokuserar jag särskilt på AI, ekonomisk politik och digitalisering – och på hur Finland kan förbli konkurrenskraftigt samtidigt som vi säkerställer integritetsskydd och digital självständighet. Samhället digitaliseras kontinuerligt, men den offentliga förvaltningen och beslutsfattandet hänger inte alltid med i utvecklingen. Samma utmaning gäller hela Finland.
     - paragraph: Jag är kommunfullmäktigeledamot i Kyrkslätt och ordförande för Gröna fullmäktigegruppen.
-    - paragraph:
-      - text: I politiken fokuserar jag särskilt på AI, ekonomisk politik och digitalisering — och på hur Finland kan förbli konkurrenskraftigt samtidigt som vi säkerställer integritetsskydd och digital självständighet. Samhället digitaliseras kontinuerligt, men den offentliga förvaltningen och beslutsfattandet hänger inte alltid med i utvecklingen.
-      - strong: Samma utmaning gäller hela Finland.
     - paragraph: Vi behöver bättre förståelse för teknologins möjligheter och risker samt mod att satsa på utbildning och högproduktiv teknologisk utveckling. Det är viktigt att Finland inte halkar efter i kompetens eller konkurrenskraft.
     - heading "Digital självständighet och medborgarinitiativ" [level=2]
-    - paragraph: Jag är initiativtagare och primär kontaktperson för medborgarinitiativet för digital självständighet. Initiativet kräver lagstiftning som säkerställer att kritiska offentliga digitala tjänster och data förblir i händerna på finska och europeiska aktörer — på servrar inom EU/EES-området.
-    - paragraph: Digital självständighet stärker demokratin, skyddar medborgarnas rättigheter och stöder europeisk teknologisk utveckling. Det är inte en ideologi utan en praktisk förutsättning för ett fungerande samhälle.
+    - paragraph: Jag är initiativtagare och primär kontaktperson för medborgarinitiativet för digital självständighet. Initiativet kräver lagstiftning som säkerställer att kritiska offentliga digitala tjänster och data förblir i händerna på finska och europeiska aktörer – på servrar inom EU/EES-området.
+    - paragraph: Digital självständighet stöder europeisk teknologisk utveckling, minskar beroendet av enskilda leverantörer och skapar bättre förutsättningar för inhemsk mjukvaruutveckling. Det är inte en ideologi utan en praktisk förutsättning för ett fungerande samhälle – och det stärker också demokratin och medborgarnas rättigheter.
     - heading "Mångdisciplinär och bred syn" [level=2]
     - paragraph: Jag är utbildad diplomingenjör i informationsnätverk. Utbildningsprogrammet bygger på datateknik, men breddas från teknik till bland annat estetik och filosofi. Utbildningen lärde mig att se system som både tekniska och mänskliga helheter.
-    - paragraph: Mångdisciplinariteten har gett mig förmågan att smidigt fungera som brobyggare och bygga gemensam förståelse med olika yrkesgrupper. Jag granskar teknologin alltid också ur perspektiven av betydelse, påverkan och ansvar.
+    - paragraph: Mångdisciplinariteten har gett mig förmågan att smidigt fungera som brobyggare och bygga gemensam förståelse med olika yrkesgrupper. Jag granskar teknologin alltid också ur perspektiven av betydelse, påverkan och ansvar. I praktiken innebär det att jag kan kommunicera med både tekniska experter och verksamheter – och säkerställa att de förstår varandra.
     - heading "Hemma och på fritiden" [level=2]
     - paragraph: På fritiden står mina fyra barn i centrum. Vardagen består av hobbyer, utflykter och gemensamma stunder. Föräldraskapet lär mig mycket om emotionella färdigheter, interaktion och ständig övning och utveckling.
     - paragraph: Brädspel, datorspel, litteratur och lagsport har följt med mig länge. Även om de hektiska åren begränsar tiden, tycker jag det är viktigt att bevara utrymme även för dessa intressen – och ersätter lagsport med aktiv löpning.


### PR DESCRIPTION
> This PR containes AI-generated code. The author has reviewed and is responsible for all AI-generated content.

## Summary

- **Segment C alignment**: Reordered framing so economic competitiveness leads throughout — politics section now opens with policy agenda before naming the Green council chair role; digital independence section leads with EU market/vendor independence before democracy/rights; SummaryBox closes on active advocacy ("ajaa") not passive focus
- **Human voice**: Replaced abstract thought-leader opener with concrete statement (builds software, makes council decisions, grounded in experience not hype); dropped ecological sustainability tail that signals "too Green" to Segment C readers; removed mid-paragraph bold
- **Finnish language**: Em dashes → en dashes throughout prose in FI and SV; "vastuullinen käyttöönotto" → "järkevää käyttöä" (less corporate)
- **Multidisciplinary section**: Added concrete ROI sentence — can speak with technical experts and business units, ensures they understand each other
- All changes applied consistently across FI, EN, and SV versions; E2E snapshots updated (460/460 passing)