### PR TITLE
feat(content): blog post #63 vaihdavihreisiin-kampanja (fi/sv/en)

### DIFF
--- a/src/pages/en/blog/63/switch-to-greens-campaign/index.mdx
+++ b/src/pages/en/blog/63/switch-to-greens-campaign/index.mdx
@@ -1,0 +1,69 @@
+---
+layout: '../../../../../layouts/PostLayout.astro'
+id: 63
+slug: 'switch-to-greens-campaign'
+lang: 'en'
+title: 'How does it feel to be in a party where you don''t have to compromise on your values?'
+pageTitle: 'Liberal, welcome home to the Greens'
+description: 'The vaihdavihreisiin.fi campaign invites liberals and social liberals to join the Finnish Greens — the party where you don''t have to compromise on your values.'
+publishDate: '2026-06-12'
+updatedDate: '2026-06-12'
+tags:
+  - economy
+  - green-party
+  - freedom
+  - national-politics
+heroImage: markkinavihreiden-kutsu-liberaali-tervetuloa-kotiin
+alt: 'Market Greens'' invitation: Liberal, welcome home — image from the vaihdavihreisiin.fi campaign'
+faq:
+  - q: 'What is the vaihdavihreisiin.fi campaign?'
+    a: 'Vaihdavihreisiin.fi is a campaign built by dozens of active market-green volunteers that lowers the bar for switching from the National Coalition Party to the Greens. It launched on 5 June 2026, alongside the Coalition Party congress, and published a website, a Market-Green Manifesto, and an open WhatsApp group.'
+  - q: 'What does "market green" mean?'
+    a: 'A market green believes the market economy is the most effective known way to allocate resources — but only when externalities are priced in, competition is fair, and pollution has a cost. Green economic policy shifts the tax burden from work to harms; it does not seek to grow the public sector''s share.'
+  - q: 'Why are the Greens a better fit for a liberal than the Coalition Party?'
+    a: 'The Coalition Party has capitulated to its conservative wing on women''s rights, education, and human rights. In the Greens, a liberal does not have to explain their actions or vote along a line set by conservatives — defending nature and human rights is core to the party.'
+  - q: 'What at the Coalition Party congress 2026 triggered the campaign?'
+    a: 'The Coalition Party continued a line in which conservatives set the party''s direction. That closed the door for blue-green liberals and social liberals. Finland''s party field needs at least one genuinely social-liberal alternative, and vaihdavihreisiin.fi provides it.'
+---
+
+import BlockQuote from '../../../../../components/body/BlockQuote.astro'
+import SmartLink from '../../../../../components/SmartLink.astro'
+import H2 from '../../../../../components/H2.astro'
+import H3 from '../../../../../components/H3.astro'
+import LI from '../../../../../components/LI.astro'
+import Paragraph from '../../../../../components/Paragraph.astro'
+import UL from '../../../../../components/UL.astro'
+
+export const components = { blockquote: BlockQuote, a: SmartLink, h2: H2, h3: H3, p: Paragraph, ul: UL, li: LI }
+
+On Friday we launched, in honour of the National Coalition Party's congress, the [vaihdavihreisiin.fi](https://vaihdavihreisiin.fi) ("switch to the Greens") campaign, whose aim is to lower the bar for switching from the Coalition Party (and from voting for it) to the Greens. The campaign has been built together with dozens of active Green economic experts. One part of the campaign is to highlight market-green voices, and the names attached include [Osmo Soininvaara](https://www.soininvaara.fi/2026/06/06/vihreat-ja-markkinatalous-1/), Atte Harjanne, Tuuli Kousa, and Kalle Euro.
+
+## How did the campaign start?
+
+The campaign traces back to May 2026, the week before the Green Party congress, when I founded the WhatsApp group "Vihreät sosiaaliliberaalit yhdistykää" ("Green social liberals, unite"). Behind it was the experience that the party's social liberals had been scattered and underrepresented in recent party-internal debate, while other currents were ever more loudly on display. Others noticed the same, including [Heikki Pursiainen](https://www.facebook.com/share/p/17WqESV7QD/?mibextid=wwXIfr), who criticised our campaign for exactly that point. (Pursiainen is right on that count — it is precisely why we made the campaign. He did, however, miss in his critique that the Greens [have](https://www.is.fi/politiikka/art-2000012002979.html) [had](https://www.orastynkkynen.fi/puoli-miljardia-vuodessa-yritystuista-ja-haittaveroista/) [several visible economic openings](https://www.iltalehti.fi/politiikka/a/e784b036-caf5-436a-a569-7a4746cec8ae) during 2026.) As someone for whom the Greens have been represented above all by figures like Jyrki Kasvi and Osmo Soininvaara, I was looking for a change.
+
+I was clearly not the only one thinking this way. Within the first days, more than a hundred like-minded Greens joined the group. Since then the discussion has continued almost without pause day after day. The group's stated shared goal is to strengthen the Greens' position in the Finnish party field especially on economic questions, where the Coalition Party has had it far too easy. The Greens' economic lines have, despite the image, been very market-friendly. Or as Sofia Virta said at the start of her term as party chair: ["The Greens are Finland's leading market-liberal party"](https://www.hs.fi/politiikka/art-2000009741581.html).
+
+In the group also grew the idea of creating a site for other social liberals, where we explain why the Greens are the best option for them. We also wrote the Market-Green Manifesto, which without compromise describes the Greens' core values. It also makes clear how those values connect to liberalism. It is worth a [read](https://vaihdavihreisiin.fi/).
+
+The site and the manifesto were ready right on time, and on Friday 5 June 2026 the [vaihdavihreisiin.fi](https://vaihdavihreisiin.fi) campaign launched alongside the Coalition Party congress.
+
+The campaign has received an enormous amount of positive feedback, from the right, the left, and the centre — and from non-voters. Many people have joined our open WhatsApp group, and thousands have visited the site since launch. We were clearly not the only ones who think expanding the Greens toward the right side of the political compass is a good idea. We even drew support from [Paavo Arhinmäki](https://www.facebook.com/share/p/1EPdARdS9P/?mibextid=wwXIfr). [Verde magazine also covered the campaign](https://www.verdelehti.fi/2026/06/11/markkinavihreat-tavoittelevat-kokoomuksen-liberaaleja-kampanja-jakaa-vihreita/).
+
+[Suomen Kuvalehti's recent analysis](https://suomenkuvalehti.fi/paajutut/vuosi-vaaleihin-sk-selvitti-miten-aanestajat-ovat-liikkuneet-sdp-keraa-kannatusta-kaikkialta/) confirmed that the Greens have been gaining support from the right. To the left we have been losing votes, even though the party has been communicating strongly on themes typically associated with the left. There was clearly demand for market-green communication.
+
+Finland's party field needs at least one genuinely social-liberal alternative. The Coalition Party could have been one, but by now it is crystal clear to everyone that the door is, for the time being, closed. So the options left for blue-green liberals are to vote in the Coalition Party along a line set by conservatives — [or face the consequences](https://www.hs.fi/politiikka/art-2000012055167.html). I would much rather see all of you voting in line with your values, in the Greens.
+
+## Why switch to the Greens?
+
+The Greens' shared values are the protection of nature and the environment, and human rights. It is therefore in the interest of both the environment and human rights that we grow both from the left and from the right. Our support was at its peak under Ville Niinistö's chairmanship, when the Sipilä government made historically short-sighted cuts to education. Back then it was not about us being the best left-wing party. It was about being the best education party. The current Coalition-led government is now pursuing the same kind of policy as Sipilä's.
+
+In the Greens you may vote for women's rights and for the defence of nature and animals. In the Greens education promises are kept. It is worth asking yourself: how would it feel to be in a party where you do not have to explain your actions?
+
+Lauri Lavanti
+
+*The author is a Green municipal councillor in Kirkkonummi and one of the people behind the [vaihdavihreisiin.fi](https://vaihdavihreisiin.fi) campaign. Liberal and social liberal.*
+
+## Where can I read more about market-green economics?
+
+I have written about my speech and amendment proposal at the congress in the blog post [Greens – The True Defenders of the Market Economy](/en/blog/62/greens-the-true-defenders-of-the-market-economy/). All my economy-related writing is in the [economy category](/en/category/economy), and all Greens-related posts are in the [green party category](/en/category/green-party).

--- a/src/pages/en/blog/63/switch-to-greens-campaign/index.mdx
+++ b/src/pages/en/blog/63/switch-to-greens-campaign/index.mdx
@@ -17,13 +17,13 @@ heroImage: markkinavihreiden-kutsu-liberaali-tervetuloa-kotiin
 alt: 'Market Greens'' invitation: Liberal, welcome home — image from the vaihdavihreisiin.fi campaign'
 faq:
   - q: 'What is the vaihdavihreisiin.fi campaign?'
-    a: 'Vaihdavihreisiin.fi is a campaign built by dozens of active market-green volunteers that lowers the bar for switching from the National Coalition Party to the Greens. It launched on 5 June 2026, alongside the Coalition Party congress, and published a website, a Market-Green Manifesto, and an open WhatsApp group.'
+    a: 'Vaihdavihreisiin.fi is a campaign built by dozens of active market-green volunteers that lowers the bar for liberals to switch to the Greens. It launched on 5 June 2026, alongside the Coalition Party congress, and published a website, a Market-Green Manifesto, and an open WhatsApp group.'
   - q: 'What does "market green" mean?'
     a: 'A market green believes the market economy is the most effective known way to allocate resources — but only when externalities are priced in, competition is fair, and pollution has a cost. Green economic policy shifts the tax burden from work to harms; it does not seek to grow the public sector''s share.'
   - q: 'Why are the Greens a better fit for a liberal than the Coalition Party?'
     a: 'The Coalition Party has capitulated to its conservative wing on women''s rights, education, and human rights. In the Greens, a liberal does not have to explain their actions or vote along a line set by conservatives — defending nature and human rights is core to the party.'
   - q: 'What at the Coalition Party congress 2026 triggered the campaign?'
-    a: 'The Coalition Party continued a line in which conservatives set the party''s direction. That closed the door for blue-green liberals and social liberals. Finland''s party field needs at least one genuinely social-liberal alternative, and vaihdavihreisiin.fi provides it.'
+    a: 'The Coalition Party continued a line in which conservatives set the party''s direction. That closed the door for blue-green liberals and social liberals. Finland''s party field needs at least one genuinely social-liberal alternative, and the Greens provide it.'
 ---
 
 import BlockQuote from '../../../../../components/body/BlockQuote.astro'
@@ -36,7 +36,7 @@ import UL from '../../../../../components/UL.astro'
 
 export const components = { blockquote: BlockQuote, a: SmartLink, h2: H2, h3: H3, p: Paragraph, ul: UL, li: LI }
 
-On Friday we launched, in honour of the National Coalition Party's congress, the [vaihdavihreisiin.fi](https://vaihdavihreisiin.fi) ("switch to the Greens") campaign, whose aim is to lower the bar for switching from the Coalition Party (and from voting for it) to the Greens. The campaign has been built together with dozens of active Green economic experts. One part of the campaign is to highlight market-green voices, and the names attached include [Osmo Soininvaara](https://www.soininvaara.fi/2026/06/06/vihreat-ja-markkinatalous-1/), Atte Harjanne, Tuuli Kousa, and Kalle Euro.
+On Friday we launched, in honour of the National Coalition Party's congress, the [vaihdavihreisiin.fi](https://vaihdavihreisiin.fi) ("switch to the Greens") campaign, whose aim is to lower the bar for switching from the Coalition Party (and from voting for it) to the Greens. The campaign has been built together with dozens of active Green economic experts. One part of the campaign is to highlight market-green voices, and the names attached include [Osmo Soininvaara](https://www.soininvaara.fi/2026/06/06/vihreat-ja-markkinatalous-1/), Atte Harjanne, Tuuli Kousa, and [Kalle Euro](https://www.tahdotaan-parempaa-maailmaa.com/l/mika-vetaa-vihreisiin/).
 
 ## How did the campaign start?
 
@@ -48,9 +48,9 @@ In the group also grew the idea of creating a site for other social liberals, wh
 
 The site and the manifesto were ready right on time, and on Friday 5 June 2026 the [vaihdavihreisiin.fi](https://vaihdavihreisiin.fi) campaign launched alongside the Coalition Party congress.
 
-The campaign has received an enormous amount of positive feedback, from the right, the left, and the centre — and from non-voters. Many people have joined our open WhatsApp group, and thousands have visited the site since launch. We were clearly not the only ones who think expanding the Greens toward the right side of the political compass is a good idea. We even drew support from [Paavo Arhinmäki](https://www.facebook.com/share/p/1EPdARdS9P/?mibextid=wwXIfr). [Verde magazine also covered the campaign](https://www.verdelehti.fi/2026/06/11/markkinavihreat-tavoittelevat-kokoomuksen-liberaaleja-kampanja-jakaa-vihreita/).
+The campaign has received an enormous amount of positive feedback, from the right, the left, and the centre — and from non-voters. Many people have joined our open WhatsApp group, and thousands have visited the site since launch. We were clearly not the only ones who think expanding the Greens toward the right side of the political compass is a good idea. We even drew support from [Paavo Arhinmäki](https://www.facebook.com/share/p/1EPdARdS9P/?mibextid=wwXIfr). [Helsingin Sanomat](https://www.hs.fi/politiikka/art-2000012062451.html) and [Verde magazine](https://www.verdelehti.fi/2026/06/11/markkinavihreat-tavoittelevat-kokoomuksen-liberaaleja-kampanja-jakaa-vihreita/) also covered the campaign.
 
-[Suomen Kuvalehti's recent analysis](https://suomenkuvalehti.fi/paajutut/vuosi-vaaleihin-sk-selvitti-miten-aanestajat-ovat-liikkuneet-sdp-keraa-kannatusta-kaikkialta/) confirmed that the Greens have been gaining support from the right. To the left we have been losing votes, even though the party has been communicating strongly on themes typically associated with the left. There was clearly demand for market-green communication.
+[Suomen Kuvalehti's recent analysis](https://suomenkuvalehti.fi/paajutut/vuosi-vaaleihin-sk-selvitti-miten-aanestajat-ovat-liikkuneet-sdp-keraa-kannatusta-kaikkialta/) confirmed that the Greens have been gaining support from the right. To the left we have been losing votes, even though the party has been communicating strongly on themes typically associated with the left (whether these themes genuinely belong to left-wing politics is, of course, a question on which reasonable people disagree). There was clearly demand for market-green communication.
 
 Finland's party field needs at least one genuinely social-liberal alternative. The Coalition Party could have been one, but by now it is crystal clear to everyone that the door is, for the time being, closed. So the options left for blue-green liberals are to vote in the Coalition Party along a line set by conservatives — [or face the consequences](https://www.hs.fi/politiikka/art-2000012055167.html). I would much rather see all of you voting in line with your values, in the Greens.
 

--- a/src/pages/en/blog/63/switch-to-greens-campaign/index.mdx
+++ b/src/pages/en/blog/63/switch-to-greens-campaign/index.mdx
@@ -50,7 +50,7 @@ The site and the manifesto were ready right on time, and on Friday 5 June 2026 t
 
 The campaign has received an enormous amount of positive feedback, from the right, the left, and the centre — and from non-voters. Many people have joined our open WhatsApp group, and thousands have visited the site since launch. We were clearly not the only ones who think expanding the Greens toward the right side of the political compass is a good idea. We even drew support from [Paavo Arhinmäki](https://www.facebook.com/share/p/1EPdARdS9P/?mibextid=wwXIfr). [Helsingin Sanomat](https://www.hs.fi/politiikka/art-2000012062451.html) and [Verde magazine](https://www.verdelehti.fi/2026/06/11/markkinavihreat-tavoittelevat-kokoomuksen-liberaaleja-kampanja-jakaa-vihreita/) also covered the campaign.
 
-[Suomen Kuvalehti's recent analysis](https://suomenkuvalehti.fi/paajutut/vuosi-vaaleihin-sk-selvitti-miten-aanestajat-ovat-liikkuneet-sdp-keraa-kannatusta-kaikkialta/) confirmed that the Greens have been gaining support from the right. To the left we have been losing votes, even though the party has been communicating strongly on themes typically associated with the left (whether these themes genuinely belong to left-wing politics is, of course, a question on which reasonable people disagree). There was clearly demand for market-green communication.
+[Suomen Kuvalehti's recent analysis](https://suomenkuvalehti.fi/paajutut/vuosi-vaaleihin-sk-selvitti-miten-aanestajat-ovat-liikkuneet-sdp-keraa-kannatusta-kaikkialta/) confirmed that the Greens have been gaining support from the right. To the left we have been losing votes, even though the party has been communicating strongly on themes typically associated with the left (whether these themes genuinely belong to left-wing politics is, of course, a question on which one can easily disagree). There was clearly demand for market-green communication.
 
 Finland's party field needs at least one genuinely social-liberal alternative. The Coalition Party could have been one, but by now it is crystal clear to everyone that the door is, for the time being, closed. So the options left for blue-green liberals are to vote in the Coalition Party along a line set by conservatives — [or face the consequences](https://www.hs.fi/politiikka/art-2000012055167.html). I would much rather see all of you voting in line with your values, in the Greens.
 
@@ -59,10 +59,6 @@ Finland's party field needs at least one genuinely social-liberal alternative. T
 The Greens' shared values are the protection of nature and the environment, and human rights. It is therefore in the interest of both the environment and human rights that we grow both from the left and from the right. Our support was at its peak under Ville Niinistö's chairmanship, when the Sipilä government made historically short-sighted cuts to education. Back then it was not about us being the best left-wing party. It was about being the best education party. The current Coalition-led government is now pursuing the same kind of policy as Sipilä's.
 
 In the Greens you may vote for women's rights and for the defence of nature and animals. In the Greens education promises are kept. It is worth asking yourself: how would it feel to be in a party where you do not have to explain your actions?
-
-Lauri Lavanti
-
-*The author is a Green municipal councillor in Kirkkonummi and one of the people behind the [vaihdavihreisiin.fi](https://vaihdavihreisiin.fi) campaign. Liberal and social liberal.*
 
 ## Where can I read more about market-green economics?
 

--- a/src/pages/fi/blog/63/vaihdavihreisiin-kampanja/index.mdx
+++ b/src/pages/fi/blog/63/vaihdavihreisiin-kampanja/index.mdx
@@ -17,13 +17,13 @@ heroImage: markkinavihreiden-kutsu-liberaali-tervetuloa-kotiin
 alt: 'Markkinavihreiden kutsu: Liberaali, tervetuloa kotiin — vaihdavihreisiin.fi-kampanjan kuva'
 faq:
   - q: 'Mikä on vaihdavihreisiin.fi-kampanja?'
-    a: 'Vaihdavihreisiin.fi on markkinavihreiden kymmenien aktiivien tekemä kampanja, joka madaltaa kynnystä siirtyä Kokoomuksesta Vihreisiin. Kampanja käynnistyi 5.6.2026 samanaikaisesti Kokoomuksen puoluekokouksen kanssa ja julkaisi sivuston, Markkinavihreän manifestin sekä avoimen WhatsApp-ryhmän.'
+    a: 'Vaihdavihreisiin.fi on kymmenien aktiivisten markkinavihreiden tekemä kampanja, jonka tarkoitus on madaltaa liberaaleille kynnystä siirtyä Vihreisiin. Kampanja käynnistyi 5.6.2026 samanaikaisesti Kokoomuksen puoluekokouksen kanssa ja julkaisi sivuston, Markkinavihreän manifestin sekä avoimen WhatsApp-ryhmän.'
   - q: 'Mitä tarkoittaa markkinavihreä?'
     a: 'Markkinavihreä uskoo, että markkinatalous on tehokkain tunnettu tapa jakaa resursseja — mutta vain silloin, kun ulkoisvaikutukset on hinnoiteltu, kilpailu on reilua ja saastuttaminen maksaa. Vihreä talouspolitiikka siirtää verotuksen painopisteen työstä haittoihin, ei pyri kasvattamaan julkisen sektorin osuutta.'
   - q: 'Miksi Vihreät sopii liberaalille paremmin kuin Kokoomus?'
     a: 'Kokoomus on viime vuosina antautunut konservatiiveille naisten oikeuksissa, koulutuksessa ja ihmisoikeuksissa. Vihreissä liberaalin ei tarvitse selitellä tekojaan eikä äänestää konservatiivien päättämän kannan mukaan — luonnon ja ihmisoikeuksien puolustaminen on puolueen ydintä.'
   - q: 'Mikä Kokoomuksen puoluekokouksessa 2026 sai kampanjan liikkeelle?'
-    a: 'Kokoomus jatkoi linjaa, jossa konservatiivit määräävät puolueen suunnan. Tämä sulki oven sinivihreille liberaaleille ja sosiaaliliberaaleille. Suomen puoluekenttään tarvitaan vähintään yksi aidosti sosiaaliliberaali vaihtoehto, ja vaihdavihreisiin.fi tarjoaa sen.'
+    a: 'Kokoomus jatkoi linjaa, jossa konservatiivit määräävät puolueen suunnan. Tämä sulki oven sinivihreille liberaaleille ja sosiaaliliberaaleille. Suomen puoluekenttään tarvitaan vähintään yksi aidosti sosiaaliliberaali vaihtoehto, ja Vihreät tarjoaa sen.'
 ---
 
 import BlockQuote from '../../../../../components/body/BlockQuote.astro'
@@ -36,7 +36,7 @@ import UL from '../../../../../components/UL.astro'
 
 export const components = { blockquote: BlockQuote, a: SmartLink, h2: H2, h3: H3, p: Paragraph, ul: UL, li: LI }
 
-Julkaisimme perjantaina Kokoomuksen puoluekokouksen kunniaksi [vaihdavihreisiin.fi](https://vaihdavihreisiin.fi)-kampanjan, jonka tavoitteena on madaltaa kynnystä siirtyä Kokoomuksesta (ja sen äänestämisestä) Vihreisiin. Kampanjaa on ollut kanssani tekemässä kymmeniä aktiivisia Vihreitä talousosaajia. Yksi osa kampanjaa on nostaa markkinavihreitä toimijoita, johon nimensä ovat antaneet muun muassa [Osmo Soininvaara](https://www.soininvaara.fi/2026/06/06/vihreat-ja-markkinatalous-1/), Atte Harjanne, Tuuli Kousa ja Kalle Euro.
+Julkaisimme perjantaina Kokoomuksen puoluekokouksen kunniaksi [vaihdavihreisiin.fi](https://vaihdavihreisiin.fi)-kampanjan, jonka tavoitteena on madaltaa kynnystä siirtyä Kokoomuksesta (ja sen äänestämisestä) Vihreisiin. Kampanjaa on ollut kanssani tekemässä kymmeniä aktiivisia Vihreitä talousosaajia. Yksi osa kampanjaa on nostaa markkinavihreitä toimijoita, johon nimensä ovat antaneet muun muassa [Osmo Soininvaara](https://www.soininvaara.fi/2026/06/06/vihreat-ja-markkinatalous-1/), Atte Harjanne, Tuuli Kousa ja [Kalle Euro](https://www.tahdotaan-parempaa-maailmaa.com/l/mika-vetaa-vihreisiin/).
 
 ## Miten kampanja sai alkunsa?
 
@@ -48,9 +48,9 @@ Ryhmässä kehittyi myös ajatus perustaa muille sosiaaliliberaaleille sivusto, 
 
 Sivusto ja manifesti saatiinkin valmiiksi sopivasti, ja perjantaina 5.6.2026 alkoi [vaihdavihreisiin.fi](https://vaihdavihreisiin.fi)-kampanja samaan aikaan Kokoomuksen puoluekokouksen kanssa.
 
-Kampanja on saanut valtavasti positiivista palautetta, niin oikealta, vasemmalta kuin keskeltä ja nukkuvilta. Avoimeen WhatsApp-ryhmäämme on liittynyt runsaasti ihmisiä, ja tuhannet ovat käyneet sivuilla julkaisun jälkeen. Emme selkeästi olleet ainoita, joiden mielestä Vihreiden laajentaminen kohti nelikentän oikeaa reunaa on hyvä idea. Saimme kannatusta jopa [Paavo Arhinmäeltä](https://www.facebook.com/share/p/1EPdARdS9P/?mibextid=wwXIfr). Myös [Verde-lehti uutisoi kampanjasta](https://www.verdelehti.fi/2026/06/11/markkinavihreat-tavoittelevat-kokoomuksen-liberaaleja-kampanja-jakaa-vihreita/).
+Kampanja on saanut valtavasti positiivista palautetta, niin oikealta, vasemmalta kuin keskeltä ja nukkuvilta. Avoimeen WhatsApp-ryhmäämme on liittynyt runsaasti ihmisiä, ja tuhannet ovat käyneet sivuilla julkaisun jälkeen. Emme selkeästi olleet ainoita, joiden mielestä Vihreiden laajentaminen kohti nelikentän oikeaa reunaa on hyvä idea. Saimme kannatusta jopa [Paavo Arhinmäeltä](https://www.facebook.com/share/p/1EPdARdS9P/?mibextid=wwXIfr). Myös [Helsingin Sanomat](https://www.hs.fi/politiikka/art-2000012062451.html) ja [Verde](https://www.verdelehti.fi/2026/06/11/markkinavihreat-tavoittelevat-kokoomuksen-liberaaleja-kampanja-jakaa-vihreita/) uutisoivat kampanjasta.
 
-Vastikään [Suomen Kuvalehden selvityksessä](https://suomenkuvalehti.fi/paajutut/vuosi-vaaleihin-sk-selvitti-miten-aanestajat-ovat-liikkuneet-sdp-keraa-kannatusta-kaikkialta/) tulikin ilmi, että Vihreille on tullut kannatusta nimenomaan oikealta. Vasemmalle sitä on vuotanut, vaikka puolue on viestinyt viime vuosina voimakkaasti nimenomaan vasemmalle yhdistetyistä teemoista. Selkeästi markkinavihreälle viestinnälle olikin nyt tilausta.
+Vastikään [Suomen Kuvalehden selvityksessä](https://suomenkuvalehti.fi/paajutut/vuosi-vaaleihin-sk-selvitti-miten-aanestajat-ovat-liikkuneet-sdp-keraa-kannatusta-kaikkialta/) tulikin ilmi, että Vihreille on tullut kannatusta nimenomaan oikealta. Vasemmalle sitä on vuotanut, vaikka puolue on viestinyt viime vuosina voimakkaasti nimenomaan vasemmalle yhdistetyistä teemoista (kyseisten teemojen oikeasta kytköksestä vasemmistolaisempaan politiikkaan voi sitten perustellusti olla montaa eri mieltä). Selkeästi markkinavihreälle viestinnälle olikin nyt tilausta.
 
 Suomen puoluekenttään tarvitaankin vähintään yksi aidosti sosiaaliliberaali vaihtoehto. Kokoomus olisi voinut olla sellainen, mutta nyt viimeistään on jokaiselle päivänselvää, että se ovi on tällä haavaa suljettu. Täten sinivihreille liberaaleille jää vaihtoehdoiksi äänestää Kokoomuksessa konservatiivien päättämän kannan mukaan [tai kärsiä seurauksia](https://www.hs.fi/politiikka/art-2000012055167.html). Paljon mieluummin näkisinkin kaikki teidät äänestämässä arvojenne mukaisesti, Vihreissä.
 
@@ -60,10 +60,6 @@ Vihreiden yhteisiä arvoja ovat luonnon ja ympäristön suojelu sekä ihmisoikeu
 
 Vihreissä saa äänestää naisten oikeuksien ja luonnon sekä eläinten puolustamisen puolesta. Vihreissä koulutuslupauksista pidetään kiinni. Kannattaakin kysyä itseltään, miltä tuntuisi olla puolueessa, jossa ei tarvitse selitellä tekojaan?
 
-Lauri Lavanti
-
-*Kirjoittaja on Vihreiden kunnanvaltuutettu Kirkkonummella ja yksi [vaihdavihreisiin.fi](https://vaihdavihreisiin.fi)-kampanjan tekijöistä. Liberaali ja sosiaaliliberaali.*
-
-## Mistä lisää markkinavihreästä taloudesta?
+## Mistä saa lisää tietoa markkinavihreästä taloudesta?
 
 Olen kirjoittanut puoluekokouksessa pitämäni puheenvuoron ja muutosesityksen taustasta blogissa [Vihreät – Markkinatalouden aito puolustaja](/fi/blog/62/vihreat-markkinatalouden-aito-puolustaja/). Kaikki talouteen liittyvät kirjoitukseni löydät [talous-kategoriasta](/fi/category/economy), ja kaikki Vihreitä koskevat tekstit [vihreät-kategoriasta](/fi/category/green-party).

--- a/src/pages/fi/blog/63/vaihdavihreisiin-kampanja/index.mdx
+++ b/src/pages/fi/blog/63/vaihdavihreisiin-kampanja/index.mdx
@@ -1,0 +1,69 @@
+---
+layout: '../../../../../layouts/PostLayout.astro'
+id: 63
+slug: 'vaihdavihreisiin-kampanja'
+lang: 'fi'
+title: 'Miltä tuntuu olla puolueessa, jossa arvoista ei tarvitse tinkiä?'
+pageTitle: 'Liberaali, tervetuloa kotiin Vihreisiin'
+description: 'Vaihdavihreisiin.fi-kampanja kutsuu liberaalit ja sosiaaliliberaalit Vihreisiin — puolueeseen, jossa arvoista ei tarvitse tinkiä.'
+publishDate: '2026-06-12'
+updatedDate: '2026-06-12'
+tags:
+  - economy
+  - green-party
+  - freedom
+  - national-politics
+heroImage: markkinavihreiden-kutsu-liberaali-tervetuloa-kotiin
+alt: 'Markkinavihreiden kutsu: Liberaali, tervetuloa kotiin — vaihdavihreisiin.fi-kampanjan kuva'
+faq:
+  - q: 'Mikä on vaihdavihreisiin.fi-kampanja?'
+    a: 'Vaihdavihreisiin.fi on markkinavihreiden kymmenien aktiivien tekemä kampanja, joka madaltaa kynnystä siirtyä Kokoomuksesta Vihreisiin. Kampanja käynnistyi 5.6.2026 samanaikaisesti Kokoomuksen puoluekokouksen kanssa ja julkaisi sivuston, Markkinavihreän manifestin sekä avoimen WhatsApp-ryhmän.'
+  - q: 'Mitä tarkoittaa markkinavihreä?'
+    a: 'Markkinavihreä uskoo, että markkinatalous on tehokkain tunnettu tapa jakaa resursseja — mutta vain silloin, kun ulkoisvaikutukset on hinnoiteltu, kilpailu on reilua ja saastuttaminen maksaa. Vihreä talouspolitiikka siirtää verotuksen painopisteen työstä haittoihin, ei pyri kasvattamaan julkisen sektorin osuutta.'
+  - q: 'Miksi Vihreät sopii liberaalille paremmin kuin Kokoomus?'
+    a: 'Kokoomus on viime vuosina antautunut konservatiiveille naisten oikeuksissa, koulutuksessa ja ihmisoikeuksissa. Vihreissä liberaalin ei tarvitse selitellä tekojaan eikä äänestää konservatiivien päättämän kannan mukaan — luonnon ja ihmisoikeuksien puolustaminen on puolueen ydintä.'
+  - q: 'Mikä Kokoomuksen puoluekokouksessa 2026 sai kampanjan liikkeelle?'
+    a: 'Kokoomus jatkoi linjaa, jossa konservatiivit määräävät puolueen suunnan. Tämä sulki oven sinivihreille liberaaleille ja sosiaaliliberaaleille. Suomen puoluekenttään tarvitaan vähintään yksi aidosti sosiaaliliberaali vaihtoehto, ja vaihdavihreisiin.fi tarjoaa sen.'
+---
+
+import BlockQuote from '../../../../../components/body/BlockQuote.astro'
+import SmartLink from '../../../../../components/SmartLink.astro'
+import H2 from '../../../../../components/H2.astro'
+import H3 from '../../../../../components/H3.astro'
+import LI from '../../../../../components/LI.astro'
+import Paragraph from '../../../../../components/Paragraph.astro'
+import UL from '../../../../../components/UL.astro'
+
+export const components = { blockquote: BlockQuote, a: SmartLink, h2: H2, h3: H3, p: Paragraph, ul: UL, li: LI }
+
+Julkaisimme perjantaina Kokoomuksen puoluekokouksen kunniaksi [vaihdavihreisiin.fi](https://vaihdavihreisiin.fi)-kampanjan, jonka tavoitteena on madaltaa kynnystä siirtyä Kokoomuksesta (ja sen äänestämisestä) Vihreisiin. Kampanjaa on ollut kanssani tekemässä kymmeniä aktiivisia Vihreitä talousosaajia. Yksi osa kampanjaa on nostaa markkinavihreitä toimijoita, johon nimensä ovat antaneet muun muassa [Osmo Soininvaara](https://www.soininvaara.fi/2026/06/06/vihreat-ja-markkinatalous-1/), Atte Harjanne, Tuuli Kousa ja Kalle Euro.
+
+## Miten kampanja sai alkunsa?
+
+Kampanja juontaa juurensa toukokuuhun 2026, Vihreiden puoluekokousta edeltäneelle viikolle, kun perustin WhatsApp-ryhmän "Vihreät sosiaaliliberaalit yhdistykää". Taustalla oli kokemus siitä, että viime vuosina puolueen sosiaaliliberaalit ovat olleet hajallaan ja aliedustettuina, samaan aikaan kun muut suuntaukset ovat olleet entistä voimakkaammin näkyvillä. Saman ovat huomanneet muutkin, kuten [Heikki Pursiainen](https://www.facebook.com/share/p/17WqESV7QD/?mibextid=wwXIfr), joka kampanjaamme kritisoi nimenomaan tästä. (Pursiainen on kritiikissään tältä osin oikeassa, siksihän me kampanjan teimme. Hän jätti toki kritiikissään huomiotta, että Vihreiltä [on](https://www.is.fi/politiikka/art-2000012002979.html) [tullut](https://www.orastynkkynen.fi/puoli-miljardia-vuodessa-yritystuista-ja-haittaveroista/) [useita näkyviä avauksia](https://www.iltalehti.fi/politiikka/a/e784b036-caf5-436a-a569-7a4746cec8ae) taloudesta vuoden 2026 aikana). Ihmisenä, jolle Vihreitä ovat edustaneet erityisesti Jyrki Kasvin ja Osmo Soininvaaran kaltaiset henkilöt, kaipasin tilanteeseen muutosta.
+
+En selkeästi ollut ainoa, joka ajatteli näin. Ensimmäisten vuorokausien aikana ryhmään liittyi toista sataa samanhenkistä Vihreää. Siitä asti keskustelua on käyty lähes lakkaamatta päivästä toiseen. Ryhmän ääneen lausuttu jaettu tavoite on vahvistaa Vihreiden asemaa suomalaisessa puoluekentässä erityisesti talouskysymyksissä, joissa Kokoomus on päässyt viime vuodet aivan liian helpolla. Vihreiden talouslinjat ovat kuitenkin olleet, mielikuvista huolimatta, erittäin markkinamyönteisiä. Tai kuten Sofia Virta sanoi puheenjohtajakautensa alussa: ["Vihreät on Suomen johtava markkinaliberaali puolue"](https://www.hs.fi/politiikka/art-2000009741581.html).
+
+Ryhmässä kehittyi myös ajatus perustaa muille sosiaaliliberaaleille sivusto, jolla kerromme, minkä takia Vihreät on heille paras vaihtoehto. Kirjoitimme myös Markkinavihreän manifestin, jossa on kuvattuna tinkimättä Vihreiden ydinarvoja. Siitä selviää myös hyvin, miten ne liittyvät liberaaliuteen. Se kannattaa käydä [lukemassa](https://vaihdavihreisiin.fi/).
+
+Sivusto ja manifesti saatiinkin valmiiksi sopivasti, ja perjantaina 5.6.2026 alkoi [vaihdavihreisiin.fi](https://vaihdavihreisiin.fi)-kampanja samaan aikaan Kokoomuksen puoluekokouksen kanssa.
+
+Kampanja on saanut valtavasti positiivista palautetta, niin oikealta, vasemmalta kuin keskeltä ja nukkuvilta. Avoimeen WhatsApp-ryhmäämme on liittynyt runsaasti ihmisiä, ja tuhannet ovat käyneet sivuilla julkaisun jälkeen. Emme selkeästi olleet ainoita, joiden mielestä Vihreiden laajentaminen kohti nelikentän oikeaa reunaa on hyvä idea. Saimme kannatusta jopa [Paavo Arhinmäeltä](https://www.facebook.com/share/p/1EPdARdS9P/?mibextid=wwXIfr). Myös [Verde-lehti uutisoi kampanjasta](https://www.verdelehti.fi/2026/06/11/markkinavihreat-tavoittelevat-kokoomuksen-liberaaleja-kampanja-jakaa-vihreita/).
+
+Vastikään [Suomen Kuvalehden selvityksessä](https://suomenkuvalehti.fi/paajutut/vuosi-vaaleihin-sk-selvitti-miten-aanestajat-ovat-liikkuneet-sdp-keraa-kannatusta-kaikkialta/) tulikin ilmi, että Vihreille on tullut kannatusta nimenomaan oikealta. Vasemmalle sitä on vuotanut, vaikka puolue on viestinyt viime vuosina voimakkaasti nimenomaan vasemmalle yhdistetyistä teemoista. Selkeästi markkinavihreälle viestinnälle olikin nyt tilausta.
+
+Suomen puoluekenttään tarvitaankin vähintään yksi aidosti sosiaaliliberaali vaihtoehto. Kokoomus olisi voinut olla sellainen, mutta nyt viimeistään on jokaiselle päivänselvää, että se ovi on tällä haavaa suljettu. Täten sinivihreille liberaaleille jää vaihtoehdoiksi äänestää Kokoomuksessa konservatiivien päättämän kannan mukaan [tai kärsiä seurauksia](https://www.hs.fi/politiikka/art-2000012055167.html). Paljon mieluummin näkisinkin kaikki teidät äänestämässä arvojenne mukaisesti, Vihreissä.
+
+## Miksi vaihtaa Vihreisiin?
+
+Vihreiden yhteisiä arvoja ovat luonnon ja ympäristön suojelu sekä ihmisoikeudet. Onkin sekä ympäristön että ihmisoikeuksien etu, että kasvamme sekä vasemmalta että oikealta. Kannatuksemme olikin suurimmillaan Ville Niinistön puheenjohtajakaudella, kun Sipilän hallitus teki historiallisen lyhytnäköisiä koulutusleikkauksia. Kyse ei silloin ollut siitä, että olisimme olleet paras vasemmistopuolue. Kyse oli siitä, että olemme paras koulutuspuolue. Kokoomuksen johtama hallitus tekee nyt täysin samanlaista politiikkaa kuin Sipilänkin.
+
+Vihreissä saa äänestää naisten oikeuksien ja luonnon sekä eläinten puolustamisen puolesta. Vihreissä koulutuslupauksista pidetään kiinni. Kannattaakin kysyä itseltään, miltä tuntuisi olla puolueessa, jossa ei tarvitse selitellä tekojaan?
+
+Lauri Lavanti
+
+*Kirjoittaja on Vihreiden kunnanvaltuutettu Kirkkonummella ja yksi [vaihdavihreisiin.fi](https://vaihdavihreisiin.fi)-kampanjan tekijöistä. Liberaali ja sosiaaliliberaali.*
+
+## Mistä lisää markkinavihreästä taloudesta?
+
+Olen kirjoittanut puoluekokouksessa pitämäni puheenvuoron ja muutosesityksen taustasta blogissa [Vihreät – Markkinatalouden aito puolustaja](/fi/blog/62/vihreat-markkinatalouden-aito-puolustaja/). Kaikki talouteen liittyvät kirjoitukseni löydät [talous-kategoriasta](/fi/category/economy), ja kaikki Vihreitä koskevat tekstit [vihreät-kategoriasta](/fi/category/green-party).

--- a/src/pages/sv/blog/63/byt-till-de-grona-kampanj/index.mdx
+++ b/src/pages/sv/blog/63/byt-till-de-grona-kampanj/index.mdx
@@ -1,0 +1,69 @@
+---
+layout: '../../../../../layouts/PostLayout.astro'
+id: 63
+slug: 'byt-till-de-grona-kampanj'
+lang: 'sv'
+title: 'Hur känns det att vara i ett parti där man inte behöver kom­promissa med sina värderingar?'
+pageTitle: 'Liberal, välkommen hem till De gröna'
+description: 'Kampanjen vaihdavihreisiin.fi bjuder liberaler och socialliberaler att byta till De gröna — partiet där man inte behöver kompromissa med sina värderingar.'
+publishDate: '2026-06-12'
+updatedDate: '2026-06-12'
+tags:
+  - economy
+  - green-party
+  - freedom
+  - national-politics
+heroImage: markkinavihreiden-kutsu-liberaali-tervetuloa-kotiin
+alt: 'Marknadsgrönas inbjudan: Liberal, välkommen hem — bild från kampanjen vaihdavihreisiin.fi'
+faq:
+  - q: 'Vad är kampanjen vaihdavihreisiin.fi?'
+    a: 'Vaihdavihreisiin.fi är en kampanj byggd av dussintals aktiva marknadsgröna som sänker tröskeln för att byta från Samlingspartiet till De gröna. Kampanjen lanserades den 5 juni 2026 samtidigt som Samlingspartiets kongress och publicerade en webbplats, ett Marknadsgrönt manifest och en öppen WhatsApp-grupp.'
+  - q: 'Vad betyder marknadsgrön?'
+    a: 'En marknadsgrön anser att marknadsekonomin är det effektivaste kända sättet att fördela resurser — men bara när externa effekter är prissatta, konkurrensen är rättvis och förorening kostar. Grön ekonomisk politik flyttar skattetyngdpunkten från arbete till skador, inte att öka den offentliga sektorns andel.'
+  - q: 'Varför passar De gröna en liberal bättre än Samlingspartiet?'
+    a: 'Samlingspartiet har under de senaste åren kapitulerat för konservativa krafter i kvinnors rättigheter, utbildning och mänskliga rättigheter. I De gröna behöver en liberal inte förklara sina handlingar eller rösta enligt en konservativ linje — försvaret av naturen och mänskliga rättigheter är partiets kärna.'
+  - q: 'Vad i Samlingspartiets kongress 2026 utlöste kampanjen?'
+    a: 'Samlingspartiet fortsatte den linje där konservativa bestämmer partiets riktning. Det stängde dörren för blågröna liberaler och socialliberaler. Finlands partifält behöver minst ett verkligt socialliberalt alternativ, och vaihdavihreisiin.fi erbjuder det.'
+---
+
+import BlockQuote from '../../../../../components/body/BlockQuote.astro'
+import SmartLink from '../../../../../components/SmartLink.astro'
+import H2 from '../../../../../components/H2.astro'
+import H3 from '../../../../../components/H3.astro'
+import LI from '../../../../../components/LI.astro'
+import Paragraph from '../../../../../components/Paragraph.astro'
+import UL from '../../../../../components/UL.astro'
+
+export const components = { blockquote: BlockQuote, a: SmartLink, h2: H2, h3: H3, p: Paragraph, ul: UL, li: LI }
+
+Vi lanserade i fredags, till ära för Samlingspartiets kongress, kampanjen [vaihdavihreisiin.fi](https://vaihdavihreisiin.fi) (på svenska "byt till de gröna"), vars mål är att sänka tröskeln för att byta från Samlingspartiet (och från att rösta på det) till De gröna. Kampanjen har gjorts tillsammans med dussintals aktiva gröna ekonomikunniga. En del av kampanjen är att lyfta fram marknadsgröna aktörer, och bland dem som gett sitt namn finns bland annat [Osmo Soininvaara](https://www.soininvaara.fi/2026/06/06/vihreat-ja-markkinatalous-1/), Atte Harjanne, Tuuli Kousa och Kalle Euro.
+
+## Hur kom kampanjen igång?
+
+Kampanjen har sitt ursprung i maj 2026, veckan före De grönas kongress, när jag grundade WhatsApp-gruppen "Vihreät sosiaaliliberaalit yhdistykää" ("Gröna socialliberaler, förena er"). Bakom låg upplevelsen att partiets socialliberaler under de senaste åren har varit splittrade och underrepresenterade, samtidigt som andra strömningar har varit starkare synliga. Samma har även andra noterat, såsom [Heikki Pursiainen](https://www.facebook.com/share/p/17WqESV7QD/?mibextid=wwXIfr), som kritiserade vår kampanj just på den punkten. (Pursiainen har på den punkten rätt i sin kritik — det är just därför vi gjorde kampanjen. Han bortsåg dock i sin kritik från att De gröna [har](https://www.is.fi/politiikka/art-2000012002979.html) [haft](https://www.orastynkkynen.fi/puoli-miljardia-vuodessa-yritystuista-ja-haittaveroista/) [flera synliga öppningar](https://www.iltalehti.fi/politiikka/a/e784b036-caf5-436a-a569-7a4746cec8ae) i ekonomi under 2026.) Som någon för vilken De gröna särskilt har representerats av personer som Jyrki Kasvi och Osmo Soininvaara, längtade jag efter förändring.
+
+Jag var tydligt inte ensam med den tanken. Under de första dygnen anslöt sig över hundra likasinnade gröna till gruppen. Sedan dess har diskussionen pågått nästan oavbrutet dag efter dag. Gruppens uttalade gemensamma mål är att stärka De grönas ställning i det finska partifältet särskilt i ekonomiska frågor, där Samlingspartiet under de senaste åren har sluppit alltför lätt undan. De grönas ekonomiska linjer har trots imagen ändå varit mycket marknadsvänliga. Eller som Sofia Virta sa i början av sin ordförandetid: ["De gröna är Finlands ledande marknadsliberala parti"](https://www.hs.fi/politiikka/art-2000009741581.html).
+
+I gruppen växte också fram tanken att grunda en webbplats för andra socialliberaler, där vi berättar varför De gröna är det bästa alternativet för dem. Vi skrev också det Marknadsgröna manifestet, som utan kompromisser beskriver De grönas kärnvärden. Av det framgår också väl hur de hänger samman med liberalism. Det är värt att gå och [läsa](https://vaihdavihreisiin.fi/).
+
+Webbplatsen och manifestet blev klara vid lämplig tidpunkt, och fredagen den 5 juni 2026 startade kampanjen [vaihdavihreisiin.fi](https://vaihdavihreisiin.fi) samtidigt som Samlingspartiets kongress.
+
+Kampanjen har fått enormt mycket positiv respons, från höger, vänster och mitt — och från soffliggare. Många människor har anslutit sig till vår öppna WhatsApp-grupp, och tusentals har besökt webbplatsen efter publiceringen. Vi var tydligt inte ensamma om att tycka att en utvidgning av De gröna mot fyrfältets högra kant är en god idé. Vi fick stöd till och med från [Paavo Arhinmäki](https://www.facebook.com/share/p/1EPdARdS9P/?mibextid=wwXIfr). Även [tidskriften Verde rapporterade om kampanjen](https://www.verdelehti.fi/2026/06/11/markkinavihreat-tavoittelevat-kokoomuksen-liberaaleja-kampanja-jakaa-vihreita/).
+
+Just nu framkom det i [Suomen Kuvalehtis utredning](https://suomenkuvalehti.fi/paajutut/vuosi-vaaleihin-sk-selvitti-miten-aanestajat-ovat-liikkuneet-sdp-keraa-kannatusta-kaikkialta/) att De gröna har fått stöd just från höger. Till vänster har stödet sipprat, trots att partiet under de senaste åren kraftigt har kommunicerat teman som vanligen kopplas till vänstern. Det fanns alltså tydligt en efterfrågan på marknadsgrön kommunikation.
+
+Finlands partifält behöver minst ett verkligt socialliberalt alternativ. Samlingspartiet kunde ha varit ett sådant, men nu senast är det glasklart för alla att den dörren tills vidare är stängd. Därmed blir alternativen för blågröna liberaler att rösta i Samlingspartiet enligt en linje konservativa har bestämt — [eller bära konsekvenserna](https://www.hs.fi/politiikka/art-2000012055167.html). Mycket hellre vill jag se er alla rösta enligt era värderingar, i De gröna.
+
+## Varför byta till De gröna?
+
+De grönas gemensamma värderingar är skyddet av naturen och miljön samt mänskliga rättigheter. Det är därför både naturens och de mänskliga rättigheternas intresse att vi växer både från vänster och höger. Vårt stöd var som störst under Ville Niinistös ordförandetid, när Sipiläs regering gjorde historiskt kortsiktiga utbildningsnedskärningar. Det handlade då inte om att vi skulle ha varit det bästa vänsterpartiet. Det handlade om att vi är det bästa utbildningspartiet. Den nu sittande regering ledd av Samlingspartiet bedriver helt samma slags politik som Sipiläs.
+
+I De gröna får man rösta för kvinnors rättigheter och försvaret av naturen och djuren. I De gröna håller man fast vid utbildningslöften. Det är värt att fråga sig själv hur det skulle kännas att vara i ett parti där man inte behöver förklara sina handlingar?
+
+Lauri Lavanti
+
+*Skribenten är De grönas kommunfullmäktigeledamot i Kyrkslätt och en av personerna bakom kampanjen [vaihdavihreisiin.fi](https://vaihdavihreisiin.fi). Liberal och socialliberal.*
+
+## Var hittar jag mer om marknadsgrön ekonomi?
+
+Jag har skrivit om mitt anförande och ändringsförslag på kongressen i bloggen [De gröna – Marknadsekonomiets sanna försvarare](/sv/blog/62/de-grona-marknadsekonomiets-sanna-forsvarare/). Alla mina skriverier om ekonomi hittar du i [ekonomi-kategorin](/sv/category/economy), och alla texter om De gröna i [de gröna-kategorin](/sv/category/green-party).

--- a/src/pages/sv/blog/63/byt-till-de-grona-kampanj/index.mdx
+++ b/src/pages/sv/blog/63/byt-till-de-grona-kampanj/index.mdx
@@ -17,13 +17,13 @@ heroImage: markkinavihreiden-kutsu-liberaali-tervetuloa-kotiin
 alt: 'Marknadsgrönas inbjudan: Liberal, välkommen hem — bild från kampanjen vaihdavihreisiin.fi'
 faq:
   - q: 'Vad är kampanjen vaihdavihreisiin.fi?'
-    a: 'Vaihdavihreisiin.fi är en kampanj byggd av dussintals aktiva marknadsgröna som sänker tröskeln för att byta från Samlingspartiet till De gröna. Kampanjen lanserades den 5 juni 2026 samtidigt som Samlingspartiets kongress och publicerade en webbplats, ett Marknadsgrönt manifest och en öppen WhatsApp-grupp.'
+    a: 'Vaihdavihreisiin.fi är en kampanj byggd av dussintals aktiva marknadsgröna som sänker tröskeln för liberaler att byta till De gröna. Kampanjen lanserades den 5 juni 2026 samtidigt som Samlingspartiets kongress och publicerade en webbplats, ett Marknadsgrönt manifest och en öppen WhatsApp-grupp.'
   - q: 'Vad betyder marknadsgrön?'
     a: 'En marknadsgrön anser att marknadsekonomin är det effektivaste kända sättet att fördela resurser — men bara när externa effekter är prissatta, konkurrensen är rättvis och förorening kostar. Grön ekonomisk politik flyttar skattetyngdpunkten från arbete till skador, inte att öka den offentliga sektorns andel.'
   - q: 'Varför passar De gröna en liberal bättre än Samlingspartiet?'
     a: 'Samlingspartiet har under de senaste åren kapitulerat för konservativa krafter i kvinnors rättigheter, utbildning och mänskliga rättigheter. I De gröna behöver en liberal inte förklara sina handlingar eller rösta enligt en konservativ linje — försvaret av naturen och mänskliga rättigheter är partiets kärna.'
   - q: 'Vad i Samlingspartiets kongress 2026 utlöste kampanjen?'
-    a: 'Samlingspartiet fortsatte den linje där konservativa bestämmer partiets riktning. Det stängde dörren för blågröna liberaler och socialliberaler. Finlands partifält behöver minst ett verkligt socialliberalt alternativ, och vaihdavihreisiin.fi erbjuder det.'
+    a: 'Samlingspartiet fortsatte den linje där konservativa bestämmer partiets riktning. Det stängde dörren för blågröna liberaler och socialliberaler. Finlands partifält behöver minst ett verkligt socialliberalt alternativ, och De gröna erbjuder det.'
 ---
 
 import BlockQuote from '../../../../../components/body/BlockQuote.astro'
@@ -36,7 +36,7 @@ import UL from '../../../../../components/UL.astro'
 
 export const components = { blockquote: BlockQuote, a: SmartLink, h2: H2, h3: H3, p: Paragraph, ul: UL, li: LI }
 
-Vi lanserade i fredags, till ära för Samlingspartiets kongress, kampanjen [vaihdavihreisiin.fi](https://vaihdavihreisiin.fi) (på svenska "byt till de gröna"), vars mål är att sänka tröskeln för att byta från Samlingspartiet (och från att rösta på det) till De gröna. Kampanjen har gjorts tillsammans med dussintals aktiva gröna ekonomikunniga. En del av kampanjen är att lyfta fram marknadsgröna aktörer, och bland dem som gett sitt namn finns bland annat [Osmo Soininvaara](https://www.soininvaara.fi/2026/06/06/vihreat-ja-markkinatalous-1/), Atte Harjanne, Tuuli Kousa och Kalle Euro.
+Vi lanserade i fredags, till ära för Samlingspartiets kongress, kampanjen [vaihdavihreisiin.fi](https://vaihdavihreisiin.fi) (på svenska "byt till de gröna"), vars mål är att sänka tröskeln för att byta från Samlingspartiet (och från att rösta på det) till De gröna. Kampanjen har gjorts tillsammans med dussintals aktiva gröna ekonomikunniga. En del av kampanjen är att lyfta fram marknadsgröna aktörer, och bland dem som gett sitt namn finns bland annat [Osmo Soininvaara](https://www.soininvaara.fi/2026/06/06/vihreat-ja-markkinatalous-1/), Atte Harjanne, Tuuli Kousa och [Kalle Euro](https://www.tahdotaan-parempaa-maailmaa.com/l/mika-vetaa-vihreisiin/).
 
 ## Hur kom kampanjen igång?
 
@@ -48,9 +48,9 @@ I gruppen växte också fram tanken att grunda en webbplats för andra sociallib
 
 Webbplatsen och manifestet blev klara vid lämplig tidpunkt, och fredagen den 5 juni 2026 startade kampanjen [vaihdavihreisiin.fi](https://vaihdavihreisiin.fi) samtidigt som Samlingspartiets kongress.
 
-Kampanjen har fått enormt mycket positiv respons, från höger, vänster och mitt — och från soffliggare. Många människor har anslutit sig till vår öppna WhatsApp-grupp, och tusentals har besökt webbplatsen efter publiceringen. Vi var tydligt inte ensamma om att tycka att en utvidgning av De gröna mot fyrfältets högra kant är en god idé. Vi fick stöd till och med från [Paavo Arhinmäki](https://www.facebook.com/share/p/1EPdARdS9P/?mibextid=wwXIfr). Även [tidskriften Verde rapporterade om kampanjen](https://www.verdelehti.fi/2026/06/11/markkinavihreat-tavoittelevat-kokoomuksen-liberaaleja-kampanja-jakaa-vihreita/).
+Kampanjen har fått enormt mycket positiv respons, från höger, vänster och mitt — och från soffliggare. Många människor har anslutit sig till vår öppna WhatsApp-grupp, och tusentals har besökt webbplatsen efter publiceringen. Vi var tydligt inte ensamma om att tycka att en utvidgning av De gröna mot fyrfältets högra kant är en god idé. Vi fick stöd till och med från [Paavo Arhinmäki](https://www.facebook.com/share/p/1EPdARdS9P/?mibextid=wwXIfr). Även [Helsingin Sanomat](https://www.hs.fi/politiikka/art-2000012062451.html) och [Verde](https://www.verdelehti.fi/2026/06/11/markkinavihreat-tavoittelevat-kokoomuksen-liberaaleja-kampanja-jakaa-vihreita/) rapporterade om kampanjen.
 
-Just nu framkom det i [Suomen Kuvalehtis utredning](https://suomenkuvalehti.fi/paajutut/vuosi-vaaleihin-sk-selvitti-miten-aanestajat-ovat-liikkuneet-sdp-keraa-kannatusta-kaikkialta/) att De gröna har fått stöd just från höger. Till vänster har stödet sipprat, trots att partiet under de senaste åren kraftigt har kommunicerat teman som vanligen kopplas till vänstern. Det fanns alltså tydligt en efterfrågan på marknadsgrön kommunikation.
+Just nu framkom det i [Suomen Kuvalehtis utredning](https://suomenkuvalehti.fi/paajutut/vuosi-vaaleihin-sk-selvitti-miten-aanestajat-ovat-liikkuneet-sdp-keraa-kannatusta-kaikkialta/) att De gröna har fått stöd just från höger. Till vänster har stödet sipprat, trots att partiet under de senaste åren kraftigt har kommunicerat teman som vanligen kopplas till vänstern (huruvida dessa teman faktiskt hör hemma i vänsterpolitiken är förstås en fråga där välgrundade meningar går isär). Det fanns alltså tydligt en efterfrågan på marknadsgrön kommunikation.
 
 Finlands partifält behöver minst ett verkligt socialliberalt alternativ. Samlingspartiet kunde ha varit ett sådant, men nu senast är det glasklart för alla att den dörren tills vidare är stängd. Därmed blir alternativen för blågröna liberaler att rösta i Samlingspartiet enligt en linje konservativa har bestämt — [eller bära konsekvenserna](https://www.hs.fi/politiikka/art-2000012055167.html). Mycket hellre vill jag se er alla rösta enligt era värderingar, i De gröna.
 

--- a/src/pages/sv/blog/63/byt-till-de-grona-kampanj/index.mdx
+++ b/src/pages/sv/blog/63/byt-till-de-grona-kampanj/index.mdx
@@ -23,7 +23,7 @@ faq:
   - q: 'Varför passar De gröna en liberal bättre än Samlingspartiet?'
     a: 'Samlingspartiet har under de senaste åren kapitulerat för konservativa krafter i kvinnors rättigheter, utbildning och mänskliga rättigheter. I De gröna behöver en liberal inte förklara sina handlingar eller rösta enligt en konservativ linje — försvaret av naturen och mänskliga rättigheter är partiets kärna.'
   - q: 'Vad i Samlingspartiets kongress 2026 utlöste kampanjen?'
-    a: 'Samlingspartiet fortsatte den linje där konservativa bestämmer partiets riktning. Det stängde dörren för blågröna liberaler och socialliberaler. Finlands partifält behöver minst ett verkligt socialliberalt alternativ, och De gröna erbjuder det.'
+    a: 'Samlingspartiet fortsatte den linje där konservativa bestämmer partiets riktning. Det stängde dörren för blågröna liberaler och socialliberaler. Finlands partifält behöver minst ett verkligt socialliberalt alternativ, och De Gröna erbjuder det.'
 ---
 
 import BlockQuote from '../../../../../components/body/BlockQuote.astro'
@@ -59,10 +59,6 @@ Finlands partifält behöver minst ett verkligt socialliberalt alternativ. Samli
 De grönas gemensamma värderingar är skyddet av naturen och miljön samt mänskliga rättigheter. Det är därför både naturens och de mänskliga rättigheternas intresse att vi växer både från vänster och höger. Vårt stöd var som störst under Ville Niinistös ordförandetid, när Sipiläs regering gjorde historiskt kortsiktiga utbildningsnedskärningar. Det handlade då inte om att vi skulle ha varit det bästa vänsterpartiet. Det handlade om att vi är det bästa utbildningspartiet. Den nu sittande regering ledd av Samlingspartiet bedriver helt samma slags politik som Sipiläs.
 
 I De gröna får man rösta för kvinnors rättigheter och försvaret av naturen och djuren. I De gröna håller man fast vid utbildningslöften. Det är värt att fråga sig själv hur det skulle kännas att vara i ett parti där man inte behöver förklara sina handlingar?
-
-Lauri Lavanti
-
-*Skribenten är De grönas kommunfullmäktigeledamot i Kyrkslätt och en av personerna bakom kampanjen [vaihdavihreisiin.fi](https://vaihdavihreisiin.fi). Liberal och socialliberal.*
 
 ## Var hittar jag mer om marknadsgrön ekonomi?
 

--- a/tests/e2e/blogEnPage.spec.ts-snapshots/Blog-Page-in-English-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/blogEnPage.spec.ts-snapshots/Blog-Page-in-English-should-match-aria-snapshot-1.aria.yml
@@ -81,6 +81,28 @@
     - paragraph: "A working economy in the AI era is not a slogan. It is substance: skills that survive the transition, businesses that can build on Finnish and European infrastructure, and a state that procures technology on its own terms."
     - list:
       - listitem:
+        - article "How does it feel to be in a party where you don't have to compromise on your values?":
+          - 'link "Market Greens'' invitation: Liberal, welcome home — image from the vaihdavihreisiin.fi campaign How does it feel to be in a party where you don''t have to compromise on your values?"':
+            - /url: /en/blog/63/switch-to-greens-campaign/
+            - 'img "Market Greens'' invitation: Liberal, welcome home — image from the vaihdavihreisiin.fi campaign"'
+            - heading "How does it feel to be in a party where you don't have to compromise on your values?" [level=2]
+          - complementary "Meta information for post \"How does it feel to be in a party where you don't have to compromise on your values?\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Economy":
+                  - /url: /en/category/economy/
+              - listitem:
+                - link "Green Party":
+                  - /url: /en/category/green-party/
+              - listitem:
+                - link "Freedom":
+                  - /url: /en/category/freedom/
+              - listitem:
+                - link "National politics":
+                  - /url: /en/category/national-politics/
+          - paragraph: The vaihdavihreisiin.fi campaign invites liberals and social liberals to join the Finnish Greens — the party where you don't have to compromise on your values.
+      - listitem:
         - article "Greens – The True Defenders of the Market Economy":
           - link /Green Party congress in Turku \d+ Greens – The True Defenders of the Market Economy/:
             - /url: /en/blog/62/greens-the-true-defenders-of-the-market-economy/
@@ -118,25 +140,6 @@
                 - link "National politics":
                   - /url: /en/category/national-politics/
           - paragraph: Leaving the debt-brake agreement does not change the scale of fiscal adjustment — it removes the Greens from shaping how the adjustment is done.
-      - listitem:
-        - article "I voted against Västra":
-          - link "Three stacks of coins at different heights on a white background. The image illustrates municipal financial decision-making. I voted against Västra":
-            - /url: /en/blog/58/i-voted-against-vastra/
-            - img "Three stacks of coins at different heights on a white background. The image illustrates municipal financial decision-making."
-            - heading "I voted against Västra" [level=2]
-          - complementary "Meta information for post \"I voted against Västra\"":
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Economy":
-                  - /url: /en/category/economy/
-              - listitem:
-                - link "Kirkkonummi":
-                  - /url: /en/category/kirkkonummi/
-              - listitem:
-                - link "Western Uusimaa":
-                  - /url: /en/category/western-uusimaa/
-          - paragraph: "I voted against Kirkkonummi joining the Västra cooperation. The council decided otherwise. My case: the money belongs in education, not a locked-in agreement."
     - link "All posts about Economy →":
       - /url: /en/category/economy/
     - heading "Learning" [level=2]
@@ -343,6 +346,25 @@
     - paragraph: "Kirkkonummi is a bilingual, coastal municipality growing fast at the edge of the Helsinki region. It has real assets — shoreline, nature, a mixed community — and real pressures: a revenue base that struggles to keep up with demand, and a rail corridor that matters enormously for how the whole region develops. Local politics here is not small politics."
     - list:
       - listitem:
+        - article "I voted against Västra":
+          - link "Three stacks of coins at different heights on a white background. The image illustrates municipal financial decision-making. I voted against Västra":
+            - /url: /en/blog/58/i-voted-against-vastra/
+            - img "Three stacks of coins at different heights on a white background. The image illustrates municipal financial decision-making."
+            - heading "I voted against Västra" [level=2]
+          - complementary "Meta information for post \"I voted against Västra\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Economy":
+                  - /url: /en/category/economy/
+              - listitem:
+                - link "Kirkkonummi":
+                  - /url: /en/category/kirkkonummi/
+              - listitem:
+                - link "Western Uusimaa":
+                  - /url: /en/category/western-uusimaa/
+          - paragraph: "I voted against Kirkkonummi joining the Västra cooperation. The council decided otherwise. My case: the money belongs in education, not a locked-in agreement."
+      - listitem:
         - article "Lähteelä — a gem on Kirkkonummi coast":
           - link "Lauri Lavanti and Miisa Jeremejew, municipal councillors (Greens), Kirkkonummi Lähteelä — a gem on Kirkkonummi coast":
             - /url: /en/blog/56/lahteela-a-gem-on-kirkkonummis-coast/
@@ -374,25 +396,6 @@
                 - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
           - paragraph: /Bullying of rainbow youth is increasing\. Kirkkonummi voted \d+–\d+ for flag-flying — a small gesture with measurable effects on young people's wellbeing\./
-      - listitem:
-        - article "The West Railway revealed problems in Kirkkonummi's governance":
-          - link "Lauri Lavanti leaning against a tall table. He is wearing a black blazer and a blue-and-white floral-patterned shirt. There is a multicoloured pocket square in the blazer pocket. Windows in the background. The West Railway revealed problems in Kirkkonummi's governance":
-            - /url: /en/blog/50/the-west-railway-decision-revealed-problems-in-kirkkonummis-long-term-strategic-development/
-            - img "Lauri Lavanti leaning against a tall table. He is wearing a black blazer and a blue-and-white floral-patterned shirt. There is a multicoloured pocket square in the blazer pocket. Windows in the background."
-            - heading "The West Railway revealed problems in Kirkkonummi's governance" [level=2]
-          - complementary "Meta information for post \"The West Railway revealed problems in Kirkkonummi's governance\"":
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Infrastructure":
-                  - /url: /en/category/infrastructure/
-              - listitem:
-                - link "Kirkkonummi":
-                  - /url: /en/category/kirkkonummi/
-              - listitem:
-                - link "Western railway":
-                  - /url: /en/category/west-railway/
-          - paragraph: The West Railway decision revealed shortcomings in Kirkkonummi's strategic planning. The municipality risks bearing the costs without the benefits.
     - link "All posts about Kirkkonummi →":
       - /url: /en/category/kirkkonummi/
     - link "All posts →":

--- a/tests/e2e/blogPage.spec.ts-snapshots/Blog-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/blogPage.spec.ts-snapshots/Blog-Page-should-match-aria-snapshot-1.aria.yml
@@ -81,6 +81,28 @@
     - paragraph: "Toimiva talous tekoälyn aikana ei ole iskulause. Se on konkretiaa: osaamista, joka kestää murroksen yli, yrityksiä, jotka voivat rakentaa suomalaisen ja eurooppalaisen infrastruktuurin päälle, ja valtio, joka hankkii teknologiaa omilla ehdoillaan."
     - list:
       - listitem:
+        - article "Miltä tuntuu olla puolueessa, jossa arvoista ei tarvitse tinkiä?":
+          - 'link "Markkinavihreiden kutsu: Liberaali, tervetuloa kotiin — vaihdavihreisiin.fi-kampanjan kuva Miltä tuntuu olla puolueessa, jossa arvoista ei tarvitse tinkiä?"':
+            - /url: /fi/blog/63/vaihdavihreisiin-kampanja/
+            - 'img "Markkinavihreiden kutsu: Liberaali, tervetuloa kotiin — vaihdavihreisiin.fi-kampanjan kuva"'
+            - heading "Miltä tuntuu olla puolueessa, jossa arvoista ei tarvitse tinkiä?" [level=2]
+          - complementary "Kirjoituksen \"Miltä tuntuu olla puolueessa, jossa arvoista ei tarvitse tinkiä?\" meta-tiedot":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Talous":
+                  - /url: /fi/category/economy/
+              - listitem:
+                - link "Vihreät":
+                  - /url: /fi/category/green-party/
+              - listitem:
+                - link "Vapaus":
+                  - /url: /fi/category/freedom/
+              - listitem:
+                - link "Kansallinen politiikka":
+                  - /url: /fi/category/national-politics/
+          - paragraph: Vaihdavihreisiin.fi-kampanja kutsuu liberaalit ja sosiaaliliberaalit Vihreisiin — puolueeseen, jossa arvoista ei tarvitse tinkiä.
+      - listitem:
         - article "Vihreät – Markkinatalouden aito puolustaja":
           - link /Vihreiden puoluekokous Turussa \d+ Vihreät – Markkinatalouden aito puolustaja/:
             - /url: /fi/blog/62/vihreat-markkinatalouden-aito-puolustaja/
@@ -118,25 +140,6 @@
                 - link "Kansallinen politiikka":
                   - /url: /fi/category/national-politics/
           - paragraph: Velkajarrusopimuksesta poistuminen ei muuta sopeutuksen määrää — se poistaa Vihreiden mahdollisuuden vaikuttaa siihen, miten sopeutus tehdään.
-      - listitem:
-        - article "Äänestin Västraa vastaan":
-          - link "Kolme kolikkopinoa eri korkeuksilla valkoisella taustalla. Kuva havainnollistaa kunnan taloudellista päätöksentekoa. Äänestin Västraa vastaan":
-            - /url: /fi/blog/58/aanestin-vastraa-vastaan/
-            - img "Kolme kolikkopinoa eri korkeuksilla valkoisella taustalla. Kuva havainnollistaa kunnan taloudellista päätöksentekoa."
-            - heading "Äänestin Västraa vastaan" [level=2]
-          - complementary "Kirjoituksen \"Äänestin Västraa vastaan\" meta-tiedot":
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Talous":
-                  - /url: /fi/category/economy/
-              - listitem:
-                - link "Kirkkonummi":
-                  - /url: /fi/category/kirkkonummi/
-              - listitem:
-                - link "Länsi-Uusimaa":
-                  - /url: /fi/category/western-uusimaa/
-          - paragraph: "Äänestin Västra-rannikkoyhteistyötä vastaan. Valtuusto päätti liittyä. Perusteluni: rahat kuuluvat sivistyspalveluihin, ei sopimukseen josta ei pääse irti."
     - link "Kaikki kirjoitukset aiheesta Talous →":
       - /url: /fi/category/economy/
     - heading "Sivistys" [level=2]
@@ -343,6 +346,25 @@
     - paragraph: "Kirkkonummi on kaksikielinen, rannikolla sijaitseva kunta, joka kasvaa nopeasti Helsingin seudun reunalla. Sillä on todellisia vahvuuksia — rantaviiva, luonto, monimuotoinen yhteisö — ja todellisia paineita: tulopohja, jolla on vaikeuksia pysyä tarpeiden perässä, ja ratakäytävä, jolla on suuri merkitys koko seudun kehitykselle. Paikallispolitiikka täällä ei ole pientä politiikkaa."
     - list:
       - listitem:
+        - article "Äänestin Västraa vastaan":
+          - link "Kolme kolikkopinoa eri korkeuksilla valkoisella taustalla. Kuva havainnollistaa kunnan taloudellista päätöksentekoa. Äänestin Västraa vastaan":
+            - /url: /fi/blog/58/aanestin-vastraa-vastaan/
+            - img "Kolme kolikkopinoa eri korkeuksilla valkoisella taustalla. Kuva havainnollistaa kunnan taloudellista päätöksentekoa."
+            - heading "Äänestin Västraa vastaan" [level=2]
+          - complementary "Kirjoituksen \"Äänestin Västraa vastaan\" meta-tiedot":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Talous":
+                  - /url: /fi/category/economy/
+              - listitem:
+                - link "Kirkkonummi":
+                  - /url: /fi/category/kirkkonummi/
+              - listitem:
+                - link "Länsi-Uusimaa":
+                  - /url: /fi/category/western-uusimaa/
+          - paragraph: "Äänestin Västra-rannikkoyhteistyötä vastaan. Valtuusto päätti liittyä. Perusteluni: rahat kuuluvat sivistyspalveluihin, ei sopimukseen josta ei pääse irti."
+      - listitem:
         - article "Lähteelä — yhteinen helmi Kirkkonummen rannikolla":
           - link "Lauri Lavanti ja Miisa Jeremejew, kunnanvaltuutettuja (vihr.), Kirkkonummi Lähteelä — yhteinen helmi Kirkkonummen rannikolla":
             - /url: /fi/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/
@@ -374,25 +396,6 @@
                 - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
           - paragraph: /Sateenkaarinuorten kiusaaminen kasvaa\. Kirkkonummi äänesti \d+–\d+ liputuksen puolesta — pieni ele, jolla on mitattavia vaikutuksia nuorten hyvinvointiin\./
-      - listitem:
-        - article "Länsirata nosti esiin ongelmia Kirkkonummen päätöksenteossa":
-          - link "Lauri Lavanti nojaamassa korkeaan pöytään. Päällään hänellä on musta bleiseri ja sinivalkoinen kukkakuvioinen kauluspaita. Bleiserin taskussa on monivärinen taskuliina. Taustalla ikkunoita. Länsirata nosti esiin ongelmia Kirkkonummen päätöksenteossa":
-            - /url: /fi/blog/50/lansirata-paatos-nosti-esiin-ongelmia-kirkkonummen-pitkajanteisessa-strategisessa-kehittamisessa/
-            - img "Lauri Lavanti nojaamassa korkeaan pöytään. Päällään hänellä on musta bleiseri ja sinivalkoinen kukkakuvioinen kauluspaita. Bleiserin taskussa on monivärinen taskuliina. Taustalla ikkunoita."
-            - heading "Länsirata nosti esiin ongelmia Kirkkonummen päätöksenteossa" [level=2]
-          - complementary "Kirjoituksen \"Länsirata nosti esiin ongelmia Kirkkonummen päätöksenteossa\" meta-tiedot":
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Infra":
-                  - /url: /fi/category/infrastructure/
-              - listitem:
-                - link "Kirkkonummi":
-                  - /url: /fi/category/kirkkonummi/
-              - listitem:
-                - link "Länsirata":
-                  - /url: /fi/category/west-railway/
-          - paragraph: Länsirata-päätöstä tehdessä mitattiin päättäjien kykyä tehdä koko kunnalle strategisesti tärkeitä, tulevaisuuteen katsovia ratkaisuja.
     - link "Kaikki kirjoitukset aiheesta Kirkkonummi →":
       - /url: /fi/category/kirkkonummi/
     - link "Kaikki kirjoitukset →":

--- a/tests/e2e/blogSwePage.spec.ts-snapshots/Blog-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/blogSwePage.spec.ts-snapshots/Blog-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
@@ -81,6 +81,28 @@
     - paragraph: "En fungerande ekonomi i AI-eran är inte en slogan. Det är substans: kompetens som överlever omställningen, företag som kan bygga på finsk och europeisk infrastruktur, och en stat som upphandlar teknik på sina egna villkor."
     - list:
       - listitem:
+        - article "Hur känns det att vara i ett parti där man inte behöver kompromissa med sina värderingar?":
+          - 'link "Marknadsgrönas inbjudan: Liberal, välkommen hem — bild från kampanjen vaihdavihreisiin.fi Hur känns det att vara i ett parti där man inte behöver kompromissa med sina värderingar?"':
+            - /url: /sv/blog/63/byt-till-de-grona-kampanj/
+            - 'img "Marknadsgrönas inbjudan: Liberal, välkommen hem — bild från kampanjen vaihdavihreisiin.fi"'
+            - heading "Hur känns det att vara i ett parti där man inte behöver kompromissa med sina värderingar?" [level=2]
+          - complementary "Metainformation för inlägget \"Hur känns det att vara i ett parti där man inte behöver kompromissa med sina värderingar?\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Ekonomi":
+                  - /url: /sv/category/economy/
+              - listitem:
+                - link "De Gröna":
+                  - /url: /sv/category/green-party/
+              - listitem:
+                - link "Frihet":
+                  - /url: /sv/category/freedom/
+              - listitem:
+                - link "Nationell politik":
+                  - /url: /sv/category/national-politics/
+          - paragraph: Kampanjen vaihdavihreisiin.fi bjuder liberaler och socialliberaler att byta till De gröna — partiet där man inte behöver kompromissa med sina värderingar.
+      - listitem:
         - article "De gröna – Marknadsekonomiets sanna försvarare":
           - link /Grönas partikongress i Åbo \d+ De gröna – Marknadsekonomiets sanna försvarare/:
             - /url: /sv/blog/62/de-grona-marknadsekonomiets-sanna-forsvarare/
@@ -118,25 +140,6 @@
                 - link "Nationell politik":
                   - /url: /sv/category/national-politics/
           - paragraph: Att lämna skuldbromsavtalet ändrar inte storleken på anpassningen — det tar bort De Grönas möjlighet att påverka hur anpassningen genomförs.
-      - listitem:
-        - article "Jag röstade mot Västra":
-          - link "Tre myntstaplar i olika höjder på vit bakgrund. Bilden illustrerar kommunalt ekonomiskt beslutsfattande. Jag röstade mot Västra":
-            - /url: /sv/blog/58/jag-rostade-mot-vastra/
-            - img "Tre myntstaplar i olika höjder på vit bakgrund. Bilden illustrerar kommunalt ekonomiskt beslutsfattande."
-            - heading "Jag röstade mot Västra" [level=2]
-          - complementary "Metainformation för inlägget \"Jag röstade mot Västra\"":
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Ekonomi":
-                  - /url: /sv/category/economy/
-              - listitem:
-                - link "Kyrkslätt":
-                  - /url: /sv/category/kirkkonummi/
-              - listitem:
-                - link "Västra Nyland":
-                  - /url: /sv/category/western-uusimaa/
-          - paragraph: Jag röstade mot Västra kustsamarbetet. Fullmäktige beslutade annorlunda. Pengarna hör till bildningsservicen, inte ett avtal man inte kan lämna.
     - link "Alla inlägg om Ekonomi →":
       - /url: /sv/category/economy/
     - heading "Lärande" [level=2]
@@ -343,6 +346,25 @@
     - paragraph: "Kyrkslätt är en tvåspråkig kustkommun som växer snabbt i kanten av Helsingforsregionen. Den har verkliga tillgångar — strandlinje, natur, en blandad gemenskap — och verkliga påfrestningar: en intäktsbas som har svårt att hålla jämna steg med behoven och ett järnvägskorridor som spelar stor roll för hur hela regionen utvecklas. Lokalpolitiken här är inte småpolitik."
     - list:
       - listitem:
+        - article "Jag röstade mot Västra":
+          - link "Tre myntstaplar i olika höjder på vit bakgrund. Bilden illustrerar kommunalt ekonomiskt beslutsfattande. Jag röstade mot Västra":
+            - /url: /sv/blog/58/jag-rostade-mot-vastra/
+            - img "Tre myntstaplar i olika höjder på vit bakgrund. Bilden illustrerar kommunalt ekonomiskt beslutsfattande."
+            - heading "Jag röstade mot Västra" [level=2]
+          - complementary "Metainformation för inlägget \"Jag röstade mot Västra\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Ekonomi":
+                  - /url: /sv/category/economy/
+              - listitem:
+                - link "Kyrkslätt":
+                  - /url: /sv/category/kirkkonummi/
+              - listitem:
+                - link "Västra Nyland":
+                  - /url: /sv/category/western-uusimaa/
+          - paragraph: Jag röstade mot Västra kustsamarbetet. Fullmäktige beslutade annorlunda. Pengarna hör till bildningsservicen, inte ett avtal man inte kan lämna.
+      - listitem:
         - article "Lähteelä — en gem vid Kyrksländets kust":
           - link "Lauri Lavanti och Miisa Jeremejew, kommunfullmäktigeledamöter (gröna), Kyrksländ Lähteelä — en gem vid Kyrksländets kust":
             - /url: /sv/blog/56/lahteela-en-gemma-vid-kyrkslaendets-kust/
@@ -374,25 +396,6 @@
                 - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
           - paragraph: /Mobbning av regnbågsungdomar ökar\. Kyrkslätt röstade \d+–\d+ för flaggning — en liten gest med mätbara effekter på ungas välmående\./
-      - listitem:
-        - article "Västbanan avslöjade problem i Kyrkslätts beslutsfattande":
-          - link "Lauri Lavanti lutar sig mot ett högt bord. Han bär en svart blazer och en blåvit blommönstrad skjorta. I blazerns ficka sitter en flerfärgad näsduk. Fönster i bakgrunden. Västbanan avslöjade problem i Kyrkslätts beslutsfattande":
-            - /url: /sv/blog/50/vastbanan-beslutet-avslojat-problem-i-kyrkslatts-langsiktiga-strategiska-utveckling/
-            - img "Lauri Lavanti lutar sig mot ett högt bord. Han bär en svart blazer och en blåvit blommönstrad skjorta. I blazerns ficka sitter en flerfärgad näsduk. Fönster i bakgrunden."
-            - heading "Västbanan avslöjade problem i Kyrkslätts beslutsfattande" [level=2]
-          - complementary "Metainformation för inlägget \"Västbanan avslöjade problem i Kyrkslätts beslutsfattande\"":
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Infrastruktur":
-                  - /url: /sv/category/infrastructure/
-              - listitem:
-                - link "Kyrkslätt":
-                  - /url: /sv/category/kirkkonummi/
-              - listitem:
-                - link "Västbanan":
-                  - /url: /sv/category/west-railway/
-          - paragraph: Vid fattandet av Västbanans beslut mättes beslutsfattarnas förmåga att fatta strategiskt viktiga, framåtblickande beslut för hela kommunen.
     - link "Alla inlägg om Kyrkslätt →":
       - /url: /sv/category/kirkkonummi/
     - link "Alla inlägg →":

--- a/tests/e2e/homeEnPage.spec.ts-snapshots/Home-Page-in-English-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/homeEnPage.spec.ts-snapshots/Home-Page-in-English-should-match-aria-snapshot-1.aria.yml
@@ -18,6 +18,28 @@
         - /url: /en/privacy-policy/
     - list:
       - listitem:
+        - article "How does it feel to be in a party where you don't have to compromise on your values?":
+          - 'link "Market Greens'' invitation: Liberal, welcome home — image from the vaihdavihreisiin.fi campaign How does it feel to be in a party where you don''t have to compromise on your values?"':
+            - /url: /en/blog/63/switch-to-greens-campaign/
+            - 'img "Market Greens'' invitation: Liberal, welcome home — image from the vaihdavihreisiin.fi campaign"'
+            - heading "How does it feel to be in a party where you don't have to compromise on your values?" [level=2]
+          - complementary "Meta information for post \"How does it feel to be in a party where you don't have to compromise on your values?\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Economy":
+                  - /url: /en/category/economy/
+              - listitem:
+                - link "Green Party":
+                  - /url: /en/category/green-party/
+              - listitem:
+                - link "Freedom":
+                  - /url: /en/category/freedom/
+              - listitem:
+                - link "National politics":
+                  - /url: /en/category/national-politics/
+          - paragraph: The vaihdavihreisiin.fi campaign invites liberals and social liberals to join the Finnish Greens — the party where you don't have to compromise on your values.
+      - listitem:
         - article "Greens – The True Defenders of the Market Economy":
           - link /Green Party congress in Turku \d+ Greens – The True Defenders of the Market Economy/:
             - /url: /en/blog/62/greens-the-true-defenders-of-the-market-economy/
@@ -153,19 +175,5 @@
                 - link "Nature":
                   - /url: /en/category/nature/
           - paragraph: Kirkkonummi acquired Lähteelä, a coastal area. One of the few places on Kirkkonummi's coast accessible without a private boat — now permanently open to all.
-      - listitem:
-        - 'article "Kirkkonummi tells everyone: you belong here"':
-          - 'link "Kirkkonummi Kirsikkapuisto park on a sunny summer day. Mostly lawn in view, apartment buildings in the background and some playground equipment in the foreground Kirkkonummi tells everyone: you belong here"':
-            - /url: /en/blog/55/kirkkonummi-tells-everyone-you-belong-here/
-            - img "Kirkkonummi Kirsikkapuisto park on a sunny summer day. Mostly lawn in view, apartment buildings in the background and some playground equipment in the foreground"
-            - 'heading "Kirkkonummi tells everyone: you belong here" [level=2]'
-          - 'complementary "Meta information for post \"Kirkkonummi tells everyone: you belong here\""':
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Equality & equity":
-                  - /url: /en/category/equality-and-non-discrimination/
-              - listitem:
-                - link "Kirkkonummi":
-                  - /url: /en/category/kirkkonummi/
-          - paragraph: /Bullying of rainbow youth is increasing\. Kirkkonummi voted \d+–\d+ for flag-flying — a small gesture with measurable effects on young people's wellbeing\./
+    - link "All posts →":
+      - /url: /en/blog/all/

--- a/tests/e2e/homePage.spec.ts-snapshots/Home-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/homePage.spec.ts-snapshots/Home-Page-should-match-aria-snapshot-1.aria.yml
@@ -18,6 +18,28 @@
         - /url: /en/privacy-policy/
     - list:
       - listitem:
+        - article "How does it feel to be in a party where you don't have to compromise on your values?":
+          - 'link "Market Greens'' invitation: Liberal, welcome home — image from the vaihdavihreisiin.fi campaign How does it feel to be in a party where you don''t have to compromise on your values?"':
+            - /url: /en/blog/63/switch-to-greens-campaign/
+            - 'img "Market Greens'' invitation: Liberal, welcome home — image from the vaihdavihreisiin.fi campaign"'
+            - heading "How does it feel to be in a party where you don't have to compromise on your values?" [level=2]
+          - complementary "Meta information for post \"How does it feel to be in a party where you don't have to compromise on your values?\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Economy":
+                  - /url: /en/category/economy/
+              - listitem:
+                - link "Green Party":
+                  - /url: /en/category/green-party/
+              - listitem:
+                - link "Freedom":
+                  - /url: /en/category/freedom/
+              - listitem:
+                - link "National politics":
+                  - /url: /en/category/national-politics/
+          - paragraph: The vaihdavihreisiin.fi campaign invites liberals and social liberals to join the Finnish Greens — the party where you don't have to compromise on your values.
+      - listitem:
         - article "Greens – The True Defenders of the Market Economy":
           - link /Green Party congress in Turku \d+ Greens – The True Defenders of the Market Economy/:
             - /url: /en/blog/62/greens-the-true-defenders-of-the-market-economy/
@@ -153,19 +175,5 @@
                 - link "Nature":
                   - /url: /en/category/nature/
           - paragraph: Kirkkonummi acquired Lähteelä, a coastal area. One of the few places on Kirkkonummi's coast accessible without a private boat — now permanently open to all.
-      - listitem:
-        - 'article "Kirkkonummi tells everyone: you belong here"':
-          - 'link "Kirkkonummi Kirsikkapuisto park on a sunny summer day. Mostly lawn in view, apartment buildings in the background and some playground equipment in the foreground Kirkkonummi tells everyone: you belong here"':
-            - /url: /en/blog/55/kirkkonummi-tells-everyone-you-belong-here/
-            - img "Kirkkonummi Kirsikkapuisto park on a sunny summer day. Mostly lawn in view, apartment buildings in the background and some playground equipment in the foreground"
-            - 'heading "Kirkkonummi tells everyone: you belong here" [level=2]'
-          - 'complementary "Meta information for post \"Kirkkonummi tells everyone: you belong here\""':
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Equality & equity":
-                  - /url: /en/category/equality-and-non-discrimination/
-              - listitem:
-                - link "Kirkkonummi":
-                  - /url: /en/category/kirkkonummi/
-          - paragraph: /Bullying of rainbow youth is increasing\. Kirkkonummi voted \d+–\d+ for flag-flying — a small gesture with measurable effects on young people's wellbeing\./
+    - link "All posts →":
+      - /url: /en/blog/all/

--- a/tests/e2e/homeSwePage.spec.ts-snapshots/Home-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/homeSwePage.spec.ts-snapshots/Home-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
@@ -19,6 +19,28 @@
       - text: .
     - list:
       - listitem:
+        - article "Hur känns det att vara i ett parti där man inte behöver kompromissa med sina värderingar?":
+          - 'link "Marknadsgrönas inbjudan: Liberal, välkommen hem — bild från kampanjen vaihdavihreisiin.fi Hur känns det att vara i ett parti där man inte behöver kompromissa med sina värderingar?"':
+            - /url: /sv/blog/63/byt-till-de-grona-kampanj/
+            - 'img "Marknadsgrönas inbjudan: Liberal, välkommen hem — bild från kampanjen vaihdavihreisiin.fi"'
+            - heading "Hur känns det att vara i ett parti där man inte behöver kompromissa med sina värderingar?" [level=2]
+          - complementary "Metainformation för inlägget \"Hur känns det att vara i ett parti där man inte behöver kompromissa med sina värderingar?\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Ekonomi":
+                  - /url: /sv/category/economy/
+              - listitem:
+                - link "De Gröna":
+                  - /url: /sv/category/green-party/
+              - listitem:
+                - link "Frihet":
+                  - /url: /sv/category/freedom/
+              - listitem:
+                - link "Nationell politik":
+                  - /url: /sv/category/national-politics/
+          - paragraph: Kampanjen vaihdavihreisiin.fi bjuder liberaler och socialliberaler att byta till De gröna — partiet där man inte behöver kompromissa med sina värderingar.
+      - listitem:
         - article "De gröna – Marknadsekonomiets sanna försvarare":
           - link /Grönas partikongress i Åbo \d+ De gröna – Marknadsekonomiets sanna försvarare/:
             - /url: /sv/blog/62/de-grona-marknadsekonomiets-sanna-forsvarare/
@@ -154,19 +176,5 @@
                 - link "Natur":
                   - /url: /sv/category/nature/
           - paragraph: Kyrksländ köpte Lähteelä som kustanläggning. En av få platser vid kusten dit man kan ta sig utan egen båt — nu permanent tillgängligt för alla invånare.
-      - listitem:
-        - 'article "Kyrkslätt till alla: du hör hemma här"':
-          - 'link "Kyrkslätt Kirsikkapuisto en solig sommardag. Nästan bara gräsmatta i blickfånget, i bakgrunden flervåningshus och i förgrunden lite lekplatsutrustning Kyrkslätt till alla: du hör hemma här"':
-            - /url: /sv/blog/55/kyrkslatt-till-alla-du-hor-hemma-har/
-            - img "Kyrkslätt Kirsikkapuisto en solig sommardag. Nästan bara gräsmatta i blickfånget, i bakgrunden flervåningshus och i förgrunden lite lekplatsutrustning"
-            - 'heading "Kyrkslätt till alla: du hör hemma här" [level=2]'
-          - 'complementary "Metainformation för inlägget \"Kyrkslätt till alla: du hör hemma här\""':
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Jämlikhet":
-                  - /url: /sv/category/equality-and-non-discrimination/
-              - listitem:
-                - link "Kyrkslätt":
-                  - /url: /sv/category/kirkkonummi/
-          - paragraph: /Mobbning av regnbågsungdomar ökar\. Kyrkslätt röstade \d+–\d+ för flaggning — en liten gest med mätbara effekter på ungas välmående\./
+    - link "Alla inlägg →":
+      - /url: /sv/blog/all/

--- a/tests/e2e/notFoundPage.spec.ts-snapshots/404-Not-Found-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/notFoundPage.spec.ts-snapshots/404-Not-Found-Page-should-match-aria-snapshot-1.aria.yml
@@ -3,6 +3,28 @@
   - article:
     - list:
       - listitem:
+        - article "Miltä tuntuu olla puolueessa, jossa arvoista ei tarvitse tinkiä?":
+          - 'link "Markkinavihreiden kutsu: Liberaali, tervetuloa kotiin — vaihdavihreisiin.fi-kampanjan kuva Miltä tuntuu olla puolueessa, jossa arvoista ei tarvitse tinkiä?"':
+            - /url: /fi/blog/63/vaihdavihreisiin-kampanja/
+            - 'img "Markkinavihreiden kutsu: Liberaali, tervetuloa kotiin — vaihdavihreisiin.fi-kampanjan kuva"'
+            - heading "Miltä tuntuu olla puolueessa, jossa arvoista ei tarvitse tinkiä?" [level=2]
+          - complementary "Kirjoituksen \"Miltä tuntuu olla puolueessa, jossa arvoista ei tarvitse tinkiä?\" meta-tiedot":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Talous":
+                  - /url: /fi/category/economy/
+              - listitem:
+                - link "Vihreät":
+                  - /url: /fi/category/green-party/
+              - listitem:
+                - link "Vapaus":
+                  - /url: /fi/category/freedom/
+              - listitem:
+                - link "Kansallinen politiikka":
+                  - /url: /fi/category/national-politics/
+          - paragraph: Vaihdavihreisiin.fi-kampanja kutsuu liberaalit ja sosiaaliliberaalit Vihreisiin — puolueeseen, jossa arvoista ei tarvitse tinkiä.
+      - listitem:
         - article "Vihreät – Markkinatalouden aito puolustaja":
           - link /Vihreiden puoluekokous Turussa \d+ Vihreät – Markkinatalouden aito puolustaja/:
             - /url: /fi/blog/62/vihreat-markkinatalouden-aito-puolustaja/
@@ -138,19 +160,3 @@
                 - link "Luonto":
                   - /url: /fi/category/nature/
           - paragraph: Kirkkonummi osti Lähteelän rannikkokohteen. Se on yksi harvoista paikoista, jonne pääsee myös ilman omaa venettä — nyt se on pysyvästi kaikkien saavutettavissa.
-      - listitem:
-        - 'article "Kirkkonummi sanoo: sinä kuulut tänne"':
-          - 'link "Kirkkonummen Kirsikkapuisto aurinkoisena kesäpäivänä. Näköpiirissä pääasiassa nurmialuetta, taustalla kerrostaloja ja edustalla hieman leikkipuistoja Kirkkonummi sanoo: sinä kuulut tänne"':
-            - /url: /fi/blog/55/kirkkonummi-sanoo-sina-kuulut-tanne/
-            - img "Kirkkonummen Kirsikkapuisto aurinkoisena kesäpäivänä. Näköpiirissä pääasiassa nurmialuetta, taustalla kerrostaloja ja edustalla hieman leikkipuistoja"
-            - 'heading "Kirkkonummi sanoo: sinä kuulut tänne" [level=2]'
-          - 'complementary "Kirjoituksen \"Kirkkonummi sanoo: sinä kuulut tänne\" meta-tiedot"':
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Tasa-arvo ja yhdenvertaisuus":
-                  - /url: /fi/category/equality-and-non-discrimination/
-              - listitem:
-                - link "Kirkkonummi":
-                  - /url: /fi/category/kirkkonummi/
-          - paragraph: /Sateenkaarinuorten kiusaaminen kasvaa\. Kirkkonummi äänesti \d+–\d+ liputuksen puolesta — pieni ele, jolla on mitattavia vaikutuksia nuorten hyvinvointiin\./


### PR DESCRIPTION
> This PR containes AI-generated code. The author has reviewed and is responsible for all AI-generated content.

Closes #1307

## Summary

- Adds blog post #63 in **all three locales** (fi/sv/en): first public airing of the op-ed originally submitted to Verde on 2026-06-07 (never published there), about the **vaihdavihreisiin.fi** campaign launched 2026-06-05 alongside Kokoomus puoluekokous.
- Hero image uploaded to Cloudflare Images as `markkinavihreiden-kutsu-liberaali-tervetuloa-kotiin` (semantic slug describing the campaign graphic).
- Incorporates **Verde-lehti's coverage** by Johanna Laurila (2026-06-11, "Markkinavihreät tavoittelevat kokoomuksen liberaaleja – kampanja jakaa vihreitä") as a linked source in the reception paragraph of each locale.
- Voice rule applied: `sivistysporvari` → `liberaali` throughout; `sosiaaliliberaali` preserved.

## Test plan

- [ ] `npm run check` — Astro TypeScript check passes
- [ ] `npm run check:freshness` — new post is fresh
- [ ] `npm run lint` clean
- [ ] `npm run test` unit tests pass
- [ ] `npm run dev` and visit each locale:
  - [ ] `/fi/blog/63/vaihdavihreisiin-kampanja/`
  - [ ] `/sv/blog/63/byt-till-de-grona-kampanj/`
  - [ ] `/en/blog/63/switch-to-greens-campaign/`
- [ ] Hero image renders via Cloudflare Images
- [ ] FAQ schema, internal links, italic byline render correctly
- [ ] `npm run test:e2e` — Playwright sweep clean (or aria snapshot updated if necessary)
- [ ] `/review-implementation 1307` adversarial pass