### PR TITLE
feat(socialshare): add Mastodon button and pre-tag author

### DIFF
--- a/src/components/SocialShare.astro
+++ b/src/components/SocialShare.astro
@@ -108,13 +108,13 @@ const l = labels[locale]
 <aside aria-label={ariaLabel}>
     <span class="share">{l.share}</span>
     <a
-        aria-label={l.facebook(title)}
-        href={`https://www.facebook.com/sharer/sharer.php?u=${encodeURI(shareUrl)}`}
+        aria-label={l.bluesky(title)}
+        href={`https://bsky.app/intent/compose?text=${encodeURI(title)}%20${encodeURI(shareUrl)}`}
         rel="noopener noreferrer"
         style={{ height: '2.75rem', minWidth: '2.75rem' }}
-        title={l.facebookTitle}
+        title={l.blueskyTitle}
     >
-        <Icon class="facebook" name="fa7-brands:facebook" />
+        <Icon class="bluesky" name="fa7-brands:bluesky" />
     </a>
     <a
         aria-label={l.threads(title)}
@@ -126,15 +126,6 @@ const l = labels[locale]
         <Icon class="threads" name="fa7-brands:threads" />
     </a>
     <a
-        aria-label={l.bluesky(title)}
-        href={`https://bsky.app/intent/compose?text=${encodeURI(title)}%20${encodeURI(shareUrl)}`}
-        rel="noopener noreferrer"
-        style={{ height: '2.75rem', minWidth: '2.75rem' }}
-        title={l.blueskyTitle}
-    >
-        <Icon class="bluesky" name="fa7-brands:bluesky" />
-    </a>
-    <a
         aria-label={l.linkedin(title)}
         href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURI(shareUrl)}`}
         rel="noopener noreferrer"
@@ -142,5 +133,14 @@ const l = labels[locale]
         title={l.linkedinTitle}
     >
         <Icon class="linkedin" name="fa7-brands:linkedin" />
+    </a>
+    <a
+        aria-label={l.facebook(title)}
+        href={`https://www.facebook.com/sharer/sharer.php?u=${encodeURI(shareUrl)}`}
+        rel="noopener noreferrer"
+        style={{ height: '2.75rem', minWidth: '2.75rem' }}
+        title={l.facebookTitle}
+    >
+        <Icon class="facebook" name="fa7-brands:facebook" />
     </a>
 </aside>

--- a/src/components/SocialShare.astro
+++ b/src/components/SocialShare.astro
@@ -2,7 +2,12 @@
 /* eslint-disable astro/no-unused-css-selector */
 import { Icon } from 'astro-icon/components'
 
-import { personBlueskyHandle, personThreadsHandle } from '../content/person'
+import {
+    personBlueskyHandle,
+    personMastodonHandle,
+    personMastodonInstance,
+    personThreadsHandle,
+} from '../content/person'
 import { colors, sizes } from '../lib/styles'
 
 interface Props {
@@ -22,6 +27,9 @@ const labels = {
         facebookTitle: 'Share on Facebook',
         linkedin: (t: string) => `Share post "${t}" on LinkedIn`,
         linkedinTitle: 'Share on LinkedIn',
+        mastodon: (t: string) => `Share post "${t}" on Mastodon`,
+        mastodonInstancePrompt: 'Enter your Mastodon instance (e.g. mastodon.social):',
+        mastodonTitle: 'Share on Mastodon',
         share: 'Share:',
         shareText: (t: string, u: string, h: string) => `Read "${t}" that was written by @${h}\n\n${u}`,
         threads: (t: string) => `Share post "${t}" on Threads`,
@@ -34,6 +42,9 @@ const labels = {
         facebookTitle: 'Jaa Facebookissa',
         linkedin: (t: string) => `Jaa kirjoitus "${t}" LinkedInissä`,
         linkedinTitle: 'Jaa LinkedInissä',
+        mastodon: (t: string) => `Jaa kirjoitus "${t}" Mastodonissa`,
+        mastodonInstancePrompt: 'Anna Mastodon-instanssisi (esim. mastodon.social):',
+        mastodonTitle: 'Jaa Mastodonissa',
         share: 'Jaa:',
         shareText: (t: string, u: string, h: string) => `Lue "${t}", jonka @${h} kirjoitti\n\n${u}`,
         threads: (t: string) => `Jaa kirjoitus "${t}" Threadsissä`,
@@ -46,6 +57,9 @@ const labels = {
         facebookTitle: 'Dela på Facebook',
         linkedin: (t: string) => `Dela inlägget "${t}" på LinkedIn`,
         linkedinTitle: 'Dela på LinkedIn',
+        mastodon: (t: string) => `Dela inlägget "${t}" på Mastodon`,
+        mastodonInstancePrompt: 'Ange din Mastodon-instans (t.ex. mastodon.social):',
+        mastodonTitle: 'Dela på Mastodon',
         share: 'Dela:',
         shareText: (t: string, u: string, h: string) => `Läs inlägget "${t}" som skrevs av @${h}\n\n${u}`,
         threads: (t: string) => `Dela inlägget "${t}" på Threads`,
@@ -57,6 +71,8 @@ const l = labels[locale]
 
 const blueskyText = l.shareText(title, shareUrl, personBlueskyHandle)
 const threadsText = l.shareText(title, shareUrl, personThreadsHandle)
+const mastodonText = l.shareText(title, shareUrl, personMastodonHandle)
+const mastodonFallbackHref = `https://${personMastodonInstance}/share?text=${encodeURIComponent(mastodonText)}`
 ---
 
 <style
@@ -64,6 +80,7 @@ const threadsText = l.shareText(title, shareUrl, personThreadsHandle)
         colorsBluesky: colors.bluesky,
         colorsFacebook: colors.facebook,
         colorsLinkedin: colors.linkedin,
+        colorsMastodon: colors.mastodon,
         colorsThreads: colors.threads,
         sizes05: sizes[0.5],
         sizes15: sizes[1.5],
@@ -111,9 +128,25 @@ const threadsText = l.shareText(title, shareUrl, personThreadsHandle)
     .linkedin {
         color: var(--colorsLinkedin);
     }
+
+    .mastodon {
+        color: var(--colorsMastodon);
+    }
 </style>
 <aside aria-label={ariaLabel}>
     <span class="share">{l.share}</span>
+    <a
+        aria-label={l.mastodon(title)}
+        data-instance-prompt={l.mastodonInstancePrompt}
+        data-share-text={mastodonText}
+        href={mastodonFallbackHref}
+        id="mastodon-share"
+        rel="noopener noreferrer"
+        style={{ height: '2.75rem', minWidth: '2.75rem' }}
+        title={l.mastodonTitle}
+    >
+        <Icon class="mastodon" name="fa7-brands:mastodon" />
+    </a>
     <a
         aria-label={l.bluesky(title)}
         href={`https://bsky.app/intent/compose?text=${encodeURIComponent(blueskyText)}`}
@@ -151,3 +184,24 @@ const threadsText = l.shareText(title, shareUrl, personThreadsHandle)
         <Icon class="facebook" name="fa7-brands:facebook" />
     </a>
 </aside>
+<script
+    is:inline
+    set:html={`(function(){
+    var link = document.getElementById('mastodon-share');
+    if (!link) return;
+    var baseText = link.getAttribute('data-share-text') || '';
+    var promptLabel = link.getAttribute('data-instance-prompt') || 'Mastodon instance:';
+    link.addEventListener('click', function(event){
+        event.preventDefault();
+        var instance = localStorage.getItem('mastodonInstance');
+        if (!instance) {
+            var raw = window.prompt(promptLabel, 'mastodon.social');
+            if (!raw) return;
+            instance = raw.trim().replace(/^https?:\\/\\//, '').replace(/\\/$/, '').replace(/^@/, '');
+            if (!/^[a-z0-9.-]+\\.[a-z]{2,}$/i.test(instance)) return;
+            localStorage.setItem('mastodonInstance', instance);
+        }
+        window.location.href = 'https://' + instance + '/share?text=' + encodeURIComponent(baseText);
+    });
+})();`}
+/>

--- a/src/components/SocialShare.astro
+++ b/src/components/SocialShare.astro
@@ -2,6 +2,7 @@
 /* eslint-disable astro/no-unused-css-selector */
 import { Icon } from 'astro-icon/components'
 
+import { personBlueskyHandle, personThreadsHandle } from '../content/person'
 import { colors, sizes } from '../lib/styles'
 
 interface Props {
@@ -22,6 +23,7 @@ const labels = {
         linkedin: (t: string) => `Share post "${t}" on LinkedIn`,
         linkedinTitle: 'Share on LinkedIn',
         share: 'Share:',
+        shareText: (t: string, u: string, h: string) => `Read "${t}" that was written by @${h}\n\n${u}`,
         threads: (t: string) => `Share post "${t}" on Threads`,
         threadsTitle: 'Share on Threads',
     },
@@ -33,6 +35,7 @@ const labels = {
         linkedin: (t: string) => `Jaa kirjoitus "${t}" LinkedInissä`,
         linkedinTitle: 'Jaa LinkedInissä',
         share: 'Jaa:',
+        shareText: (t: string, u: string, h: string) => `Lue "${t}", jonka @${h} kirjoitti\n\n${u}`,
         threads: (t: string) => `Jaa kirjoitus "${t}" Threadsissä`,
         threadsTitle: 'Jaa Threadsissä',
     },
@@ -44,12 +47,16 @@ const labels = {
         linkedin: (t: string) => `Dela inlägget "${t}" på LinkedIn`,
         linkedinTitle: 'Dela på LinkedIn',
         share: 'Dela:',
+        shareText: (t: string, u: string, h: string) => `Läs inlägget "${t}" som skrevs av @${h}\n\n${u}`,
         threads: (t: string) => `Dela inlägget "${t}" på Threads`,
         threadsTitle: 'Dela på Threads',
     },
 }
 
 const l = labels[locale]
+
+const blueskyText = l.shareText(title, shareUrl, personBlueskyHandle)
+const threadsText = l.shareText(title, shareUrl, personThreadsHandle)
 ---
 
 <style
@@ -109,7 +116,7 @@ const l = labels[locale]
     <span class="share">{l.share}</span>
     <a
         aria-label={l.bluesky(title)}
-        href={`https://bsky.app/intent/compose?text=${encodeURI(title)}%20${encodeURI(shareUrl)}`}
+        href={`https://bsky.app/intent/compose?text=${encodeURIComponent(blueskyText)}`}
         rel="noopener noreferrer"
         style={{ height: '2.75rem', minWidth: '2.75rem' }}
         title={l.blueskyTitle}
@@ -118,7 +125,7 @@ const l = labels[locale]
     </a>
     <a
         aria-label={l.threads(title)}
-        href={`https://threads.com/intent/post?text=${encodeURI(title)}%20${encodeURI(shareUrl)}`}
+        href={`https://threads.com/intent/post?text=${encodeURIComponent(threadsText)}`}
         rel="noopener noreferrer"
         style={{ height: '2.75rem', minWidth: '2.75rem' }}
         title={l.threadsTitle}

--- a/src/components/SocialShare.spec.ts
+++ b/src/components/SocialShare.spec.ts
@@ -2,6 +2,7 @@ import { getByRole } from '@testing-library/dom'
 import { describe, expect, it } from 'vitest'
 
 import { renderAstroComponent } from '../../tests/helpers'
+import { personBlueskyHandle, personThreadsHandle } from '../content/person'
 import SocialShare from './SocialShare.astro'
 
 // filepath: /home/lapanti/code/laurilavanti/src/components/SocialShare.spec.ts
@@ -115,7 +116,7 @@ describe('<SocialShare />', () => {
 
         expect(getByRole(result, 'link', { name: `Jaa kirjoitus "${title}" Threadsissä` })).toHaveAttribute(
             'href',
-            `https://threads.com/intent/post?text=${encodeURI(title)}%20${encodeURI(shareUrl)}`
+            `https://threads.com/intent/post?text=${encodeURIComponent(`Lue "${title}", jonka @${personThreadsHandle} kirjoitti\n\n${shareUrl}`)}`
         )
     })
 
@@ -172,7 +173,7 @@ describe('<SocialShare />', () => {
 
         expect(getByRole(result, 'link', { name: `Jaa kirjoitus "${title}" Blueskyssa` })).toHaveAttribute(
             'href',
-            `https://bsky.app/intent/compose?text=${encodeURI(title)}%20${encodeURI(shareUrl)}`
+            `https://bsky.app/intent/compose?text=${encodeURIComponent(`Lue "${title}", jonka @${personBlueskyHandle} kirjoitti\n\n${shareUrl}`)}`
         )
     })
 
@@ -293,6 +294,22 @@ describe('<SocialShare />', () => {
             expect(getByRole(result, 'link', { name: `Share post "${enTitle}" on Threads` })).toBeDefined()
         })
 
+        it('should render correct url for threads link with English share text', async () => {
+            const result = await renderAstroComponent(SocialShare, {
+                props: {
+                    ariaLabel: enAriaLabel,
+                    locale: 'en',
+                    shareUrl: enShareUrl,
+                    title: enTitle,
+                },
+            })
+
+            expect(getByRole(result, 'link', { name: `Share post "${enTitle}" on Threads` })).toHaveAttribute(
+                'href',
+                `https://threads.com/intent/post?text=${encodeURIComponent(`Read "${enTitle}" that was written by @${personThreadsHandle}\n\n${enShareUrl}`)}`
+            )
+        })
+
         it('should render bluesky link with English label', async () => {
             const result = await renderAstroComponent(SocialShare, {
                 props: {
@@ -304,6 +321,22 @@ describe('<SocialShare />', () => {
             })
 
             expect(getByRole(result, 'link', { name: `Share post "${enTitle}" on Bluesky` })).toBeDefined()
+        })
+
+        it('should render correct url for bluesky link with English share text', async () => {
+            const result = await renderAstroComponent(SocialShare, {
+                props: {
+                    ariaLabel: enAriaLabel,
+                    locale: 'en',
+                    shareUrl: enShareUrl,
+                    title: enTitle,
+                },
+            })
+
+            expect(getByRole(result, 'link', { name: `Share post "${enTitle}" on Bluesky` })).toHaveAttribute(
+                'href',
+                `https://bsky.app/intent/compose?text=${encodeURIComponent(`Read "${enTitle}" that was written by @${personBlueskyHandle}\n\n${enShareUrl}`)}`
+            )
         })
 
         it('should render linkedin link with English label', async () => {
@@ -351,6 +384,22 @@ describe('<SocialShare />', () => {
             expect(getByRole(result, 'link', { name: `Dela inlägget "${svTitle}" på Threads` })).toBeDefined()
         })
 
+        it('should render correct url for threads link with Swedish share text', async () => {
+            const result = await renderAstroComponent(SocialShare, {
+                props: {
+                    ariaLabel: svAriaLabel,
+                    locale: 'sv',
+                    shareUrl: svShareUrl,
+                    title: svTitle,
+                },
+            })
+
+            expect(getByRole(result, 'link', { name: `Dela inlägget "${svTitle}" på Threads` })).toHaveAttribute(
+                'href',
+                `https://threads.com/intent/post?text=${encodeURIComponent(`Läs inlägget "${svTitle}" som skrevs av @${personThreadsHandle}\n\n${svShareUrl}`)}`
+            )
+        })
+
         it('should render bluesky link with Swedish label', async () => {
             const result = await renderAstroComponent(SocialShare, {
                 props: {
@@ -362,6 +411,22 @@ describe('<SocialShare />', () => {
             })
 
             expect(getByRole(result, 'link', { name: `Dela inlägget "${svTitle}" på Bluesky` })).toBeDefined()
+        })
+
+        it('should render correct url for bluesky link with Swedish share text', async () => {
+            const result = await renderAstroComponent(SocialShare, {
+                props: {
+                    ariaLabel: svAriaLabel,
+                    locale: 'sv',
+                    shareUrl: svShareUrl,
+                    title: svTitle,
+                },
+            })
+
+            expect(getByRole(result, 'link', { name: `Dela inlägget "${svTitle}" på Bluesky` })).toHaveAttribute(
+                'href',
+                `https://bsky.app/intent/compose?text=${encodeURIComponent(`Läs inlägget "${svTitle}" som skrevs av @${personBlueskyHandle}\n\n${svShareUrl}`)}`
+            )
         })
 
         it('should render linkedin link with Swedish label', async () => {

--- a/src/components/SocialShare.spec.ts
+++ b/src/components/SocialShare.spec.ts
@@ -2,7 +2,12 @@ import { getByRole } from '@testing-library/dom'
 import { describe, expect, it } from 'vitest'
 
 import { renderAstroComponent } from '../../tests/helpers'
-import { personBlueskyHandle, personThreadsHandle } from '../content/person'
+import {
+    personBlueskyHandle,
+    personMastodonHandle,
+    personMastodonInstance,
+    personThreadsHandle,
+} from '../content/person'
 import SocialShare from './SocialShare.astro'
 
 // filepath: /home/lapanti/code/laurilavanti/src/components/SocialShare.spec.ts
@@ -207,6 +212,63 @@ describe('<SocialShare />', () => {
         )
     })
 
+    it('should render mastodon link', async () => {
+        const result = await renderAstroComponent(SocialShare, {
+            props: {
+                ariaLabel,
+                shareUrl,
+                title,
+            },
+        })
+
+        expect(getByRole(result, 'link', { name: `Jaa kirjoitus "${title}" Mastodonissa` })).toBeDefined()
+    })
+
+    it('should render correct url for mastodon link', async () => {
+        const result = await renderAstroComponent(SocialShare, {
+            props: {
+                ariaLabel,
+                shareUrl,
+                title,
+            },
+        })
+
+        expect(getByRole(result, 'link', { name: `Jaa kirjoitus "${title}" Mastodonissa` })).toHaveAttribute(
+            'href',
+            `https://${personMastodonInstance}/share?text=${encodeURIComponent(`Lue "${title}", jonka @${personMastodonHandle} kirjoitti\n\n${shareUrl}`)}`
+        )
+    })
+
+    it('should render correct rel for mastodon link', async () => {
+        const result = await renderAstroComponent(SocialShare, {
+            props: {
+                ariaLabel,
+                shareUrl,
+                title,
+            },
+        })
+
+        expect(getByRole(result, 'link', { name: `Jaa kirjoitus "${title}" Mastodonissa` })).toHaveAttribute(
+            'rel',
+            'noopener noreferrer'
+        )
+    })
+
+    it('should render correct title for mastodon link', async () => {
+        const result = await renderAstroComponent(SocialShare, {
+            props: {
+                ariaLabel,
+                shareUrl,
+                title,
+            },
+        })
+
+        expect(getByRole(result, 'link', { name: `Jaa kirjoitus "${title}" Mastodonissa` })).toHaveAttribute(
+            'title',
+            'Jaa Mastodonissa'
+        )
+    })
+
     it('should render linkedin link', async () => {
         const result = await renderAstroComponent(SocialShare, {
             props: {
@@ -351,6 +413,35 @@ describe('<SocialShare />', () => {
 
             expect(getByRole(result, 'link', { name: `Share post "${enTitle}" on LinkedIn` })).toBeDefined()
         })
+
+        it('should render mastodon link with English label', async () => {
+            const result = await renderAstroComponent(SocialShare, {
+                props: {
+                    ariaLabel: enAriaLabel,
+                    locale: 'en',
+                    shareUrl: enShareUrl,
+                    title: enTitle,
+                },
+            })
+
+            expect(getByRole(result, 'link', { name: `Share post "${enTitle}" on Mastodon` })).toBeDefined()
+        })
+
+        it('should render correct url for mastodon link with English share text', async () => {
+            const result = await renderAstroComponent(SocialShare, {
+                props: {
+                    ariaLabel: enAriaLabel,
+                    locale: 'en',
+                    shareUrl: enShareUrl,
+                    title: enTitle,
+                },
+            })
+
+            expect(getByRole(result, 'link', { name: `Share post "${enTitle}" on Mastodon` })).toHaveAttribute(
+                'href',
+                `https://${personMastodonInstance}/share?text=${encodeURIComponent(`Read "${enTitle}" that was written by @${personMastodonHandle}\n\n${enShareUrl}`)}`
+            )
+        })
     })
 
     describe('when locale is sv', () => {
@@ -440,6 +531,35 @@ describe('<SocialShare />', () => {
             })
 
             expect(getByRole(result, 'link', { name: `Dela inlägget "${svTitle}" på LinkedIn` })).toBeDefined()
+        })
+
+        it('should render mastodon link with Swedish label', async () => {
+            const result = await renderAstroComponent(SocialShare, {
+                props: {
+                    ariaLabel: svAriaLabel,
+                    locale: 'sv',
+                    shareUrl: svShareUrl,
+                    title: svTitle,
+                },
+            })
+
+            expect(getByRole(result, 'link', { name: `Dela inlägget "${svTitle}" på Mastodon` })).toBeDefined()
+        })
+
+        it('should render correct url for mastodon link with Swedish share text', async () => {
+            const result = await renderAstroComponent(SocialShare, {
+                props: {
+                    ariaLabel: svAriaLabel,
+                    locale: 'sv',
+                    shareUrl: svShareUrl,
+                    title: svTitle,
+                },
+            })
+
+            expect(getByRole(result, 'link', { name: `Dela inlägget "${svTitle}" på Mastodon` })).toHaveAttribute(
+                'href',
+                `https://${personMastodonInstance}/share?text=${encodeURIComponent(`Läs inlägget "${svTitle}" som skrevs av @${personMastodonHandle}\n\n${svShareUrl}`)}`
+            )
         })
     })
 })

--- a/src/content/person.ts
+++ b/src/content/person.ts
@@ -4,6 +4,11 @@ import { getImage } from '../lib/images'
 
 export const PERSON_ID = 'https://laurilavanti.fi/fi/about/#person'
 
+export const personBlueskyHandle = 'laurilavanti.fi'
+export const personThreadsHandle = 'laurilavanti'
+export const personMastodonInstance = 'mastodon.social'
+export const personMastodonHandle = `laurilavanti@${personMastodonInstance}`
+
 export const personName = 'Lauri Lavanti'
 export const personGivenName = 'Lauri'
 export const personFamilyName = 'Lavanti'

--- a/tests/__snapshots__/components/SocialShare.spec.ts.snap
+++ b/tests/__snapshots__/components/SocialShare.spec.ts.snap
@@ -16,33 +16,33 @@ exports[`<SocialShare /> > should render 1`] = `
   </span>
    
   <a
-    aria-label="Jaa kirjoitus "Vuosi 2026 on tekoälyn" Facebookissa"
+    aria-label="Jaa kirjoitus "Vuosi 2026 on tekoälyn" Blueskyssa"
     data-astro-cid-luj3ckct=""
-    href="https://www.facebook.com/sharer/sharer.php?u=https://laurilavanti.fi/blogi/vuosi-2026-on-tekoalyn"
+    href="https://bsky.app/intent/compose?text=Vuosi%202026%20on%20teko%C3%A4lyn%20https://laurilavanti.fi/blogi/vuosi-2026-on-tekoalyn"
     rel="noopener noreferrer"
     style="height:2.75rem;min-width:2.75rem;--colorsBluesky: #0060df;--colorsFacebook: #4267B2;--colorsLinkedin: #0E76A8;--colorsThreads: rgb(0, 0, 0);--sizes05: 0.5rem;--sizes15: 1.5rem;"
-    title="Jaa Facebookissa"
+    title="Jaa Blueskyssa"
   >
      
     <svg
-      class="facebook"
+      class="bluesky"
       data-astro-cid-luj3ckct="true"
-      data-icon="fa7-brands:facebook"
+      data-icon="fa7-brands:bluesky"
       height="1em"
       width="1em"
     >
          
       <symbol
-        id="ai:fa7-brands:facebook"
+        id="ai:fa7-brands:bluesky"
         viewBox="0 0 640 640"
       >
         <path
-          d="M576 320c0-141.4-114.6-256-256-256S64 178.6 64 320c0 120 82.7 220.8 194.2 248.5V398.2h-52.8V320h52.8v-33.7c0-87.1 39.4-127.5 125-127.5c16.2 0 44.2 3.2 55.7 6.4V236c-6-.6-16.5-1-29.6-1c-42 0-58.2 15.9-58.2 57.2V320h83.6l-14.4 78.2H351v175.9C477.8 558.8 576 450.9 576 320"
+          d="M439.8 358.7c-3.3-.4-6.7-.8-10-1.3c3.4.4 6.7.9 10 1.3M320 291.1c-26.1-50.7-97.1-145.2-163.1-191.8c-63.3-44.7-87.4-37-103.3-29.8C35.3 77.8 32 105.9 32 122.4S41.1 258 47 277.9c19.5 65.7 89.1 87.9 153.2 80.7c3.3-.5 6.6-.9 10-1.4c-3.3.5-6.6 1-10 1.4c-93.9 14-177.3 48.2-67.9 169.9C252.6 653.1 297.1 501.8 320 425.1c22.9 76.7 49.2 222.5 185.6 103.4c102.4-103.4 28.1-156-65.8-169.9c-3.3-.4-6.7-.8-10-1.3c3.4.4 6.7.9 10 1.3c64.1 7.1 133.6-15.1 153.2-80.7c5.9-19.9 15-138.9 15-155.5s-3.3-44.7-21.6-52.9c-15.8-7.1-40-14.9-103.2 29.8c-66.1 46.6-137.1 141.1-163.2 191.8"
           fill="currentColor"
         />
       </symbol>
       <use
-        href="#ai:fa7-brands:facebook"
+        href="#ai:fa7-brands:bluesky"
       />
         
     </svg>
@@ -84,40 +84,6 @@ exports[`<SocialShare /> > should render 1`] = `
   </a>
    
   <a
-    aria-label="Jaa kirjoitus "Vuosi 2026 on tekoälyn" Blueskyssa"
-    data-astro-cid-luj3ckct=""
-    href="https://bsky.app/intent/compose?text=Vuosi%202026%20on%20teko%C3%A4lyn%20https://laurilavanti.fi/blogi/vuosi-2026-on-tekoalyn"
-    rel="noopener noreferrer"
-    style="height:2.75rem;min-width:2.75rem;--colorsBluesky: #0060df;--colorsFacebook: #4267B2;--colorsLinkedin: #0E76A8;--colorsThreads: rgb(0, 0, 0);--sizes05: 0.5rem;--sizes15: 1.5rem;"
-    title="Jaa Blueskyssa"
-  >
-     
-    <svg
-      class="bluesky"
-      data-astro-cid-luj3ckct="true"
-      data-icon="fa7-brands:bluesky"
-      height="1em"
-      width="1em"
-    >
-         
-      <symbol
-        id="ai:fa7-brands:bluesky"
-        viewBox="0 0 640 640"
-      >
-        <path
-          d="M439.8 358.7c-3.3-.4-6.7-.8-10-1.3c3.4.4 6.7.9 10 1.3M320 291.1c-26.1-50.7-97.1-145.2-163.1-191.8c-63.3-44.7-87.4-37-103.3-29.8C35.3 77.8 32 105.9 32 122.4S41.1 258 47 277.9c19.5 65.7 89.1 87.9 153.2 80.7c3.3-.5 6.6-.9 10-1.4c-3.3.5-6.6 1-10 1.4c-93.9 14-177.3 48.2-67.9 169.9C252.6 653.1 297.1 501.8 320 425.1c22.9 76.7 49.2 222.5 185.6 103.4c102.4-103.4 28.1-156-65.8-169.9c-3.3-.4-6.7-.8-10-1.3c3.4.4 6.7.9 10 1.3c64.1 7.1 133.6-15.1 153.2-80.7c5.9-19.9 15-138.9 15-155.5s-3.3-44.7-21.6-52.9c-15.8-7.1-40-14.9-103.2 29.8c-66.1 46.6-137.1 141.1-163.2 191.8"
-          fill="currentColor"
-        />
-      </symbol>
-      <use
-        href="#ai:fa7-brands:bluesky"
-      />
-        
-    </svg>
-     
-  </a>
-   
-  <a
     aria-label="Jaa kirjoitus "Vuosi 2026 on tekoälyn" LinkedInissä"
     data-astro-cid-luj3ckct=""
     href="https://www.linkedin.com/sharing/share-offsite/?url=https://laurilavanti.fi/blogi/vuosi-2026-on-tekoalyn"
@@ -145,6 +111,40 @@ exports[`<SocialShare /> > should render 1`] = `
       </symbol>
       <use
         href="#ai:fa7-brands:linkedin"
+      />
+        
+    </svg>
+     
+  </a>
+   
+  <a
+    aria-label="Jaa kirjoitus "Vuosi 2026 on tekoälyn" Facebookissa"
+    data-astro-cid-luj3ckct=""
+    href="https://www.facebook.com/sharer/sharer.php?u=https://laurilavanti.fi/blogi/vuosi-2026-on-tekoalyn"
+    rel="noopener noreferrer"
+    style="height:2.75rem;min-width:2.75rem;--colorsBluesky: #0060df;--colorsFacebook: #4267B2;--colorsLinkedin: #0E76A8;--colorsThreads: rgb(0, 0, 0);--sizes05: 0.5rem;--sizes15: 1.5rem;"
+    title="Jaa Facebookissa"
+  >
+     
+    <svg
+      class="facebook"
+      data-astro-cid-luj3ckct="true"
+      data-icon="fa7-brands:facebook"
+      height="1em"
+      width="1em"
+    >
+         
+      <symbol
+        id="ai:fa7-brands:facebook"
+        viewBox="0 0 640 640"
+      >
+        <path
+          d="M576 320c0-141.4-114.6-256-256-256S64 178.6 64 320c0 120 82.7 220.8 194.2 248.5V398.2h-52.8V320h52.8v-33.7c0-87.1 39.4-127.5 125-127.5c16.2 0 44.2 3.2 55.7 6.4V236c-6-.6-16.5-1-29.6-1c-42 0-58.2 15.9-58.2 57.2V320h83.6l-14.4 78.2H351v175.9C477.8 558.8 576 450.9 576 320"
+          fill="currentColor"
+        />
+      </symbol>
+      <use
+        href="#ai:fa7-brands:facebook"
       />
         
     </svg>

--- a/tests/__snapshots__/components/SocialShare.spec.ts.snap
+++ b/tests/__snapshots__/components/SocialShare.spec.ts.snap
@@ -4,23 +4,62 @@ exports[`<SocialShare /> > should render 1`] = `
 <aside
   aria-label="Kirjoituksen "Vuosi 2026 on tekoälyn" jakaminen sosiaalisessa mediassa"
   data-astro-cid-luj3ckct=""
-  style="--colorsBluesky: #0060df;--colorsFacebook: #4267B2;--colorsLinkedin: #0E76A8;--colorsThreads: rgb(0, 0, 0);--sizes05: 0.5rem;--sizes15: 1.5rem;"
+  style="--colorsBluesky: #0060df;--colorsFacebook: #4267B2;--colorsLinkedin: #0E76A8;--colorsMastodon: #6363ff;--colorsThreads: rgb(0, 0, 0);--sizes05: 0.5rem;--sizes15: 1.5rem;"
 >
    
   <span
     class="share"
     data-astro-cid-luj3ckct=""
-    style="--colorsBluesky: #0060df;--colorsFacebook: #4267B2;--colorsLinkedin: #0E76A8;--colorsThreads: rgb(0, 0, 0);--sizes05: 0.5rem;--sizes15: 1.5rem;"
+    style="--colorsBluesky: #0060df;--colorsFacebook: #4267B2;--colorsLinkedin: #0E76A8;--colorsMastodon: #6363ff;--colorsThreads: rgb(0, 0, 0);--sizes05: 0.5rem;--sizes15: 1.5rem;"
   >
     Jaa:
   </span>
+   
+  <a
+    aria-label="Jaa kirjoitus "Vuosi 2026 on tekoälyn" Mastodonissa"
+    data-astro-cid-luj3ckct=""
+    data-instance-prompt="Anna Mastodon-instanssisi (esim. mastodon.social):"
+    data-share-text="Lue "Vuosi 2026 on tekoälyn", jonka @laurilavanti@mastodon.social kirjoitti
+
+https://laurilavanti.fi/blogi/vuosi-2026-on-tekoalyn"
+    href="https://mastodon.social/share?text=Lue%20%22Vuosi%202026%20on%20teko%C3%A4lyn%22%2C%20jonka%20%40laurilavanti%40mastodon.social%20kirjoitti%0A%0Ahttps%3A%2F%2Flaurilavanti.fi%2Fblogi%2Fvuosi-2026-on-tekoalyn"
+    id="mastodon-share"
+    rel="noopener noreferrer"
+    style="height:2.75rem;min-width:2.75rem;--colorsBluesky: #0060df;--colorsFacebook: #4267B2;--colorsLinkedin: #0E76A8;--colorsMastodon: #6363ff;--colorsThreads: rgb(0, 0, 0);--sizes05: 0.5rem;--sizes15: 1.5rem;"
+    title="Jaa Mastodonissa"
+  >
+     
+    <svg
+      class="mastodon"
+      data-astro-cid-luj3ckct="true"
+      data-icon="fa7-brands:mastodon"
+      height="1em"
+      width="1em"
+    >
+         
+      <symbol
+        id="ai:fa7-brands:mastodon"
+        viewBox="0 0 640 640"
+      >
+        <path
+          d="M529 243.1c0-97.2-63.7-125.7-63.7-125.7c-62.5-28.7-228.6-28.4-290.5 0c0 0-63.7 28.5-63.7 125.7c0 115.7-6.6 259.4 105.6 289.1c40.5 10.7 75.3 13 103.3 11.4c50.8-2.8 79.3-18.1 79.3-18.1l-1.7-36.9s-36.3 11.4-77.1 10.1c-40.4-1.4-83-4.4-89.6-54c-.6-4.6-.9-9.3-.9-13.9c85.6 20.9 158.7 9.1 178.7 6.7c56.1-6.7 105-41.3 111.2-72.9c9.8-49.8 9-121.5 9-121.5zm-75.1 125.2h-46.6V254.1c0-49.7-64-51.6-64 6.9v62.5H297V261c0-58.5-64-56.6-64-6.9v114.2h-46.7c0-122.1-5.2-147.9 18.4-175c25.9-28.9 79.8-30.8 103.8 6.1l11.6 19.5l11.6-19.5c24.1-37.1 78.1-34.8 103.8-6.1c23.7 27.3 18.4 53 18.4 175"
+          fill="currentColor"
+        />
+      </symbol>
+      <use
+        href="#ai:fa7-brands:mastodon"
+      />
+        
+    </svg>
+     
+  </a>
    
   <a
     aria-label="Jaa kirjoitus "Vuosi 2026 on tekoälyn" Blueskyssa"
     data-astro-cid-luj3ckct=""
     href="https://bsky.app/intent/compose?text=Lue%20%22Vuosi%202026%20on%20teko%C3%A4lyn%22%2C%20jonka%20%40laurilavanti.fi%20kirjoitti%0A%0Ahttps%3A%2F%2Flaurilavanti.fi%2Fblogi%2Fvuosi-2026-on-tekoalyn"
     rel="noopener noreferrer"
-    style="height:2.75rem;min-width:2.75rem;--colorsBluesky: #0060df;--colorsFacebook: #4267B2;--colorsLinkedin: #0E76A8;--colorsThreads: rgb(0, 0, 0);--sizes05: 0.5rem;--sizes15: 1.5rem;"
+    style="height:2.75rem;min-width:2.75rem;--colorsBluesky: #0060df;--colorsFacebook: #4267B2;--colorsLinkedin: #0E76A8;--colorsMastodon: #6363ff;--colorsThreads: rgb(0, 0, 0);--sizes05: 0.5rem;--sizes15: 1.5rem;"
     title="Jaa Blueskyssa"
   >
      
@@ -54,7 +93,7 @@ exports[`<SocialShare /> > should render 1`] = `
     data-astro-cid-luj3ckct=""
     href="https://threads.com/intent/post?text=Lue%20%22Vuosi%202026%20on%20teko%C3%A4lyn%22%2C%20jonka%20%40laurilavanti%20kirjoitti%0A%0Ahttps%3A%2F%2Flaurilavanti.fi%2Fblogi%2Fvuosi-2026-on-tekoalyn"
     rel="noopener noreferrer"
-    style="height:2.75rem;min-width:2.75rem;--colorsBluesky: #0060df;--colorsFacebook: #4267B2;--colorsLinkedin: #0E76A8;--colorsThreads: rgb(0, 0, 0);--sizes05: 0.5rem;--sizes15: 1.5rem;"
+    style="height:2.75rem;min-width:2.75rem;--colorsBluesky: #0060df;--colorsFacebook: #4267B2;--colorsLinkedin: #0E76A8;--colorsMastodon: #6363ff;--colorsThreads: rgb(0, 0, 0);--sizes05: 0.5rem;--sizes15: 1.5rem;"
     title="Jaa Threadsissä"
   >
      
@@ -88,7 +127,7 @@ exports[`<SocialShare /> > should render 1`] = `
     data-astro-cid-luj3ckct=""
     href="https://www.linkedin.com/sharing/share-offsite/?url=https://laurilavanti.fi/blogi/vuosi-2026-on-tekoalyn"
     rel="noopener noreferrer"
-    style="height:2.75rem;min-width:2.75rem;--colorsBluesky: #0060df;--colorsFacebook: #4267B2;--colorsLinkedin: #0E76A8;--colorsThreads: rgb(0, 0, 0);--sizes05: 0.5rem;--sizes15: 1.5rem;"
+    style="height:2.75rem;min-width:2.75rem;--colorsBluesky: #0060df;--colorsFacebook: #4267B2;--colorsLinkedin: #0E76A8;--colorsMastodon: #6363ff;--colorsThreads: rgb(0, 0, 0);--sizes05: 0.5rem;--sizes15: 1.5rem;"
     title="Jaa LinkedInissä"
   >
      
@@ -122,7 +161,7 @@ exports[`<SocialShare /> > should render 1`] = `
     data-astro-cid-luj3ckct=""
     href="https://www.facebook.com/sharer/sharer.php?u=https://laurilavanti.fi/blogi/vuosi-2026-on-tekoalyn"
     rel="noopener noreferrer"
-    style="height:2.75rem;min-width:2.75rem;--colorsBluesky: #0060df;--colorsFacebook: #4267B2;--colorsLinkedin: #0E76A8;--colorsThreads: rgb(0, 0, 0);--sizes05: 0.5rem;--sizes15: 1.5rem;"
+    style="height:2.75rem;min-width:2.75rem;--colorsBluesky: #0060df;--colorsFacebook: #4267B2;--colorsLinkedin: #0E76A8;--colorsMastodon: #6363ff;--colorsThreads: rgb(0, 0, 0);--sizes05: 0.5rem;--sizes15: 1.5rem;"
     title="Jaa Facebookissa"
   >
      

--- a/tests/__snapshots__/components/SocialShare.spec.ts.snap
+++ b/tests/__snapshots__/components/SocialShare.spec.ts.snap
@@ -18,7 +18,7 @@ exports[`<SocialShare /> > should render 1`] = `
   <a
     aria-label="Jaa kirjoitus "Vuosi 2026 on tekoälyn" Blueskyssa"
     data-astro-cid-luj3ckct=""
-    href="https://bsky.app/intent/compose?text=Vuosi%202026%20on%20teko%C3%A4lyn%20https://laurilavanti.fi/blogi/vuosi-2026-on-tekoalyn"
+    href="https://bsky.app/intent/compose?text=Lue%20%22Vuosi%202026%20on%20teko%C3%A4lyn%22%2C%20jonka%20%40laurilavanti.fi%20kirjoitti%0A%0Ahttps%3A%2F%2Flaurilavanti.fi%2Fblogi%2Fvuosi-2026-on-tekoalyn"
     rel="noopener noreferrer"
     style="height:2.75rem;min-width:2.75rem;--colorsBluesky: #0060df;--colorsFacebook: #4267B2;--colorsLinkedin: #0E76A8;--colorsThreads: rgb(0, 0, 0);--sizes05: 0.5rem;--sizes15: 1.5rem;"
     title="Jaa Blueskyssa"
@@ -52,7 +52,7 @@ exports[`<SocialShare /> > should render 1`] = `
   <a
     aria-label="Jaa kirjoitus "Vuosi 2026 on tekoälyn" Threadsissä"
     data-astro-cid-luj3ckct=""
-    href="https://threads.com/intent/post?text=Vuosi%202026%20on%20teko%C3%A4lyn%20https://laurilavanti.fi/blogi/vuosi-2026-on-tekoalyn"
+    href="https://threads.com/intent/post?text=Lue%20%22Vuosi%202026%20on%20teko%C3%A4lyn%22%2C%20jonka%20%40laurilavanti%20kirjoitti%0A%0Ahttps%3A%2F%2Flaurilavanti.fi%2Fblogi%2Fvuosi-2026-on-tekoalyn"
     rel="noopener noreferrer"
     style="height:2.75rem;min-width:2.75rem;--colorsBluesky: #0060df;--colorsFacebook: #4267B2;--colorsLinkedin: #0E76A8;--colorsThreads: rgb(0, 0, 0);--sizes05: 0.5rem;--sizes15: 1.5rem;"
     title="Jaa Threadsissä"

--- a/tests/e2e/blogPostPage.spec.ts-snapshots/Blog-Post-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/blogPostPage.spec.ts-snapshots/Blog-Post-Page-should-match-aria-snapshot-1.aria.yml
@@ -2,6 +2,8 @@
   - heading "Sote on hyvinvointiyhteiskunnan kulmakivi" [level=1]
   - complementary "Kirjoituksen Sote on hyvinvointiyhteiskunnan kulmakivi meta-tiedot":
     - time: /\d+\.\d+\.\d+/
+    - text: 2 min lukuaika
+    - time: "/Päivitetty: \\d+\\.\\d+\\.\\d+/"
     - list:
       - listitem:
         - link /Aluevaalit \d+/:
@@ -83,17 +85,20 @@
       - emphasis: "/Julkaistu myös: Länsiväylä, 5\\. tammikuuta \\d+\\./"
     - complementary "Kirjoituksen Sote on hyvinvointiyhteiskunnan kulmakivi sosiaalisen median jakolinkit":
       - text: "Jaa:"
-      - link "Jaa kirjoitus \"Sote on hyvinvointiyhteiskunnan kulmakivi\" Facebookissa":
-        - /url: https://www.facebook.com/sharer/sharer.php?u=https://laurilavanti.fi/fi/blog/10/sote-on-hyvinvointiyhteiskunnan-kulmakivi/
-        - img
-      - link "Jaa kirjoitus \"Sote on hyvinvointiyhteiskunnan kulmakivi\" Threadsissä":
-        - /url: https://threads.com/intent/post?text=Sote%20on%20hyvinvointiyhteiskunnan%20kulmakivi%20https://laurilavanti.fi/fi/blog/10/sote-on-hyvinvointiyhteiskunnan-kulmakivi/
+      - link "Jaa kirjoitus \"Sote on hyvinvointiyhteiskunnan kulmakivi\" Mastodonissa":
+        - /url: https://mastodon.social/share?text=Lue%20%22Sote%20on%20hyvinvointiyhteiskunnan%20kulmakivi%22%2C%20jonka%20%40laurilavanti%40mastodon.social%20kirjoitti%0A%0Ahttps%3A%2F%2Flaurilavanti.fi%2Ffi%2Fblog%2F10%2Fsote-on-hyvinvointiyhteiskunnan-kulmakivi%2F
         - img
       - link "Jaa kirjoitus \"Sote on hyvinvointiyhteiskunnan kulmakivi\" Blueskyssa":
-        - /url: https://bsky.app/intent/compose?text=Sote%20on%20hyvinvointiyhteiskunnan%20kulmakivi%20https://laurilavanti.fi/fi/blog/10/sote-on-hyvinvointiyhteiskunnan-kulmakivi/
+        - /url: https://bsky.app/intent/compose?text=Lue%20%22Sote%20on%20hyvinvointiyhteiskunnan%20kulmakivi%22%2C%20jonka%20%40laurilavanti.fi%20kirjoitti%0A%0Ahttps%3A%2F%2Flaurilavanti.fi%2Ffi%2Fblog%2F10%2Fsote-on-hyvinvointiyhteiskunnan-kulmakivi%2F
+        - img
+      - link "Jaa kirjoitus \"Sote on hyvinvointiyhteiskunnan kulmakivi\" Threadsissä":
+        - /url: https://threads.com/intent/post?text=Lue%20%22Sote%20on%20hyvinvointiyhteiskunnan%20kulmakivi%22%2C%20jonka%20%40laurilavanti%20kirjoitti%0A%0Ahttps%3A%2F%2Flaurilavanti.fi%2Ffi%2Fblog%2F10%2Fsote-on-hyvinvointiyhteiskunnan-kulmakivi%2F
         - img
       - link "Jaa kirjoitus \"Sote on hyvinvointiyhteiskunnan kulmakivi\" LinkedInissä":
         - /url: https://www.linkedin.com/sharing/share-offsite/?url=https://laurilavanti.fi/fi/blog/10/sote-on-hyvinvointiyhteiskunnan-kulmakivi/
+        - img
+      - link "Jaa kirjoitus \"Sote on hyvinvointiyhteiskunnan kulmakivi\" Facebookissa":
+        - /url: https://www.facebook.com/sharer/sharer.php?u=https://laurilavanti.fi/fi/blog/10/sote-on-hyvinvointiyhteiskunnan-kulmakivi/
         - img
     - heading "Muita kirjoituksia" [level=2]
     - list:


### PR DESCRIPTION
> This PR containes AI-generated code. The author has reviewed and is responsible for all AI-generated content.

## Summary
- Expose Bluesky/Threads/Mastodon handle constants in `src/content/person.ts`
- Pre-tag author in Bluesky/Threads/Mastodon share text using new templated format (en/fi/sv)
- Add Mastodon share button with viewer-instance prompt; no-JS fallback to `mastodon.social`
- Reorder buttons to match footer canonical order: Mastodon, Bluesky, Threads, LinkedIn, Facebook

## Test plan
- [ ] `npm run check`
- [ ] `npm run lint`
- [ ] `npm run test -- SocialShare`
- [ ] Manual: button order, Mastodon `prompt()` + `localStorage` cache, no-JS fallback, fi/en/sv share text and aria-labels