### PR TITLE
feat(content): add post 64 – Pride flag next steps in Kirkkonummi (fi/sv/en)

### DIFF
--- a/src/components/Head.spec.ts
+++ b/src/components/Head.spec.ts
@@ -369,7 +369,7 @@ describe('<Head />', () => {
         expect(jsonLd.birthDate).toBe('1991-10-01')
         expect(jsonLd.birthPlace).toEqual({ '@type': 'Place', name: 'Jyväskylä' })
         expect(jsonLd.nationality).toEqual({ '@type': 'Country', name: 'FI' })
-        expect(jsonLd.jobTitle).toBe('Kunnanvaltuutettu ja johtava ohjelmistokehittäjä')
+        expect(jsonLd.jobTitle).toBe('kunnanvaltuutettu ja johtava ohjelmistokehittäjä')
         expect(jsonLd.sameAs).toHaveLength(9)
         expect(jsonLd.sameAs).toContain('https://fi.wikipedia.org/wiki/Lauri_Lavanti')
         expect(jsonLd.sameAs).toContain('https://www.wikidata.org/wiki/Q139711658')
@@ -399,7 +399,7 @@ describe('<Head />', () => {
 
         const jsonLdScript = result.querySelector('script[type="application/ld+json"]')
         const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
-        expect(jsonLd.jobTitle).toBe('Municipal councillor & lead developer')
+        expect(jsonLd.jobTitle).toBe('municipal councillor & lead developer')
         expect(jsonLd.knowsAbout).toContain('Economic policy')
         expect(jsonLd.knowsAbout).not.toContain('Talouspolitiikka')
     })
@@ -415,7 +415,7 @@ describe('<Head />', () => {
 
         const jsonLdScript = result.querySelector('script[type="application/ld+json"]')
         const jsonLd = JSON.parse(jsonLdScript?.textContent || '{}')
-        expect(jsonLd.jobTitle).toBe('Kommunfullmäktigeledamot och ledande mjukvaruutvecklare')
+        expect(jsonLd.jobTitle).toBe('kommunfullmäktigeledamot och ledande mjukvaruutvecklare')
         expect(jsonLd.knowsAbout).toContain('Ekonomisk politik')
         expect(jsonLd.knowsAbout).not.toContain('Talouspolitiikka')
     })

--- a/src/content/person.ts
+++ b/src/content/person.ts
@@ -34,9 +34,9 @@ export const personSameAs = [
 ]
 
 export const personJobTitle: Record<Lang, string> = {
-    en: 'Municipal councillor & lead developer',
-    fi: 'Kunnanvaltuutettu ja johtava ohjelmistokehittäjä',
-    sv: 'Kommunfullmäktigeledamot och ledande mjukvaruutvecklare',
+    en: 'municipal councillor & lead developer',
+    fi: 'kunnanvaltuutettu ja johtava ohjelmistokehittäjä',
+    sv: 'kommunfullmäktigeledamot och ledande mjukvaruutvecklare',
 }
 
 export const personDescription: Record<Lang, string> = {

--- a/src/pages/en/blog/64/the-flag-is-up-what-does-kirkkonummi-do-next/index.mdx
+++ b/src/pages/en/blog/64/the-flag-is-up-what-does-kirkkonummi-do-next/index.mdx
@@ -1,0 +1,66 @@
+---
+layout: '../../../../../layouts/PostLayout.astro'
+id: 64
+slug: 'the-flag-is-up-what-does-kirkkonummi-do-next'
+lang: 'en'
+pageTitle: 'Pride flag in Kirkkonummi — what now?'
+title: 'The flag is up. What does Kirkko­nummi do next?'
+description: 'Kirkkonummi raised the Pride flag for the first time on 22 June 2026. The flag matters, but equality also demands concrete action in the autumn budget.'
+publishDate: '2026-07-01'
+updatedDate: '2026-07-01'
+externalPublications:
+  - date: '2026-06-23'
+    name: 'Kirkkonummen Sanomat'
+    url: 'https://www.kirkkonummensanomat.fi/lippu-nousi-salkoon-mita-kirkkonummi-tekee-seuraavaksi-6.175.86006.b5bd43d098'
+authors:
+  - name: 'Suvi Annala'
+    role: 'deputy councillor (Greens), deputy member of the municipal board'
+  - lauri
+tags:
+  - kirkkonummi
+  - equality-and-non-discrimination
+heroImage: Sateenkaarilippuja-Kirkkonummen-kunnantalolla-2026
+alt: 'Rainbow flag flying at the Kirkkonummi municipal hall in June 2026.'
+faq:
+  - q: 'When did Kirkkonummi raise the Pride flag for the first time?'
+    a: 'On Monday 22 June 2026 at the Kirkkonummi municipal hall. The flag will be raised twice a year going forward, following the council motion approved in March 2026 by a vote of 30–14.'
+  - q: 'Why is flag-raising alone not enough?'
+    a: 'The Finnish Municipal Act obliges the municipality to promote residents'' well-being, and that duty does not end at the flagpole. Equality only materialises through everyday encounters in youth centres, schools, and student welfare services. The autumn 2026 budget round must assess whether current resources match the need.'
+  - q: 'Who filed the original council motion on Pride flag-raising?'
+    a: 'The Green council group, led by Lauri Lavanti, filed the motion in June 2025. The council approved it in March 2026 by a vote of 30–14.'
+---
+
+import SmartLink from '../../../../../components/SmartLink.astro'
+import H2 from '../../../../../components/H2.astro'
+import Paragraph from '../../../../../components/Paragraph.astro'
+import ImageWithCaption from '../../../../../components/body/ImageWithCaption.astro'
+
+export const components = { a: SmartLink, h2: H2, p: Paragraph }
+
+On Monday 22 June 2026, the rainbow flag was raised at the Kirkkonummi municipal hall for the first time. The decision was made in March, when the council approved [the Pride flag motion](/en/blog/39/council-initiative-annual-pride-flag-flying-in-kirkkonummi/) by a vote of 30–14. Going forward, the flag will be raised twice a year.
+
+## Is the Pride flag just a symbol?
+
+Some argue that Pride flag-raising is just a symbol. For those who have faced discrimination, exclusion, or bullying because of their identity, however, the flag-raising carries a very concrete meaning. Official flag-raising tells residents that the municipality sees all of them, values them, and welcomes each person as they are. For many LGBTQ+ people, regardless of age, the flag can be a message that they are not alone.
+
+According to the School Health Survey by the Finnish Institute for Health and Welfare, one in seven secondary school students belonging to a sexual minority experiences school bullying at least once a week. The situation has also worsened in recent years. In such a climate, visible acts on behalf of equality matter especially. For a young person reflecting on their identity or feeling left out, the rainbow flag can be a message that they are not alone.
+
+## What concrete action is needed alongside the flag?
+
+Kirkkonummi's strategy emphasises [equality](/en/category/equality-and-non-discrimination/), non-discrimination, and youth-friendliness. Raising the Pride flag is a step toward making these values real in practice. Values, however, are not realised through symbols alone, which is why concrete action is needed alongside the flag-raising.
+
+Equality must also show in everyday encounters. Youth centres, schools, and student welfare services need enough expertise to identify and support the needs of LGBTQ+ youth, and to help young people experiencing loneliness, exclusion, or bullying. The autumn budget negotiations must assess whether current resources match this need.
+
+## Why is the municipal role highlighted right now?
+
+In public debate, the importance of equality and the standing of organisations that support minorities are currently being questioned more visibly than before. That is precisely why the role of municipalities in building a safe and welcoming atmosphere stands out. At the local level, we meet each other in everyday life — in schools, in youth centres, and in hobbies.
+
+The Finnish Municipal Act obliges the municipality to promote the well-being of its residents. That obligation does not end at the flagpole. Kirkkonummi has the chance to show that equality is more than a celebratory speech or a goal written into a strategy. Equality is concrete action that builds a safer [municipality](/en/category/kirkkonummi/) for all of us.
+
+The flag is now up. The next task is to make sure it does not remain a mere gesture, but that we do the work to make Kirkkonummi a safe and welcoming municipality for everyone.
+
+<ImageWithCaption
+    alt="Suvi Annala and Lauri Lavanti, Green local politicians in Kirkkonummi."
+    caption="Suvi Annala and Lauri Lavanti."
+    image="Suvi-Annala-ja-Lauri-Lavanti"
+/>

--- a/src/pages/en/blog/64/the-flag-is-up-what-does-kirkkonummi-do-next/index.mdx
+++ b/src/pages/en/blog/64/the-flag-is-up-what-does-kirkkonummi-do-next/index.mdx
@@ -14,7 +14,7 @@ externalPublications:
     url: 'https://www.kirkkonummensanomat.fi/lippu-nousi-salkoon-mita-kirkkonummi-tekee-seuraavaksi-6.175.86006.b5bd43d098'
 authors:
   - name: 'Suvi Annala'
-    role: 'deputy councillor (Greens), deputy member of the municipal board'
+    role: 'deputy councillor and deputy member of the municipal board'
   - lauri
 tags:
   - kirkkonummi

--- a/src/pages/fi/blog/64/lippu-nousi-salkoon-mita-kirkkonummi-tekee-seuraavaksi/index.mdx
+++ b/src/pages/fi/blog/64/lippu-nousi-salkoon-mita-kirkkonummi-tekee-seuraavaksi/index.mdx
@@ -1,0 +1,66 @@
+---
+layout: '../../../../../layouts/PostLayout.astro'
+id: 64
+slug: 'lippu-nousi-salkoon-mita-kirkkonummi-tekee-seuraavaksi'
+lang: 'fi'
+pageTitle: 'Pride-liputus: mitä Kirkkonummi tekee nyt?'
+title: 'Lippu nousi salkoon. Mitä Kirkko­nummi tekee seuraa­vaksi?'
+description: 'Kirkkonummi nosti sateenkaarilipun salkoon 22.6.2026. Liputus on tärkeä, mutta yhdenvertaisuus vaatii myös konkreettisia tekoja syksyn talousarviossa.'
+publishDate: '2026-07-01'
+updatedDate: '2026-07-01'
+externalPublications:
+  - date: '2026-06-23'
+    name: 'Kirkkonummen Sanomat'
+    url: 'https://www.kirkkonummensanomat.fi/lippu-nousi-salkoon-mita-kirkkonummi-tekee-seuraavaksi-6.175.86006.b5bd43d098'
+authors:
+  - name: 'Suvi Annala'
+    role: 'varavaltuutettu (vihr.), kunnanhallituksen varajäsen'
+  - lauri
+tags:
+  - kirkkonummi
+  - equality-and-non-discrimination
+heroImage: Sateenkaarilippuja-Kirkkonummen-kunnantalolla-2026
+alt: 'Sateenkaarilippu liehuu Kirkkonummen kunnantalon lipputangossa kesäkuussa 2026.'
+faq:
+  - q: 'Milloin Kirkkonummi nosti sateenkaarilipun salkoon ensimmäistä kertaa?'
+    a: 'Maanantaina 22.6.2026 Kirkkonummen kunnantalolla. Jatkossa lippu nostetaan vuosittain kahdesti, valtuuston maaliskuussa 2026 äänin 30–14 hyväksymän aloitteen mukaisesti.'
+  - q: 'Miksi pelkkä liputus ei riitä?'
+    a: 'Kuntalaki velvoittaa edistämään asukkaiden hyvinvointia, eikä velvoite pääty lippusalkoon. Yhdenvertaisuus toteutuu vasta arjen kohtaamisissa nuorisotiloissa, kouluissa ja oppilashuollossa. Syksyn 2026 talousarvioneuvotteluissa on arvioitava, vastaavatko resurssit tähän tarpeeseen.'
+  - q: 'Kuka teki alkuperäisen valtuustoaloitteen Pride-liputuksesta?'
+    a: 'Vihreä valtuustoryhmä Lauri Lavannin johdolla jätti aloitteen kesäkuussa 2025. Aloite hyväksyttiin valtuustossa maaliskuussa 2026 äänin 30–14.'
+---
+
+import SmartLink from '../../../../../components/SmartLink.astro'
+import H2 from '../../../../../components/H2.astro'
+import Paragraph from '../../../../../components/Paragraph.astro'
+import ImageWithCaption from '../../../../../components/body/ImageWithCaption.astro'
+
+export const components = { a: SmartLink, h2: H2, p: Paragraph }
+
+Maanantaina 22.6.2026 nousi sateenkaarilippu salkoon Kirkkonummen kunnantalolla ensimmäistä kertaa. Päätös syntyi maaliskuussa, kun valtuusto hyväksyi [aloitteen Pride-liputuksesta](/fi/blog/39/valtuustoaloite-vuosittainen-pride-liputus-kirkkonummelle/) äänin 30–14. Jatkossa lippu nostetaan salkoon vuosittain kahdesti.
+
+## Onko Pride-liputus pelkkä symboli?
+
+Jotkut väittävät, että Pride-liputus on vain symboli. Heille, jotka ovat kohdanneet syrjintää, ulkopuolisuutta tai kiusaamista oman identiteettinsä vuoksi, liputuksen merkitys on kuitenkin hyvin konkreettinen. Virallinen liputus kertoo, että kunta näkee kaikki asukkaansa, arvostaa heitä ja toivottaa jokaisen tervetulleeksi omana itsenään. Monelle sateenkaari-ihmiselle iästä riippumatta liputus voi olla viesti siitä, ettei ole yksin.
+
+Terveyden ja hyvinvoinnin laitoksen kouluterveyskyselyn mukaan joka seitsemäs seksuaalivähemmistöihin kuuluva yläkoululainen kokee koulukiusaamista vähintään kerran viikossa. Tilanne on lisäksi heikentynyt viime vuosina. Tällaisessa ilmapiirissä näkyvillä teoilla yhdenvertaisuuden puolesta on erityistä merkitystä. Nuorelle, joka pohtii omaa identiteettiään tai kokee jäävänsä ulkopuolelle, sateenkaarilippu voi olla viesti siitä, ettei hän ole yksin.
+
+## Mitä konkreettista liputuksen rinnalle tarvitaan?
+
+Kirkkonummen strategiassa korostuvat [yhdenvertaisuus](/fi/category/equality-and-non-discrimination/), syrjimättömyys ja nuorisoystävällisyys. Pride-liputus on askel kohti näiden arvojen toteutumista käytännössä. Arvot eivät kuitenkaan toteudu pelkillä symboleilla, siksi liputuksen rinnalle tarvitaan myös konkreettisia toimia.
+
+Yhdenvertaisuuden tulee näkyä myös arjen kohtaamisissa. Nuorisotiloissa, kouluissa ja oppilashuollossa on oltava riittävästi osaamista sateenkaarinuorten tarpeiden tunnistamiseen ja tukemiseen sekä niiden nuorten auttamiseen, jotka kokevat yksinäisyyttä, ulkopuolisuutta tai kiusaamista. Syksyn talousarvioneuvotteluissa on arvioitava, vastaavatko nykyiset resurssit tähän tarpeeseen.
+
+## Miksi kuntien rooli korostuu juuri nyt?
+
+Yhteiskunnallisessa keskustelussa yhdenvertaisuuden merkitystä ja vähemmistöjä tukevien toimijoiden asemaa kyseenalaistetaan tällä hetkellä aiempaa näkyvämmin. Juuri siksi kuntien rooli turvallisen ja hyväksyvän ilmapiirin rakentajina korostuu. Paikallisella tasolla kohtaamme toisemme arjessa, kouluissa, nuorisotiloissa ja harrastuksissa.
+
+Kuntalaki velvoittaa kuntaa edistämään asukkaidensa hyvinvointia. Tämä velvoite ei pääty lippusalkoon. Kirkkonummella on mahdollisuus näyttää, että yhdenvertaisuus on enemmän kuin juhlapuhe tai strategiaan kirjattu tavoite. Yhdenvertaisuus on konkreettisia tekoja, jotka rakentavat turvallisempaa [kuntaa](/fi/category/kirkkonummi/) meille kaikille.
+
+Lippu on nyt salossa. Seuraavaksi on huolehdittava siitä, että se ei jää pelkäksi eleeksi, vaan meidän on tehtävä töitä sen eteen, että Kirkkonummi on turvallinen ja hyväksyvä kunta kaikille.
+
+<ImageWithCaption
+    alt="Suvi Annala ja Lauri Lavanti, Kirkkonummen vihreät kuntapoliitikot."
+    caption="Suvi Annala ja Lauri Lavanti."
+    image="Suvi-Annala-ja-Lauri-Lavanti"
+/>

--- a/src/pages/fi/blog/64/lippu-nousi-salkoon-mita-kirkkonummi-tekee-seuraavaksi/index.mdx
+++ b/src/pages/fi/blog/64/lippu-nousi-salkoon-mita-kirkkonummi-tekee-seuraavaksi/index.mdx
@@ -14,7 +14,7 @@ externalPublications:
     url: 'https://www.kirkkonummensanomat.fi/lippu-nousi-salkoon-mita-kirkkonummi-tekee-seuraavaksi-6.175.86006.b5bd43d098'
 authors:
   - name: 'Suvi Annala'
-    role: 'varavaltuutettu (vihr.), kunnanhallituksen varajäsen'
+    role: 'varavaltuutettu ja kunnanhallituksen varajäsen'
   - lauri
 tags:
   - kirkkonummi

--- a/src/pages/sv/blog/64/flaggan-hissades-vad-gor-kyrkslatt-nasta/index.mdx
+++ b/src/pages/sv/blog/64/flaggan-hissades-vad-gor-kyrkslatt-nasta/index.mdx
@@ -14,7 +14,7 @@ externalPublications:
     url: 'https://www.kirkkonummensanomat.fi/flaggan-hissades-vad-gor-kyrkslatt-nasta-6.175.86005.af0b5dc9e4'
 authors:
   - name: 'Suvi Annala'
-    role: 'suppleant i kommunfullmäktige (gröna), suppleant i kommunstyrelsen'
+    role: 'suppleant i kommunfullmäktige och suppleant i kommunstyrelsen'
   - lauri
 tags:
   - kirkkonummi

--- a/src/pages/sv/blog/64/flaggan-hissades-vad-gor-kyrkslatt-nasta/index.mdx
+++ b/src/pages/sv/blog/64/flaggan-hissades-vad-gor-kyrkslatt-nasta/index.mdx
@@ -1,0 +1,66 @@
+---
+layout: '../../../../../layouts/PostLayout.astro'
+id: 64
+slug: 'flaggan-hissades-vad-gor-kyrkslatt-nasta'
+lang: 'sv'
+pageTitle: 'Prideflaggan — vad gör Kyrkslätt nu?'
+title: 'Flaggan hissades. Vad gör Kyrkslätt nästa?'
+description: 'Kyrkslätt hissade regnbågsflaggan första gången 22.6.2026. Flaggningen är viktig, men jämlikhet kräver också konkreta åtgärder i höstens budget.'
+publishDate: '2026-07-01'
+updatedDate: '2026-07-01'
+externalPublications:
+  - date: '2026-06-23'
+    name: 'Kirkkonummen Sanomat'
+    url: 'https://www.kirkkonummensanomat.fi/flaggan-hissades-vad-gor-kyrkslatt-nasta-6.175.86005.af0b5dc9e4'
+authors:
+  - name: 'Suvi Annala'
+    role: 'suppleant i kommunfullmäktige (gröna), suppleant i kommunstyrelsen'
+  - lauri
+tags:
+  - kirkkonummi
+  - equality-and-non-discrimination
+heroImage: Sateenkaarilippuja-Kirkkonummen-kunnantalolla-2026
+alt: 'Regnbågsflaggan vajar vid Kyrkslätts kommunhus i juni 2026.'
+faq:
+  - q: 'När hissade Kyrkslätt regnbågsflaggan första gången?'
+    a: 'Måndagen den 22 juni 2026 vid Kyrkslätts kommunhus. Framöver hissas flaggan två gånger om året enligt fullmäktiges beslut i mars 2026, som fattades med rösterna 30–14.'
+  - q: 'Varför räcker inte enbart flaggningen?'
+    a: 'Kommunallagen ålägger kommunen att främja invånarnas välbefinnande, och skyldigheten slutar inte vid flaggstången. Jämlikhet förverkligas först i vardagens möten på ungdomsgårdar, i skolor och inom elevvården. Under höstens budgetförhandlingar 2026 måste man bedöma om resurserna motsvarar behovet.'
+  - q: 'Vem lämnade den ursprungliga fullmäktigemotionen om prideflaggning?'
+    a: 'Den gröna fullmäktigegruppen under Lauri Lavantis ledning lämnade motionen i juni 2025. Fullmäktige godkände motionen i mars 2026 med rösterna 30–14.'
+---
+
+import SmartLink from '../../../../../components/SmartLink.astro'
+import H2 from '../../../../../components/H2.astro'
+import Paragraph from '../../../../../components/Paragraph.astro'
+import ImageWithCaption from '../../../../../components/body/ImageWithCaption.astro'
+
+export const components = { a: SmartLink, h2: H2, p: Paragraph }
+
+Måndagen den 22 juni 2026 hissades regnbågsflaggan för första gången vid Kyrkslätts kommunhus. Beslutet fattades i mars, då fullmäktige godkände [förslaget om att hissa prideflaggan](/sv/blog/39/fullmaktigemotion-arlig-pride-flaggning-i-kyrkslätt/) med rösterna 30–14. Framöver kommer flaggan att hissas två gånger om året.
+
+## Är prideflaggningen bara en symbol?
+
+Vissa hävdar att prideflaggningen bara är en symbol. För dem som har utsatts för diskriminering, utfrysning eller mobbning på grund av sin identitet har flaggningen dock en mycket konkret betydelse. Den officiella flaggningen visar att kommunen ser alla sina invånare, värdesätter dem och välkomnar var och en att vara sig själv. För många LHBTIQ-personer, oavsett ålder, kan flaggningen vara ett budskap om att de inte är ensamma.
+
+Enligt Enkäten Hälsa i skolan från Institutet för hälsa och välfärd upplever var sjunde elev i högstadiet som tillhör en sexuell minoritet mobbning i skolan minst en gång i veckan. Situationen har dessutom försämrats under de senaste åren. I en sådan atmosfär har synliga handlingar för jämlikhet särskild betydelse. För en ung person som funderar över sin egen identitet eller känner sig utanför kan regnbågsflaggan vara ett budskap om att hen inte är ensam.
+
+## Vilka konkreta åtgärder behövs vid sidan av flaggningen?
+
+I Kyrkslätts strategi betonas [jämlikhet](/sv/category/equality-and-non-discrimination/), icke-diskriminering och ungdomsvänlighet. Att hissa prideflaggan är ett steg mot att förverkliga dessa värden i praktiken. Värdena förverkligas dock inte enbart genom symboler. Därför behövs det även konkreta åtgärder vid sidan av flaggningen.
+
+Jämlikheten måste också synas i vardagens möten. På ungdomsgårdar, i skolor och inom elevvården måste det finnas tillräcklig kompetens för att kunna identifiera och stödja LHBTIQ-ungdomars behov samt hjälpa ungdomar som upplever ensamhet, utanförskap eller mobbning. Under höstens budgetförhandlingar måste man utvärdera om de nuvarande resurserna motsvarar detta behov.
+
+## Varför framhävs kommunernas roll just nu?
+
+I den samhälleliga debatten ifrågasätts för närvarande betydelsen av jämlikhet och rollen för de aktörer som stöder minoriteter på ett mer synligt sätt än tidigare. Just därför framhävs kommunernas roll som skapare av en trygg och accepterande atmosfär. På lokal nivå möter vi varandra i vardagen, i skolor, på ungdomsgårdar och i fritidsaktiviteter.
+
+Enligt kommunallagen är kommunen skyldig att främja sina invånares välbefinnande. Denna skyldighet slutar inte vid flaggstången. Kyrkslätt har möjlighet att visa att jämlikhet är mer än bara festtal eller ett mål som står skrivet i strategin. Jämlikhet handlar om konkreta åtgärder som bidrar till att skapa en tryggare [kommun](/sv/category/kirkkonummi/) för oss alla.
+
+Flaggan är nu hissad. Nu gäller det att se till att det inte bara blir en symbolisk gest, utan att vi arbetar för att Kyrkslätt ska vara en trygg och inkluderande kommun för alla.
+
+<ImageWithCaption
+    alt="Suvi Annala och Lauri Lavanti, gröna kommunalpolitiker i Kyrkslätt."
+    caption="Suvi Annala och Lauri Lavanti."
+    image="Suvi-Annala-ja-Lauri-Lavanti"
+/>

--- a/tests/e2e/blogEnPage.spec.ts-snapshots/Blog-Page-in-English-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/blogEnPage.spec.ts-snapshots/Blog-Page-in-English-should-match-aria-snapshot-1.aria.yml
@@ -101,6 +101,9 @@
               - listitem:
                 - link "National politics":
                   - /url: /en/category/national-politics/
+              - listitem:
+                - link "Marketgreen":
+                  - /url: /en/category/marketgreen/
           - paragraph: The vaihdavihreisiin.fi campaign invites liberals and social liberals to join the Finnish Greens — the party where you don't have to compromise on your values.
       - listitem:
         - article "Greens – The True Defenders of the Market Economy":
@@ -346,6 +349,22 @@
     - paragraph: "Kirkkonummi is a bilingual, coastal municipality growing fast at the edge of the Helsinki region. It has real assets — shoreline, nature, a mixed community — and real pressures: a revenue base that struggles to keep up with demand, and a rail corridor that matters enormously for how the whole region develops. Local politics here is not small politics."
     - list:
       - listitem:
+        - article "The flag is up. What does Kirkkonummi do next?":
+          - link /Rainbow flag flying at the Kirkkonummi municipal hall in June \d+\. The flag is up\. What does Kirkkonummi do next\?/:
+            - /url: /en/blog/64/the-flag-is-up-what-does-kirkkonummi-do-next/
+            - img /Rainbow flag flying at the Kirkkonummi municipal hall in June \d+\./
+            - heading "The flag is up. What does Kirkkonummi do next?" [level=2]
+          - complementary "Meta information for post \"The flag is up. What does Kirkkonummi do next?\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Kirkkonummi":
+                  - /url: /en/category/kirkkonummi/
+              - listitem:
+                - link "Equality & equity":
+                  - /url: /en/category/equality-and-non-discrimination/
+          - paragraph: /Kirkkonummi raised the Pride flag for the first time on \d+ June \d+\. The flag matters, but equality also demands concrete action in the autumn budget\./
+      - listitem:
         - article "I voted against Västra":
           - link "Three stacks of coins at different heights on a white background. The image illustrates municipal financial decision-making. I voted against Västra":
             - /url: /en/blog/58/i-voted-against-vastra/
@@ -380,22 +399,6 @@
                 - link "Nature":
                   - /url: /en/category/nature/
           - paragraph: Kirkkonummi acquired Lähteelä, a coastal area. One of the few places on Kirkkonummi's coast accessible without a private boat — now permanently open to all.
-      - listitem:
-        - 'article "Kirkkonummi tells everyone: you belong here"':
-          - 'link "Kirkkonummi Kirsikkapuisto park on a sunny summer day. Mostly lawn in view, apartment buildings in the background and some playground equipment in the foreground Kirkkonummi tells everyone: you belong here"':
-            - /url: /en/blog/55/kirkkonummi-tells-everyone-you-belong-here/
-            - img "Kirkkonummi Kirsikkapuisto park on a sunny summer day. Mostly lawn in view, apartment buildings in the background and some playground equipment in the foreground"
-            - 'heading "Kirkkonummi tells everyone: you belong here" [level=2]'
-          - 'complementary "Meta information for post \"Kirkkonummi tells everyone: you belong here\""':
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Equality & equity":
-                  - /url: /en/category/equality-and-non-discrimination/
-              - listitem:
-                - link "Kirkkonummi":
-                  - /url: /en/category/kirkkonummi/
-          - paragraph: /Bullying of rainbow youth is increasing\. Kirkkonummi voted \d+–\d+ for flag-flying — a small gesture with measurable effects on young people's wellbeing\./
     - link "All posts about Kirkkonummi →":
       - /url: /en/category/kirkkonummi/
     - link "All posts →":

--- a/tests/e2e/blogPage.spec.ts-snapshots/Blog-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/blogPage.spec.ts-snapshots/Blog-Page-should-match-aria-snapshot-1.aria.yml
@@ -101,6 +101,9 @@
               - listitem:
                 - link "Kansallinen politiikka":
                   - /url: /fi/category/national-politics/
+              - listitem:
+                - link "Markkinavihreä":
+                  - /url: /fi/category/marketgreen/
           - paragraph: Vaihdavihreisiin.fi-kampanja kutsuu liberaalit ja sosiaaliliberaalit Vihreisiin — puolueeseen, jossa arvoista ei tarvitse tinkiä.
       - listitem:
         - article "Vihreät – Markkinatalouden aito puolustaja":
@@ -346,6 +349,22 @@
     - paragraph: "Kirkkonummi on kaksikielinen, rannikolla sijaitseva kunta, joka kasvaa nopeasti Helsingin seudun reunalla. Sillä on todellisia vahvuuksia — rantaviiva, luonto, monimuotoinen yhteisö — ja todellisia paineita: tulopohja, jolla on vaikeuksia pysyä tarpeiden perässä, ja ratakäytävä, jolla on suuri merkitys koko seudun kehitykselle. Paikallispolitiikka täällä ei ole pientä politiikkaa."
     - list:
       - listitem:
+        - article "Lippu nousi salkoon. Mitä Kirkkonummi tekee seuraavaksi?":
+          - link /Sateenkaarilippu liehuu Kirkkonummen kunnantalon lipputangossa kesäkuussa \d+\. Lippu nousi salkoon\. Mitä Kirkkonummi tekee seuraavaksi\?/:
+            - /url: /fi/blog/64/lippu-nousi-salkoon-mita-kirkkonummi-tekee-seuraavaksi/
+            - img /Sateenkaarilippu liehuu Kirkkonummen kunnantalon lipputangossa kesäkuussa \d+\./
+            - heading "Lippu nousi salkoon. Mitä Kirkkonummi tekee seuraavaksi?" [level=2]
+          - complementary "Kirjoituksen \"Lippu nousi salkoon. Mitä Kirkkonummi tekee seuraavaksi?\" meta-tiedot":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Kirkkonummi":
+                  - /url: /fi/category/kirkkonummi/
+              - listitem:
+                - link "Tasa-arvo ja yhdenvertaisuus":
+                  - /url: /fi/category/equality-and-non-discrimination/
+          - paragraph: /Kirkkonummi nosti sateenkaarilipun salkoon \d+\.\d+\.\d+\. Liputus on tärkeä, mutta yhdenvertaisuus vaatii myös konkreettisia tekoja syksyn talousarviossa\./
+      - listitem:
         - article "Äänestin Västraa vastaan":
           - link "Kolme kolikkopinoa eri korkeuksilla valkoisella taustalla. Kuva havainnollistaa kunnan taloudellista päätöksentekoa. Äänestin Västraa vastaan":
             - /url: /fi/blog/58/aanestin-vastraa-vastaan/
@@ -380,22 +399,6 @@
                 - link "Luonto":
                   - /url: /fi/category/nature/
           - paragraph: Kirkkonummi osti Lähteelän rannikkokohteen. Se on yksi harvoista paikoista, jonne pääsee myös ilman omaa venettä — nyt se on pysyvästi kaikkien saavutettavissa.
-      - listitem:
-        - 'article "Kirkkonummi sanoo: sinä kuulut tänne"':
-          - 'link "Kirkkonummen Kirsikkapuisto aurinkoisena kesäpäivänä. Näköpiirissä pääasiassa nurmialuetta, taustalla kerrostaloja ja edustalla hieman leikkipuistoja Kirkkonummi sanoo: sinä kuulut tänne"':
-            - /url: /fi/blog/55/kirkkonummi-sanoo-sina-kuulut-tanne/
-            - img "Kirkkonummen Kirsikkapuisto aurinkoisena kesäpäivänä. Näköpiirissä pääasiassa nurmialuetta, taustalla kerrostaloja ja edustalla hieman leikkipuistoja"
-            - 'heading "Kirkkonummi sanoo: sinä kuulut tänne" [level=2]'
-          - 'complementary "Kirjoituksen \"Kirkkonummi sanoo: sinä kuulut tänne\" meta-tiedot"':
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Tasa-arvo ja yhdenvertaisuus":
-                  - /url: /fi/category/equality-and-non-discrimination/
-              - listitem:
-                - link "Kirkkonummi":
-                  - /url: /fi/category/kirkkonummi/
-          - paragraph: /Sateenkaarinuorten kiusaaminen kasvaa\. Kirkkonummi äänesti \d+–\d+ liputuksen puolesta — pieni ele, jolla on mitattavia vaikutuksia nuorten hyvinvointiin\./
     - link "Kaikki kirjoitukset aiheesta Kirkkonummi →":
       - /url: /fi/category/kirkkonummi/
     - link "Kaikki kirjoitukset →":

--- a/tests/e2e/blogPostPage.spec.ts-snapshots/Blog-Post-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/blogPostPage.spec.ts-snapshots/Blog-Post-Page-should-match-aria-snapshot-1.aria.yml
@@ -69,6 +69,9 @@
     - paragraph: Sosiaali- ja terveydenhuolto ei ole pelkkä menoerä, vaan sijoitus tulevaisuuteemme. Jokainen järkevästi käytetty euro soteen on askel kohti hyvinvoivaa väestöä. Soten kustannusten kasvua ei hillitä palveluita leikkaamalla, vaan oikeiden palveluiden tarjoamisella oikeaan aikaan.
     - paragraph: Tasapainotetaanko taloutta vai korjataanko hyvinvointiyhteiskunta?
     - paragraph:
+      - strong: /Päivitetty \d+\.\d+\.\d+\./
+      - text: /Sote-uudistus toteutui ja Länsi-Uudenmaan hyvinvointialue aloitti toimintansa tammikuussa \d+\. Ennaltaehkäiseviin palveluihin ei edelleenkään panosteta riittävästi — tekstin ydinargumentti on siksi yhtä ajankohtainen kuin kirjoitushetkellä\./
+    - paragraph:
       - text: "Olen kirjoittanut sote-uudistuksesta laajemmin:"
       - link "mitä tapahtuisi ilman terveyskeskusta":
         - /url: /fi/blog/9/mita-jos-terveyskeskusta-ei-olisikaan/
@@ -160,24 +163,18 @@
                   - /url: /fi/category/health-and-social-reform/
           - paragraph: Asetan itseni ehdolle aluevaaleihin. Tärkeintä on lähipalvelujen säilyminen, terveydenhuollon pitäminen julkisena ja hoitohenkilökunnan hyvinvointi.
       - listitem:
-        - article "Tekoäly auttaa palvelujen turvaamisessa, mutta se ei ole ilmaista":
-          - link "Lauri Lavanti seisoo kukkapaita päällään valkoisella taustalla. Tekoäly auttaa palvelujen turvaamisessa, mutta se ei ole ilmaista":
-            - /url: /fi/blog/60/tekoaly-auttaa-palvelujen-turvaamisessa-mutta-se-ei-ole-ilmaista/
-            - img "Lauri Lavanti seisoo kukkapaita päällään valkoisella taustalla."
-            - heading "Tekoäly auttaa palvelujen turvaamisessa, mutta se ei ole ilmaista" [level=2]
-          - complementary "Kirjoituksen \"Tekoäly auttaa palvelujen turvaamisessa, mutta se ei ole ilmaista\" meta-tiedot":
+        - article "Lippu nousi salkoon. Mitä Kirkkonummi tekee seuraavaksi?":
+          - link /Sateenkaarilippu liehuu Kirkkonummen kunnantalon lipputangossa kesäkuussa \d+\. Lippu nousi salkoon\. Mitä Kirkkonummi tekee seuraavaksi\?/:
+            - /url: /fi/blog/64/lippu-nousi-salkoon-mita-kirkkonummi-tekee-seuraavaksi/
+            - img /Sateenkaarilippu liehuu Kirkkonummen kunnantalon lipputangossa kesäkuussa \d+\./
+            - heading "Lippu nousi salkoon. Mitä Kirkkonummi tekee seuraavaksi?" [level=2]
+          - complementary "Kirjoituksen \"Lippu nousi salkoon. Mitä Kirkkonummi tekee seuraavaksi?\" meta-tiedot":
             - time: /\d+\.\d+\.\d+/
             - list:
-              - listitem:
-                - link "Tekoäly":
-                  - /url: /fi/category/artificial-intelligence/
               - listitem:
                 - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "Digitalisaatio":
-                  - /url: /fi/category/digitalisation/
-              - listitem:
-                - link "Sivistys":
-                  - /url: /fi/category/learning/
-          - paragraph: Konnevedellä tekoäly lyhensi käsittelyajan kahdesta kuukaudesta päiviin. Kirkkonummi on liian pieni yksin — mutta yhteistyöllä muutos on mahdollinen.
+                - link "Tasa-arvo ja yhdenvertaisuus":
+                  - /url: /fi/category/equality-and-non-discrimination/
+          - paragraph: /Kirkkonummi nosti sateenkaarilipun salkoon \d+\.\d+\.\d+\. Liputus on tärkeä, mutta yhdenvertaisuus vaatii myös konkreettisia tekoja syksyn talousarviossa\./

--- a/tests/e2e/blogSwePage.spec.ts-snapshots/Blog-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/blogSwePage.spec.ts-snapshots/Blog-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
@@ -101,6 +101,9 @@
               - listitem:
                 - link "Nationell politik":
                   - /url: /sv/category/national-politics/
+              - listitem:
+                - link "Marknadsgrön":
+                  - /url: /sv/category/marketgreen/
           - paragraph: Kampanjen vaihdavihreisiin.fi bjuder liberaler och socialliberaler att byta till De gröna — partiet där man inte behöver kompromissa med sina värderingar.
       - listitem:
         - article "De gröna – Marknadsekonomiets sanna försvarare":
@@ -346,6 +349,22 @@
     - paragraph: "Kyrkslätt är en tvåspråkig kustkommun som växer snabbt i kanten av Helsingforsregionen. Den har verkliga tillgångar — strandlinje, natur, en blandad gemenskap — och verkliga påfrestningar: en intäktsbas som har svårt att hålla jämna steg med behoven och ett järnvägskorridor som spelar stor roll för hur hela regionen utvecklas. Lokalpolitiken här är inte småpolitik."
     - list:
       - listitem:
+        - article "Flaggan hissades. Vad gör Kyrkslätt nästa?":
+          - link /Regnbågsflaggan vajar vid Kyrkslätts kommunhus i juni \d+\. Flaggan hissades\. Vad gör Kyrkslätt nästa\?/:
+            - /url: /sv/blog/64/flaggan-hissades-vad-gor-kyrkslatt-nasta/
+            - img /Regnbågsflaggan vajar vid Kyrkslätts kommunhus i juni \d+\./
+            - heading "Flaggan hissades. Vad gör Kyrkslätt nästa?" [level=2]
+          - complementary "Metainformation för inlägget \"Flaggan hissades. Vad gör Kyrkslätt nästa?\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Kyrkslätt":
+                  - /url: /sv/category/kirkkonummi/
+              - listitem:
+                - link "Jämlikhet":
+                  - /url: /sv/category/equality-and-non-discrimination/
+          - paragraph: /Kyrkslätt hissade regnbågsflaggan första gången \d+\.\d+\.\d+\. Flaggningen är viktig, men jämlikhet kräver också konkreta åtgärder i höstens budget\./
+      - listitem:
         - article "Jag röstade mot Västra":
           - link "Tre myntstaplar i olika höjder på vit bakgrund. Bilden illustrerar kommunalt ekonomiskt beslutsfattande. Jag röstade mot Västra":
             - /url: /sv/blog/58/jag-rostade-mot-vastra/
@@ -380,22 +399,6 @@
                 - link "Natur":
                   - /url: /sv/category/nature/
           - paragraph: Kyrksländ köpte Lähteelä som kustanläggning. En av få platser vid kusten dit man kan ta sig utan egen båt — nu permanent tillgängligt för alla invånare.
-      - listitem:
-        - 'article "Kyrkslätt till alla: du hör hemma här"':
-          - 'link "Kyrkslätt Kirsikkapuisto en solig sommardag. Nästan bara gräsmatta i blickfånget, i bakgrunden flervåningshus och i förgrunden lite lekplatsutrustning Kyrkslätt till alla: du hör hemma här"':
-            - /url: /sv/blog/55/kyrkslatt-till-alla-du-hor-hemma-har/
-            - img "Kyrkslätt Kirsikkapuisto en solig sommardag. Nästan bara gräsmatta i blickfånget, i bakgrunden flervåningshus och i förgrunden lite lekplatsutrustning"
-            - 'heading "Kyrkslätt till alla: du hör hemma här" [level=2]'
-          - 'complementary "Metainformation för inlägget \"Kyrkslätt till alla: du hör hemma här\""':
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Jämlikhet":
-                  - /url: /sv/category/equality-and-non-discrimination/
-              - listitem:
-                - link "Kyrkslätt":
-                  - /url: /sv/category/kirkkonummi/
-          - paragraph: /Mobbning av regnbågsungdomar ökar\. Kyrkslätt röstade \d+–\d+ för flaggning — en liten gest med mätbara effekter på ungas välmående\./
     - link "Alla inlägg om Kyrkslätt →":
       - /url: /sv/category/kirkkonummi/
     - link "Alla inlägg →":

--- a/tests/e2e/homeEnPage.spec.ts-snapshots/Home-Page-in-English-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/homeEnPage.spec.ts-snapshots/Home-Page-in-English-should-match-aria-snapshot-1.aria.yml
@@ -18,6 +18,22 @@
         - /url: /en/privacy-policy/
     - list:
       - listitem:
+        - article "The flag is up. What does Kirkkonummi do next?":
+          - link /Rainbow flag flying at the Kirkkonummi municipal hall in June \d+\. The flag is up\. What does Kirkkonummi do next\?/:
+            - /url: /en/blog/64/the-flag-is-up-what-does-kirkkonummi-do-next/
+            - img /Rainbow flag flying at the Kirkkonummi municipal hall in June \d+\./
+            - heading "The flag is up. What does Kirkkonummi do next?" [level=2]
+          - complementary "Meta information for post \"The flag is up. What does Kirkkonummi do next?\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Kirkkonummi":
+                  - /url: /en/category/kirkkonummi/
+              - listitem:
+                - link "Equality & equity":
+                  - /url: /en/category/equality-and-non-discrimination/
+          - paragraph: /Kirkkonummi raised the Pride flag for the first time on \d+ June \d+\. The flag matters, but equality also demands concrete action in the autumn budget\./
+      - listitem:
         - article "How does it feel to be in a party where you don't have to compromise on your values?":
           - 'link "Market Greens'' invitation: Liberal, welcome home — image from the vaihdavihreisiin.fi campaign How does it feel to be in a party where you don''t have to compromise on your values?"':
             - /url: /en/blog/63/switch-to-greens-campaign/
@@ -38,6 +54,9 @@
               - listitem:
                 - link "National politics":
                   - /url: /en/category/national-politics/
+              - listitem:
+                - link "Marketgreen":
+                  - /url: /en/category/marketgreen/
           - paragraph: The vaihdavihreisiin.fi campaign invites liberals and social liberals to join the Finnish Greens — the party where you don't have to compromise on your values.
       - listitem:
         - article "Greens – The True Defenders of the Market Economy":
@@ -159,21 +178,5 @@
                 - link "Economy":
                   - /url: /en/category/economy/
           - paragraph: AI does in two minutes what used to take a developer two weeks. The price of code is collapsing — but what will developers get paid for instead?
-      - listitem:
-        - article "Lähteelä — a gem on Kirkkonummi coast":
-          - link "Lauri Lavanti and Miisa Jeremejew, municipal councillors (Greens), Kirkkonummi Lähteelä — a gem on Kirkkonummi coast":
-            - /url: /en/blog/56/lahteela-a-gem-on-kirkkonummis-coast/
-            - img "Lauri Lavanti and Miisa Jeremejew, municipal councillors (Greens), Kirkkonummi"
-            - heading "Lähteelä — a gem on Kirkkonummi coast" [level=2]
-          - complementary "Meta information for post \"Lähteelä — a gem on Kirkkonummi coast\"":
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Kirkkonummi":
-                  - /url: /en/category/kirkkonummi/
-              - listitem:
-                - link "Nature":
-                  - /url: /en/category/nature/
-          - paragraph: Kirkkonummi acquired Lähteelä, a coastal area. One of the few places on Kirkkonummi's coast accessible without a private boat — now permanently open to all.
     - link "All posts →":
       - /url: /en/blog/all/

--- a/tests/e2e/homePage.spec.ts-snapshots/Home-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/homePage.spec.ts-snapshots/Home-Page-should-match-aria-snapshot-1.aria.yml
@@ -18,6 +18,22 @@
         - /url: /en/privacy-policy/
     - list:
       - listitem:
+        - article "The flag is up. What does Kirkkonummi do next?":
+          - link /Rainbow flag flying at the Kirkkonummi municipal hall in June \d+\. The flag is up\. What does Kirkkonummi do next\?/:
+            - /url: /en/blog/64/the-flag-is-up-what-does-kirkkonummi-do-next/
+            - img /Rainbow flag flying at the Kirkkonummi municipal hall in June \d+\./
+            - heading "The flag is up. What does Kirkkonummi do next?" [level=2]
+          - complementary "Meta information for post \"The flag is up. What does Kirkkonummi do next?\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Kirkkonummi":
+                  - /url: /en/category/kirkkonummi/
+              - listitem:
+                - link "Equality & equity":
+                  - /url: /en/category/equality-and-non-discrimination/
+          - paragraph: /Kirkkonummi raised the Pride flag for the first time on \d+ June \d+\. The flag matters, but equality also demands concrete action in the autumn budget\./
+      - listitem:
         - article "How does it feel to be in a party where you don't have to compromise on your values?":
           - 'link "Market Greens'' invitation: Liberal, welcome home — image from the vaihdavihreisiin.fi campaign How does it feel to be in a party where you don''t have to compromise on your values?"':
             - /url: /en/blog/63/switch-to-greens-campaign/
@@ -38,6 +54,9 @@
               - listitem:
                 - link "National politics":
                   - /url: /en/category/national-politics/
+              - listitem:
+                - link "Marketgreen":
+                  - /url: /en/category/marketgreen/
           - paragraph: The vaihdavihreisiin.fi campaign invites liberals and social liberals to join the Finnish Greens — the party where you don't have to compromise on your values.
       - listitem:
         - article "Greens – The True Defenders of the Market Economy":
@@ -159,21 +178,5 @@
                 - link "Economy":
                   - /url: /en/category/economy/
           - paragraph: AI does in two minutes what used to take a developer two weeks. The price of code is collapsing — but what will developers get paid for instead?
-      - listitem:
-        - article "Lähteelä — a gem on Kirkkonummi coast":
-          - link "Lauri Lavanti and Miisa Jeremejew, municipal councillors (Greens), Kirkkonummi Lähteelä — a gem on Kirkkonummi coast":
-            - /url: /en/blog/56/lahteela-a-gem-on-kirkkonummis-coast/
-            - img "Lauri Lavanti and Miisa Jeremejew, municipal councillors (Greens), Kirkkonummi"
-            - heading "Lähteelä — a gem on Kirkkonummi coast" [level=2]
-          - complementary "Meta information for post \"Lähteelä — a gem on Kirkkonummi coast\"":
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Kirkkonummi":
-                  - /url: /en/category/kirkkonummi/
-              - listitem:
-                - link "Nature":
-                  - /url: /en/category/nature/
-          - paragraph: Kirkkonummi acquired Lähteelä, a coastal area. One of the few places on Kirkkonummi's coast accessible without a private boat — now permanently open to all.
     - link "All posts →":
       - /url: /en/blog/all/

--- a/tests/e2e/homeSwePage.spec.ts-snapshots/Home-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/homeSwePage.spec.ts-snapshots/Home-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
@@ -19,6 +19,22 @@
       - text: .
     - list:
       - listitem:
+        - article "Flaggan hissades. Vad gör Kyrkslätt nästa?":
+          - link /Regnbågsflaggan vajar vid Kyrkslätts kommunhus i juni \d+\. Flaggan hissades\. Vad gör Kyrkslätt nästa\?/:
+            - /url: /sv/blog/64/flaggan-hissades-vad-gor-kyrkslatt-nasta/
+            - img /Regnbågsflaggan vajar vid Kyrkslätts kommunhus i juni \d+\./
+            - heading "Flaggan hissades. Vad gör Kyrkslätt nästa?" [level=2]
+          - complementary "Metainformation för inlägget \"Flaggan hissades. Vad gör Kyrkslätt nästa?\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Kyrkslätt":
+                  - /url: /sv/category/kirkkonummi/
+              - listitem:
+                - link "Jämlikhet":
+                  - /url: /sv/category/equality-and-non-discrimination/
+          - paragraph: /Kyrkslätt hissade regnbågsflaggan första gången \d+\.\d+\.\d+\. Flaggningen är viktig, men jämlikhet kräver också konkreta åtgärder i höstens budget\./
+      - listitem:
         - article "Hur känns det att vara i ett parti där man inte behöver kompromissa med sina värderingar?":
           - 'link "Marknadsgrönas inbjudan: Liberal, välkommen hem — bild från kampanjen vaihdavihreisiin.fi Hur känns det att vara i ett parti där man inte behöver kompromissa med sina värderingar?"':
             - /url: /sv/blog/63/byt-till-de-grona-kampanj/
@@ -39,6 +55,9 @@
               - listitem:
                 - link "Nationell politik":
                   - /url: /sv/category/national-politics/
+              - listitem:
+                - link "Marknadsgrön":
+                  - /url: /sv/category/marketgreen/
           - paragraph: Kampanjen vaihdavihreisiin.fi bjuder liberaler och socialliberaler att byta till De gröna — partiet där man inte behöver kompromissa med sina värderingar.
       - listitem:
         - article "De gröna – Marknadsekonomiets sanna försvarare":
@@ -160,21 +179,5 @@
                 - link "Ekonomi":
                   - /url: /sv/category/economy/
           - paragraph: AI gör på två minuter det som en utvecklare tidigare behövde två veckor på sig för. Priset på kod rasar — men vad ska utvecklare få betalt för i stället?
-      - listitem:
-        - article "Lähteelä — en gem vid Kyrksländets kust":
-          - link "Lauri Lavanti och Miisa Jeremejew, kommunfullmäktigeledamöter (gröna), Kyrksländ Lähteelä — en gem vid Kyrksländets kust":
-            - /url: /sv/blog/56/lahteela-en-gemma-vid-kyrkslaendets-kust/
-            - img "Lauri Lavanti och Miisa Jeremejew, kommunfullmäktigeledamöter (gröna), Kyrksländ"
-            - heading "Lähteelä — en gem vid Kyrksländets kust" [level=2]
-          - complementary "Metainformation för inlägget \"Lähteelä — en gem vid Kyrksländets kust\"":
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Kyrkslätt":
-                  - /url: /sv/category/kirkkonummi/
-              - listitem:
-                - link "Natur":
-                  - /url: /sv/category/nature/
-          - paragraph: Kyrksländ köpte Lähteelä som kustanläggning. En av få platser vid kusten dit man kan ta sig utan egen båt — nu permanent tillgängligt för alla invånare.
     - link "Alla inlägg →":
       - /url: /sv/blog/all/

--- a/tests/e2e/notFoundPage.spec.ts-snapshots/404-Not-Found-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/notFoundPage.spec.ts-snapshots/404-Not-Found-Page-should-match-aria-snapshot-1.aria.yml
@@ -3,6 +3,22 @@
   - article:
     - list:
       - listitem:
+        - article "Lippu nousi salkoon. Mitä Kirkkonummi tekee seuraavaksi?":
+          - link /Sateenkaarilippu liehuu Kirkkonummen kunnantalon lipputangossa kesäkuussa \d+\. Lippu nousi salkoon\. Mitä Kirkkonummi tekee seuraavaksi\?/:
+            - /url: /fi/blog/64/lippu-nousi-salkoon-mita-kirkkonummi-tekee-seuraavaksi/
+            - img /Sateenkaarilippu liehuu Kirkkonummen kunnantalon lipputangossa kesäkuussa \d+\./
+            - heading "Lippu nousi salkoon. Mitä Kirkkonummi tekee seuraavaksi?" [level=2]
+          - complementary "Kirjoituksen \"Lippu nousi salkoon. Mitä Kirkkonummi tekee seuraavaksi?\" meta-tiedot":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Kirkkonummi":
+                  - /url: /fi/category/kirkkonummi/
+              - listitem:
+                - link "Tasa-arvo ja yhdenvertaisuus":
+                  - /url: /fi/category/equality-and-non-discrimination/
+          - paragraph: /Kirkkonummi nosti sateenkaarilipun salkoon \d+\.\d+\.\d+\. Liputus on tärkeä, mutta yhdenvertaisuus vaatii myös konkreettisia tekoja syksyn talousarviossa\./
+      - listitem:
         - article "Miltä tuntuu olla puolueessa, jossa arvoista ei tarvitse tinkiä?":
           - 'link "Markkinavihreiden kutsu: Liberaali, tervetuloa kotiin — vaihdavihreisiin.fi-kampanjan kuva Miltä tuntuu olla puolueessa, jossa arvoista ei tarvitse tinkiä?"':
             - /url: /fi/blog/63/vaihdavihreisiin-kampanja/
@@ -23,6 +39,9 @@
               - listitem:
                 - link "Kansallinen politiikka":
                   - /url: /fi/category/national-politics/
+              - listitem:
+                - link "Markkinavihreä":
+                  - /url: /fi/category/marketgreen/
           - paragraph: Vaihdavihreisiin.fi-kampanja kutsuu liberaalit ja sosiaaliliberaalit Vihreisiin — puolueeseen, jossa arvoista ei tarvitse tinkiä.
       - listitem:
         - article "Vihreät – Markkinatalouden aito puolustaja":
@@ -144,19 +163,3 @@
                 - link "Talous":
                   - /url: /fi/category/economy/
           - paragraph: Tekoäly tekee kahdessa minuutissa sen, mihin kehittäjältä meni kaksi viikkoa. Koodin hinta romahtaa — mutta mistä kehittäjille sitten maksetaan?
-      - listitem:
-        - article "Lähteelä — yhteinen helmi Kirkkonummen rannikolla":
-          - link "Lauri Lavanti ja Miisa Jeremejew, kunnanvaltuutettuja (vihr.), Kirkkonummi Lähteelä — yhteinen helmi Kirkkonummen rannikolla":
-            - /url: /fi/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/
-            - img "Lauri Lavanti ja Miisa Jeremejew, kunnanvaltuutettuja (vihr.), Kirkkonummi"
-            - heading "Lähteelä — yhteinen helmi Kirkkonummen rannikolla" [level=2]
-          - complementary "Kirjoituksen \"Lähteelä — yhteinen helmi Kirkkonummen rannikolla\" meta-tiedot":
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Kirkkonummi":
-                  - /url: /fi/category/kirkkonummi/
-              - listitem:
-                - link "Luonto":
-                  - /url: /fi/category/nature/
-          - paragraph: Kirkkonummi osti Lähteelän rannikkokohteen. Se on yksi harvoista paikoista, jonne pääsee myös ilman omaa venettä — nyt se on pysyvästi kaikkien saavutettavissa.


### PR DESCRIPTION
> This PR containes AI-generated code. The author has reviewed and is responsible for all AI-generated content.

## Summary

- Republishes the 2026-06-23 Kirkkonummen Sanomat op-ed "Lippu nousi salkoon. Mitä Kirkkonummi tekee seuraavaksi?" — co-authored with Suvi Annala — as trilingual blog post **id 64**, publishing 2026-07-01.
- Argues that the 2026-06-22 Pride flag-raising at the Kirkkonummi municipal hall must be followed by concrete resourcing of youth work and anti-bullying support in the autumn 2026 budget round.
- Co-authorship + republication attribution handled exclusively via frontmatter (`authors` + `externalPublications`) — the Byline component renders both. No inline editor's note.
- Two new images uploaded to Cloudflare Images: `Sateenkaarilippuja-Kirkkonummen-kunnantalolla-2026` (hero) and `Suvi-Annala-ja-Lauri-Lavanti` (body, just above the byline).
- Three question-format H2s added per locale to satisfy the AEO check; verbatim op-ed prose is otherwise preserved (EN is a fresh translation).

## Test plan

- [ ] `npm run check` passes
- [ ] `npm run lint` passes
- [ ] `npm run check:freshness` clean
- [ ] `npm run dev` — load all three locales, verify hero + body image render, byline lists both authors, FAQ accordions work, related posts include 39 + 55
- [ ] `npm run build && npm run preview` — production build clean
- [ ] CI green (Playwright e2e + unit tests)