### PR TITLE
feat: pillar tag requirement for posts #43+

### DIFF
--- a/.claude/skills/review-content/SKILL.md
+++ b/.claude/skills/review-content/SKILL.md
@@ -57,7 +57,7 @@ Flag:
 - Map to segment (A/C/D/E) — is that the right primary target?
 - Any segment blockers triggered? (see write skill for blocker lists)
 - Any Tier 3 assumptions (IT/privacy as a voting issue stated as fact)?
-- Does post connect to AI/digitaalinen itsenäisyys — or is exception flagged?
+- Does post connect to AI/digitaalinen itsenäisyys? If not, does it include one of the pillar tags (`artificial-intelligence`, `digital-independence`, `economy`, `culture-and-education`, `freedom`)? Flag if neither.
 
 ---
 

--- a/.claude/skills/write/SKILL.md
+++ b/.claude/skills/write/SKILL.md
@@ -61,3 +61,12 @@ Hard don'ts: attack individuals/parties by name; AI utopia/dystopia ("mullistaa"
 - En-dashes (`–`): max two per piece; em-dashes (`—`) avoid
 - No structural colons as separators (EU:ssa OK)
 - Finnish only
+
+## Tag requirement
+
+Must include at least one pillar tag:
+- `artificial-intelligence`
+- `digital-independence`
+- `economy`
+- `culture-and-education`
+- `freedom`

--- a/scripts/checks/content.sh
+++ b/scripts/checks/content.sh
@@ -146,6 +146,24 @@ if is_blog_post; then
             fi
         done <<< "$post_tags"
     fi
+
+    # ── pillar tag requirement (posts #43+) ──────────────────────────────────
+    # Every post with id >= 43 must carry at least one pillar tag.
+    pillar_tags=("artificial-intelligence" "digital-independence" "economy" "culture-and-education" "freedom")
+    post_id="$(fm_field "$file" id)"
+    if [[ -n "$post_id" && "$post_id" -ge 43 ]] 2>/dev/null; then
+        has_pillar=0
+        while IFS= read -r tag; do
+            tag="$(echo "$tag" | xargs)"
+            for pt in "${pillar_tags[@]}"; do
+                if [[ "$tag" == "$pt" ]]; then has_pillar=1; break 2; fi
+            done
+        done <<< "$post_tags"
+        if [[ "$has_pillar" -eq 0 ]]; then
+            error "$file" "missing pillar tag (post #${post_id} ≥ 43) — add one of: artificial-intelligence, digital-independence, economy, culture-and-education, freedom"
+            failed=1
+        fi
+    fi
 fi
 
 exit "$failed"

--- a/scripts/checks/content.sh
+++ b/scripts/checks/content.sh
@@ -130,8 +130,8 @@ if is_blog_post; then
     post_tags="$(awk '
         /^---$/ { c++; if (c == 2) exit; next }
         c == 1 && /^tags:/ { in_tags = 1; next }
-        c == 1 && in_tags && /^  - / { gsub(/^  - /, ""); print }
-        c == 1 && in_tags && !/^  - / { in_tags = 0 }
+        c == 1 && in_tags && /^  - / { gsub(/^  - /, ""); print; next }
+        c == 1 && in_tags { in_tags = 0 }
     ' "$file")"
 
     if [[ -z "$post_tags" ]]; then

--- a/src/pages/en/blog/46/i-voted-for-the-western-rail-link/index.mdx
+++ b/src/pages/en/blog/46/i-voted-for-the-western-rail-link/index.mdx
@@ -12,6 +12,7 @@ tags:
   - infrastructure
   - kirkkonummi
   - west-railway
+  - economy
 heroImage: Havainnekuva-Veikkolan-asemasta
 alt: "A visualisation by Länsirata Oy of what the Veikkola railway station could look like. The image shows tracks, platforms and a pedestrian overpass. Taken from https://lansirata.sitowise.com/?link=Pysm6# on 8 December 2025."
 ---

--- a/src/pages/en/blog/50/the-west-railway-decision-revealed-problems-in-kirkkonummis-long-term-strategic-development/index.mdx
+++ b/src/pages/en/blog/50/the-west-railway-decision-revealed-problems-in-kirkkonummis-long-term-strategic-development/index.mdx
@@ -16,6 +16,7 @@ tags:
   - infrastructure
   - kirkkonummi
   - west-railway
+  - economy
 heroImage: 'Lauri-Lavanti-sitting-in-front-of-a-window'
 alt: 'Lauri Lavanti leaning against a tall table. He is wearing a black blazer and a blue-and-white floral-patterned shirt. There is a multicoloured pocket square in the blazer pocket. Windows in the background.'
 ---

--- a/src/pages/en/blog/52/kirkkonummi-is-more-equal-today-than-yesterday/index.mdx
+++ b/src/pages/en/blog/52/kirkkonummi-is-more-equal-today-than-yesterday/index.mdx
@@ -10,6 +10,7 @@ publishDate: '2026-03-10'
 updatedDate: '2026-03-10'
 tags:
   - equality-and-non-discrimination
+  - freedom
 heroImage: Kaksi-leijonaa
 alt: 'Two male lions on a savannah. One is sitting and roaring, the other is lying down.'
 ---

--- a/src/pages/en/blog/55/kirkkonummi-tells-everyone-you-belong-here/index.mdx
+++ b/src/pages/en/blog/55/kirkkonummi-tells-everyone-you-belong-here/index.mdx
@@ -17,6 +17,7 @@ externalPublications:
 tags:
   - equality-and-non-discrimination
   - kirkkonummi
+  - freedom
 heroImage: Kirsikkapuisto
 alt: 'Kirkkonummi Kirsikkapuisto park on a sunny summer day. Mostly lawn in view, apartment buildings in the background and some playground equipment in the foreground'
 faq:

--- a/src/pages/en/blog/56/lahteela-a-gem-on-kirkkonummis-coast/index.mdx
+++ b/src/pages/en/blog/56/lahteela-a-gem-on-kirkkonummis-coast/index.mdx
@@ -18,6 +18,7 @@ authors:
 tags:
   - kirkkonummi
   - nature
+  - freedom
 heroImage: Lauri-Lavanti-ja-Miisa-Jeremejew
 alt: 'Lauri Lavanti and Miisa Jeremejew, municipal councillors (Greens), Kirkkonummi'
 faq:

--- a/src/pages/en/blog/64/the-flag-is-up-what-does-kirkkonummi-do-next/index.mdx
+++ b/src/pages/en/blog/64/the-flag-is-up-what-does-kirkkonummi-do-next/index.mdx
@@ -19,6 +19,7 @@ authors:
 tags:
   - kirkkonummi
   - equality-and-non-discrimination
+  - freedom
 heroImage: Sateenkaarilippuja-Kirkkonummen-kunnantalolla-2026
 alt: 'Rainbow flag flying at the Kirkkonummi municipal hall in June 2026.'
 faq:

--- a/src/pages/fi/blog/46/aanestin-lansiradan-puolesta/index.mdx
+++ b/src/pages/fi/blog/46/aanestin-lansiradan-puolesta/index.mdx
@@ -12,6 +12,7 @@ tags:
   - infrastructure
   - kirkkonummi
   - west-railway
+  - economy
 heroImage: Havainnekuva-Veikkolan-asemasta
 alt: 'Länsirata Oyn havainnekuva siitä, millainen Veikkolan juna-asema voisi olla. Kuvassa näkyy raiteet, laiturit ja ylikulkukävelysilta. Otettu osoitteesta https://lansirata.sitowise.com/?link=Pysm6# 8.12.2025.'
 ---

--- a/src/pages/fi/blog/50/lansirata-paatos-nosti-esiin-ongelmia-kirkkonummen-pitkajanteisessa-strategisessa-kehittamisessa/index.mdx
+++ b/src/pages/fi/blog/50/lansirata-paatos-nosti-esiin-ongelmia-kirkkonummen-pitkajanteisessa-strategisessa-kehittamisessa/index.mdx
@@ -16,6 +16,7 @@ tags:
   - infrastructure
   - kirkkonummi
   - west-railway
+  - economy
 heroImage: Lauri-Lavanti-sitting-in-front-of-a-window
 alt: 'Lauri Lavanti nojaamassa korkeaan pöytään. Päällään hänellä on musta bleiseri ja sinivalkoinen kukkakuvioinen kauluspaita. Bleiserin taskussa on monivärinen taskuliina. Taustalla ikkunoita.'
 ---

--- a/src/pages/fi/blog/52/kirkkonummi-on-tanaan-tasa-arvoisempi-kuin-eilen/index.mdx
+++ b/src/pages/fi/blog/52/kirkkonummi-on-tanaan-tasa-arvoisempi-kuin-eilen/index.mdx
@@ -10,6 +10,7 @@ publishDate: '2026-03-10'
 updatedDate: '2026-03-10'
 tags:
   - equality-and-non-discrimination
+  - freedom
 heroImage: Kaksi-leijonaa
 alt: 'Kuvassa on kaksi urosleijonaa savannilla. Toinen istuu ja karjuu, toinen makaa.'
 ---

--- a/src/pages/fi/blog/55/kirkkonummi-sanoo-sina-kuulut-tanne/index.mdx
+++ b/src/pages/fi/blog/55/kirkkonummi-sanoo-sina-kuulut-tanne/index.mdx
@@ -17,6 +17,7 @@ externalPublications:
 tags:
   - equality-and-non-discrimination
   - kirkkonummi
+  - freedom
 heroImage: Kirsikkapuisto
 alt: 'Kirkkonummen Kirsikkapuisto aurinkoisena kesäpäivänä. Näköpiirissä pääasiassa nurmialuetta, taustalla kerrostaloja ja edustalla hieman leikkipuistoja'
 faq:

--- a/src/pages/fi/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/index.mdx
+++ b/src/pages/fi/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/index.mdx
@@ -18,6 +18,7 @@ authors:
 tags:
   - kirkkonummi
   - nature
+  - freedom
 heroImage: Lauri-Lavanti-ja-Miisa-Jeremejew
 alt: 'Lauri Lavanti ja Miisa Jeremejew, kunnanvaltuutettuja (vihr.), Kirkkonummi'
 faq:

--- a/src/pages/fi/blog/64/lippu-nousi-salkoon-mita-kirkkonummi-tekee-seuraavaksi/index.mdx
+++ b/src/pages/fi/blog/64/lippu-nousi-salkoon-mita-kirkkonummi-tekee-seuraavaksi/index.mdx
@@ -19,6 +19,7 @@ authors:
 tags:
   - kirkkonummi
   - equality-and-non-discrimination
+  - freedom
 heroImage: Sateenkaarilippuja-Kirkkonummen-kunnantalolla-2026
 alt: 'Sateenkaarilippu liehuu Kirkkonummen kunnantalon lipputangossa kesäkuussa 2026.'
 faq:

--- a/src/pages/sv/blog/46/jag-rostade-for-vasternabanan/index.mdx
+++ b/src/pages/sv/blog/46/jag-rostade-for-vasternabanan/index.mdx
@@ -12,6 +12,7 @@ tags:
   - infrastructure
   - kirkkonummi
   - west-railway
+  - economy
 heroImage: Havainnekuva-Veikkolan-asemasta
 alt: 'En visualisering av Länsirata Oy om hur Veikkola järnvägsstation skulle kunna se ut. Bilden visar spår, plattformar och en gångbro. Tagen från https://lansirata.sitowise.com/?link=Pysm6# den 8 december 2025.'
 ---

--- a/src/pages/sv/blog/50/vastbanan-beslutet-avslojat-problem-i-kyrkslatts-langsiktiga-strategiska-utveckling/index.mdx
+++ b/src/pages/sv/blog/50/vastbanan-beslutet-avslojat-problem-i-kyrkslatts-langsiktiga-strategiska-utveckling/index.mdx
@@ -16,6 +16,7 @@ tags:
   - infrastructure
   - kirkkonummi
   - west-railway
+  - economy
 heroImage: 'Lauri-Lavanti-sitting-in-front-of-a-window'
 alt: 'Lauri Lavanti lutar sig mot ett högt bord. Han bär en svart blazer och en blåvit blommönstrad skjorta. I blazerns ficka sitter en flerfärgad näsduk. Fönster i bakgrunden.'
 ---

--- a/src/pages/sv/blog/52/kyrsklatt-ar-mer-jamlikt-idag-an-det-var-igar/index.mdx
+++ b/src/pages/sv/blog/52/kyrsklatt-ar-mer-jamlikt-idag-an-det-var-igar/index.mdx
@@ -10,6 +10,7 @@ publishDate: '2026-03-10'
 updatedDate: '2026-03-10'
 tags:
   - equality-and-non-discrimination
+  - freedom
 heroImage: Kaksi-leijonaa
 alt: 'Två hanlejon på en savann. Den ena sitter och ryter, den andra ligger ner.'
 ---

--- a/src/pages/sv/blog/55/kyrkslatt-till-alla-du-hor-hemma-har/index.mdx
+++ b/src/pages/sv/blog/55/kyrkslatt-till-alla-du-hor-hemma-har/index.mdx
@@ -11,6 +11,7 @@ updatedDate: '2026-05-15'
 tags:
   - equality-and-non-discrimination
   - kirkkonummi
+  - freedom
 heroImage: Kirsikkapuisto
 alt: 'Kyrkslätt Kirsikkapuisto en solig sommardag. Nästan bara gräsmatta i blickfånget, i bakgrunden flervåningshus och i förgrunden lite lekplatsutrustning'
 faq:

--- a/src/pages/sv/blog/56/lahteela-en-gemma-vid-kyrkslaendets-kust/index.mdx
+++ b/src/pages/sv/blog/56/lahteela-en-gemma-vid-kyrkslaendets-kust/index.mdx
@@ -18,6 +18,7 @@ authors:
 tags:
   - kirkkonummi
   - nature
+  - freedom
 heroImage: Lauri-Lavanti-ja-Miisa-Jeremejew
 alt: 'Lauri Lavanti och Miisa Jeremejew, kommunfullmäktigeledamöter (gröna), Kyrksländ'
 faq:

--- a/src/pages/sv/blog/64/flaggan-hissades-vad-gor-kyrkslatt-nasta/index.mdx
+++ b/src/pages/sv/blog/64/flaggan-hissades-vad-gor-kyrkslatt-nasta/index.mdx
@@ -19,6 +19,7 @@ authors:
 tags:
   - kirkkonummi
   - equality-and-non-discrimination
+  - freedom
 heroImage: Sateenkaarilippuja-Kirkkonummen-kunnantalolla-2026
 alt: 'Regnbågsflaggan vajar vid Kyrkslätts kommunhus i juni 2026.'
 faq:

--- a/tests/e2e/blogEnPage.spec.ts-snapshots/Blog-Page-in-English-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/blogEnPage.spec.ts-snapshots/Blog-Page-in-English-should-match-aria-snapshot-1.aria.yml
@@ -224,65 +224,62 @@
     - paragraph: Securing freedom in the AI era means being honest about the trade-offs. Mass surveillance, expanding the use of biometric identifiers, and chat scanning are not neutral tools waiting to be used wisely. They reshape the relationship between citizens and the state. The job of parliament is to set limits before the tools are built — not to debate them after the fact.
     - list:
       - listitem:
-        - 'article "Chat control: parliament was right"':
-          - 'link "A Japanese-style screen behind which a room is visible in soft focus. Chat control: parliament was right"':
-            - /url: /en/blog/54/chat-control-parliament-was-right/
-            - img "A Japanese-style screen behind which a room is visible in soft focus."
-            - 'heading "Chat control: parliament was right" [level=2]'
-          - 'complementary "Meta information for post \"Chat control: parliament was right\""':
+        - article "The flag is up. What does Kirkkonummi do next?":
+          - link /Rainbow flag flying at the Kirkkonummi municipal hall in June \d+\. The flag is up\. What does Kirkkonummi do next\?/:
+            - /url: /en/blog/64/the-flag-is-up-what-does-kirkkonummi-do-next/
+            - img /Rainbow flag flying at the Kirkkonummi municipal hall in June \d+\./
+            - heading "The flag is up. What does Kirkkonummi do next?" [level=2]
+          - complementary "Meta information for post \"The flag is up. What does Kirkkonummi do next?\"":
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "Privacy":
-                  - /url: /en/category/privacy/
+                - link "Kirkkonummi":
+                  - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "Technology":
-                  - /url: /en/category/technology/
-              - listitem:
-                - link "Digitalisation":
-                  - /url: /en/category/digitalisation/
+                - link "Equality & equity":
+                  - /url: /en/category/equality-and-non-discrimination/
               - listitem:
                 - link "Freedom":
                   - /url: /en/category/freedom/
-          - paragraph: The European Parliament rejected the extension of the chat control law. The police statistics are real, but parliament was still right — here is why.
+          - paragraph: /Kirkkonummi raised the Pride flag for the first time on \d+ June \d+\. The flag matters, but equality also demands concrete action in the autumn budget\./
       - listitem:
-        - article "The use of biometric identifiers in passports must not be expanded":
-          - link "A photo of Atte Harjanne and Lauri Lavanti. Both are wearing a black jacket and shirt. The use of biometric identifiers in passports must not be expanded":
-            - /url: /en/blog/48/the-use-of-biometric-identifiers-in-passports-must-not-be-expanded/
-            - img "A photo of Atte Harjanne and Lauri Lavanti. Both are wearing a black jacket and shirt."
-            - heading "The use of biometric identifiers in passports must not be expanded" [level=2]
-          - complementary "Meta information for post \"The use of biometric identifiers in passports must not be expanded\"":
+        - article "Lähteelä — a gem on Kirkkonummi coast":
+          - link "Lauri Lavanti and Miisa Jeremejew, municipal councillors (Greens), Kirkkonummi Lähteelä — a gem on Kirkkonummi coast":
+            - /url: /en/blog/56/lahteela-a-gem-on-kirkkonummis-coast/
+            - img "Lauri Lavanti and Miisa Jeremejew, municipal councillors (Greens), Kirkkonummi"
+            - heading "Lähteelä — a gem on Kirkkonummi coast" [level=2]
+          - complementary "Meta information for post \"Lähteelä — a gem on Kirkkonummi coast\"":
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "Technology":
-                  - /url: /en/category/technology/
+                - link "Kirkkonummi":
+                  - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "Privacy":
-                  - /url: /en/category/privacy/
+                - link "Nature":
+                  - /url: /en/category/nature/
               - listitem:
                 - link "Freedom":
                   - /url: /en/category/freedom/
-          - paragraph: When fingerprints were added to passports, Finland created a national biometric register. Now the government wants to open it to police use.
+          - paragraph: Kirkkonummi acquired Lähteelä, a coastal area. One of the few places on Kirkkonummi's coast accessible without a private boat — now permanently open to all.
       - listitem:
-        - article "Fundamental rights must not be dismantled without justification":
-          - link "An image of the lights on the roof of a police car. Fundamental rights must not be dismantled without justification":
-            - /url: /en/blog/45/fundamental-rights-must-not-be-dismantled-without-justification/
-            - img "An image of the lights on the roof of a police car."
-            - heading "Fundamental rights must not be dismantled without justification" [level=2]
-          - complementary "Meta information for post \"Fundamental rights must not be dismantled without justification\"":
+        - 'article "Kirkkonummi tells everyone: you belong here"':
+          - 'link "Kirkkonummi Kirsikkapuisto park on a sunny summer day. Mostly lawn in view, apartment buildings in the background and some playground equipment in the foreground Kirkkonummi tells everyone: you belong here"':
+            - /url: /en/blog/55/kirkkonummi-tells-everyone-you-belong-here/
+            - img "Kirkkonummi Kirsikkapuisto park on a sunny summer day. Mostly lawn in view, apartment buildings in the background and some playground equipment in the foreground"
+            - 'heading "Kirkkonummi tells everyone: you belong here" [level=2]'
+          - 'complementary "Meta information for post \"Kirkkonummi tells everyone: you belong here\""':
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "Technology":
-                  - /url: /en/category/technology/
+                - link "Equality & equity":
+                  - /url: /en/category/equality-and-non-discrimination/
               - listitem:
-                - link "Privacy":
-                  - /url: /en/category/privacy/
+                - link "Kirkkonummi":
+                  - /url: /en/category/kirkkonummi/
               - listitem:
                 - link "Freedom":
                   - /url: /en/category/freedom/
-          - paragraph: The government plans to extend intelligence methods to fight crime without individual suspicion — a serious threat to fundamental rights.
+          - paragraph: /Bullying of rainbow youth is increasing\. Kirkkonummi voted \d+–\d+ for flag-flying — a small gesture with measurable effects on young people's wellbeing\./
     - link "All posts about Freedom →":
       - /url: /en/category/freedom/
     - heading "Digital independence" [level=2]
@@ -349,22 +346,6 @@
     - paragraph: "Kirkkonummi is a bilingual, coastal municipality growing fast at the edge of the Helsinki region. It has real assets — shoreline, nature, a mixed community — and real pressures: a revenue base that struggles to keep up with demand, and a rail corridor that matters enormously for how the whole region develops. Local politics here is not small politics."
     - list:
       - listitem:
-        - article "The flag is up. What does Kirkkonummi do next?":
-          - link /Rainbow flag flying at the Kirkkonummi municipal hall in June \d+\. The flag is up\. What does Kirkkonummi do next\?/:
-            - /url: /en/blog/64/the-flag-is-up-what-does-kirkkonummi-do-next/
-            - img /Rainbow flag flying at the Kirkkonummi municipal hall in June \d+\./
-            - heading "The flag is up. What does Kirkkonummi do next?" [level=2]
-          - complementary "Meta information for post \"The flag is up. What does Kirkkonummi do next?\"":
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Kirkkonummi":
-                  - /url: /en/category/kirkkonummi/
-              - listitem:
-                - link "Equality & equity":
-                  - /url: /en/category/equality-and-non-discrimination/
-          - paragraph: /Kirkkonummi raised the Pride flag for the first time on \d+ June \d+\. The flag matters, but equality also demands concrete action in the autumn budget\./
-      - listitem:
         - article "I voted against Västra":
           - link "Three stacks of coins at different heights on a white background. The image illustrates municipal financial decision-making. I voted against Västra":
             - /url: /en/blog/58/i-voted-against-vastra/
@@ -384,21 +365,43 @@
                   - /url: /en/category/western-uusimaa/
           - paragraph: "I voted against Kirkkonummi joining the Västra cooperation. The council decided otherwise. My case: the money belongs in education, not a locked-in agreement."
       - listitem:
-        - article "Lähteelä — a gem on Kirkkonummi coast":
-          - link "Lauri Lavanti and Miisa Jeremejew, municipal councillors (Greens), Kirkkonummi Lähteelä — a gem on Kirkkonummi coast":
-            - /url: /en/blog/56/lahteela-a-gem-on-kirkkonummis-coast/
-            - img "Lauri Lavanti and Miisa Jeremejew, municipal councillors (Greens), Kirkkonummi"
-            - heading "Lähteelä — a gem on Kirkkonummi coast" [level=2]
-          - complementary "Meta information for post \"Lähteelä — a gem on Kirkkonummi coast\"":
+        - article "The West Railway revealed problems in Kirkkonummi's governance":
+          - link "Lauri Lavanti leaning against a tall table. He is wearing a black blazer and a blue-and-white floral-patterned shirt. There is a multicoloured pocket square in the blazer pocket. Windows in the background. The West Railway revealed problems in Kirkkonummi's governance":
+            - /url: /en/blog/50/the-west-railway-decision-revealed-problems-in-kirkkonummis-long-term-strategic-development/
+            - img "Lauri Lavanti leaning against a tall table. He is wearing a black blazer and a blue-and-white floral-patterned shirt. There is a multicoloured pocket square in the blazer pocket. Windows in the background."
+            - heading "The West Railway revealed problems in Kirkkonummi's governance" [level=2]
+          - complementary "Meta information for post \"The West Railway revealed problems in Kirkkonummi's governance\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Infrastructure":
+                  - /url: /en/category/infrastructure/
+              - listitem:
+                - link "Kirkkonummi":
+                  - /url: /en/category/kirkkonummi/
+              - listitem:
+                - link "Western railway":
+                  - /url: /en/category/west-railway/
+              - listitem:
+                - link "Economy":
+                  - /url: /en/category/economy/
+          - paragraph: The West Railway decision revealed shortcomings in Kirkkonummi's strategic planning. The municipality risks bearing the costs without the benefits.
+      - listitem:
+        - article "Lyyra opens new possibilities for Kirkkonummi's future":
+          - link "An image of Kirkkonummi's new upper secondary school campus, the House of Culture Lyyra, still under construction. Lyyra opens new possibilities for Kirkkonummi's future":
+            - /url: /en/blog/49/lyyra-the-house-of-culture-opens-new-possibilities-and-points-the-way/
+            - img "An image of Kirkkonummi's new upper secondary school campus, the House of Culture Lyyra, still under construction."
+            - heading "Lyyra opens new possibilities for Kirkkonummi's future" [level=2]
+          - complementary "Meta information for post \"Lyyra opens new possibilities for Kirkkonummi's future\"":
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
                 - link "Kirkkonummi":
                   - /url: /en/category/kirkkonummi/
               - listitem:
-                - link "Nature":
-                  - /url: /en/category/nature/
-          - paragraph: Kirkkonummi acquired Lähteelä, a coastal area. One of the few places on Kirkkonummi's coast accessible without a private boat — now permanently open to all.
+                - link "Culture & education":
+                  - /url: /en/category/culture-and-education/
+          - paragraph: Kirkkonummi's renovation creates a culture cluster of Fyyri, Lyyra and Rovastinpuisto park. It sets conditions for growth for decades to come.
     - link "All posts about Kirkkonummi →":
       - /url: /en/category/kirkkonummi/
     - link "All posts →":

--- a/tests/e2e/blogPage.spec.ts-snapshots/Blog-Page-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/blogPage.spec.ts-snapshots/Blog-Page-should-match-aria-snapshot-1.aria.yml
@@ -224,65 +224,62 @@
     - paragraph: Vapauden varmaksi tekeminen tekoälyn aikana edellyttää rehellisyyttä kompromisseista. Massavalvonta, biometristen tunnisteiden käytön laajentaminen ja viestien automaattinen seulonta eivät ole neutraaleja työkaluja, joita vain odotetaan käytettävän viisaasti. Ne muotoilevat uudelleen kansalaisen ja valtion suhteen. Eduskunnan tehtävä on asettaa rajat ennen kuin työkalut on rakennettu — ei keskustella niistä jälkikäteen.
     - list:
       - listitem:
-        - 'article "Chat control: parlamentti toimi oikein"':
-          - 'link "Kuva japanilaistyylisestä sermistä, jonka takana näkyy sumeasti huone. Chat control: parlamentti toimi oikein"':
-            - /url: /fi/blog/54/chat-control-parlamentti-toimi-oikein/
-            - img "Kuva japanilaistyylisestä sermistä, jonka takana näkyy sumeasti huone."
-            - 'heading "Chat control: parlamentti toimi oikein" [level=2]'
-          - 'complementary "Kirjoituksen \"Chat control: parlamentti toimi oikein\" meta-tiedot"':
+        - article "Lippu nousi salkoon. Mitä Kirkkonummi tekee seuraavaksi?":
+          - link /Sateenkaarilippu liehuu Kirkkonummen kunnantalon lipputangossa kesäkuussa \d+\. Lippu nousi salkoon\. Mitä Kirkkonummi tekee seuraavaksi\?/:
+            - /url: /fi/blog/64/lippu-nousi-salkoon-mita-kirkkonummi-tekee-seuraavaksi/
+            - img /Sateenkaarilippu liehuu Kirkkonummen kunnantalon lipputangossa kesäkuussa \d+\./
+            - heading "Lippu nousi salkoon. Mitä Kirkkonummi tekee seuraavaksi?" [level=2]
+          - complementary "Kirjoituksen \"Lippu nousi salkoon. Mitä Kirkkonummi tekee seuraavaksi?\" meta-tiedot":
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "Yksityisyydensuoja":
-                  - /url: /fi/category/privacy/
+                - link "Kirkkonummi":
+                  - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "Teknologia":
-                  - /url: /fi/category/technology/
-              - listitem:
-                - link "Digitalisaatio":
-                  - /url: /fi/category/digitalisation/
+                - link "Tasa-arvo ja yhdenvertaisuus":
+                  - /url: /fi/category/equality-and-non-discrimination/
               - listitem:
                 - link "Vapaus":
                   - /url: /fi/category/freedom/
-          - paragraph: Chat control -lain jatkoaika kaatui Euroopan parlamentissa. KRP:n luvut ovat todellisia, mutta parlamentti toimi silti oikein — ja tässä syy, miksi.
+          - paragraph: /Kirkkonummi nosti sateenkaarilipun salkoon \d+\.\d+\.\d+\. Liputus on tärkeä, mutta yhdenvertaisuus vaatii myös konkreettisia tekoja syksyn talousarviossa\./
       - listitem:
-        - article "Passien biometristen tunnisteiden käyttöä ei pidä laajentaa":
-          - link "Kuva Atte Harjanteesta ja Lauri Lavannista. Kummallakin musta takki ja kauluspaita. Passien biometristen tunnisteiden käyttöä ei pidä laajentaa":
-            - /url: /fi/blog/48/passien-biometristen-tunnisteiden-kayttoa-ei-pida-laajentaa/
-            - img "Kuva Atte Harjanteesta ja Lauri Lavannista. Kummallakin musta takki ja kauluspaita."
-            - heading "Passien biometristen tunnisteiden käyttöä ei pidä laajentaa" [level=2]
-          - complementary "Kirjoituksen \"Passien biometristen tunnisteiden käyttöä ei pidä laajentaa\" meta-tiedot":
+        - article "Lähteelä — yhteinen helmi Kirkkonummen rannikolla":
+          - link "Lauri Lavanti ja Miisa Jeremejew, kunnanvaltuutettuja (vihr.), Kirkkonummi Lähteelä — yhteinen helmi Kirkkonummen rannikolla":
+            - /url: /fi/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/
+            - img "Lauri Lavanti ja Miisa Jeremejew, kunnanvaltuutettuja (vihr.), Kirkkonummi"
+            - heading "Lähteelä — yhteinen helmi Kirkkonummen rannikolla" [level=2]
+          - complementary "Kirjoituksen \"Lähteelä — yhteinen helmi Kirkkonummen rannikolla\" meta-tiedot":
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "Teknologia":
-                  - /url: /fi/category/technology/
+                - link "Kirkkonummi":
+                  - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "Yksityisyydensuoja":
-                  - /url: /fi/category/privacy/
+                - link "Luonto":
+                  - /url: /fi/category/nature/
               - listitem:
                 - link "Vapaus":
                   - /url: /fi/category/freedom/
-          - paragraph: Kun sormenjäljet tuotiin passeihin, Suomeen perustettiin kansallinen biometrinen rekisteri. Nyt hallitus haluaa avata sen poliisin käyttöön.
+          - paragraph: Kirkkonummi osti Lähteelän rannikkokohteen. Se on yksi harvoista paikoista, jonne pääsee myös ilman omaa venettä — nyt se on pysyvästi kaikkien saavutettavissa.
       - listitem:
-        - article "Perusoikeuksia ei pidä purkaa perusteettomasti":
-          - link "Kuva poliisiauton katolla olevista valoista Perusoikeuksia ei pidä purkaa perusteettomasti":
-            - /url: /fi/blog/45/perusoikeuksia-ei-pida-purkaa-perusteettomasti/
-            - img "Kuva poliisiauton katolla olevista valoista"
-            - heading "Perusoikeuksia ei pidä purkaa perusteettomasti" [level=2]
-          - complementary "Kirjoituksen \"Perusoikeuksia ei pidä purkaa perusteettomasti\" meta-tiedot":
+        - 'article "Kirkkonummi sanoo: sinä kuulut tänne"':
+          - 'link "Kirkkonummen Kirsikkapuisto aurinkoisena kesäpäivänä. Näköpiirissä pääasiassa nurmialuetta, taustalla kerrostaloja ja edustalla hieman leikkipuistoja Kirkkonummi sanoo: sinä kuulut tänne"':
+            - /url: /fi/blog/55/kirkkonummi-sanoo-sina-kuulut-tanne/
+            - img "Kirkkonummen Kirsikkapuisto aurinkoisena kesäpäivänä. Näköpiirissä pääasiassa nurmialuetta, taustalla kerrostaloja ja edustalla hieman leikkipuistoja"
+            - 'heading "Kirkkonummi sanoo: sinä kuulut tänne" [level=2]'
+          - 'complementary "Kirjoituksen \"Kirkkonummi sanoo: sinä kuulut tänne\" meta-tiedot"':
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "Teknologia":
-                  - /url: /fi/category/technology/
+                - link "Tasa-arvo ja yhdenvertaisuus":
+                  - /url: /fi/category/equality-and-non-discrimination/
               - listitem:
-                - link "Yksityisyydensuoja":
-                  - /url: /fi/category/privacy/
+                - link "Kirkkonummi":
+                  - /url: /fi/category/kirkkonummi/
               - listitem:
                 - link "Vapaus":
                   - /url: /fi/category/freedom/
-          - paragraph: Hallitus suunnittelee tiedustelulainsäädännön laajentamista rikollisuuden torjuntaan ilman yksilöityä epäilyä – tämä uhkaa perusoikeuksia vakavasti.
+          - paragraph: /Sateenkaarinuorten kiusaaminen kasvaa\. Kirkkonummi äänesti \d+–\d+ liputuksen puolesta — pieni ele, jolla on mitattavia vaikutuksia nuorten hyvinvointiin\./
     - link "Kaikki kirjoitukset aiheesta Vapaus →":
       - /url: /fi/category/freedom/
     - heading "Digitaalinen itsenäisyys" [level=2]
@@ -349,22 +346,6 @@
     - paragraph: "Kirkkonummi on kaksikielinen, rannikolla sijaitseva kunta, joka kasvaa nopeasti Helsingin seudun reunalla. Sillä on todellisia vahvuuksia — rantaviiva, luonto, monimuotoinen yhteisö — ja todellisia paineita: tulopohja, jolla on vaikeuksia pysyä tarpeiden perässä, ja ratakäytävä, jolla on suuri merkitys koko seudun kehitykselle. Paikallispolitiikka täällä ei ole pientä politiikkaa."
     - list:
       - listitem:
-        - article "Lippu nousi salkoon. Mitä Kirkkonummi tekee seuraavaksi?":
-          - link /Sateenkaarilippu liehuu Kirkkonummen kunnantalon lipputangossa kesäkuussa \d+\. Lippu nousi salkoon\. Mitä Kirkkonummi tekee seuraavaksi\?/:
-            - /url: /fi/blog/64/lippu-nousi-salkoon-mita-kirkkonummi-tekee-seuraavaksi/
-            - img /Sateenkaarilippu liehuu Kirkkonummen kunnantalon lipputangossa kesäkuussa \d+\./
-            - heading "Lippu nousi salkoon. Mitä Kirkkonummi tekee seuraavaksi?" [level=2]
-          - complementary "Kirjoituksen \"Lippu nousi salkoon. Mitä Kirkkonummi tekee seuraavaksi?\" meta-tiedot":
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Kirkkonummi":
-                  - /url: /fi/category/kirkkonummi/
-              - listitem:
-                - link "Tasa-arvo ja yhdenvertaisuus":
-                  - /url: /fi/category/equality-and-non-discrimination/
-          - paragraph: /Kirkkonummi nosti sateenkaarilipun salkoon \d+\.\d+\.\d+\. Liputus on tärkeä, mutta yhdenvertaisuus vaatii myös konkreettisia tekoja syksyn talousarviossa\./
-      - listitem:
         - article "Äänestin Västraa vastaan":
           - link "Kolme kolikkopinoa eri korkeuksilla valkoisella taustalla. Kuva havainnollistaa kunnan taloudellista päätöksentekoa. Äänestin Västraa vastaan":
             - /url: /fi/blog/58/aanestin-vastraa-vastaan/
@@ -384,21 +365,43 @@
                   - /url: /fi/category/western-uusimaa/
           - paragraph: "Äänestin Västra-rannikkoyhteistyötä vastaan. Valtuusto päätti liittyä. Perusteluni: rahat kuuluvat sivistyspalveluihin, ei sopimukseen josta ei pääse irti."
       - listitem:
-        - article "Lähteelä — yhteinen helmi Kirkkonummen rannikolla":
-          - link "Lauri Lavanti ja Miisa Jeremejew, kunnanvaltuutettuja (vihr.), Kirkkonummi Lähteelä — yhteinen helmi Kirkkonummen rannikolla":
-            - /url: /fi/blog/56/lahteela-yhteinen-helmi-kirkkonummen-rannikolla/
-            - img "Lauri Lavanti ja Miisa Jeremejew, kunnanvaltuutettuja (vihr.), Kirkkonummi"
-            - heading "Lähteelä — yhteinen helmi Kirkkonummen rannikolla" [level=2]
-          - complementary "Kirjoituksen \"Lähteelä — yhteinen helmi Kirkkonummen rannikolla\" meta-tiedot":
+        - article "Länsirata nosti esiin ongelmia Kirkkonummen päätöksenteossa":
+          - link "Lauri Lavanti nojaamassa korkeaan pöytään. Päällään hänellä on musta bleiseri ja sinivalkoinen kukkakuvioinen kauluspaita. Bleiserin taskussa on monivärinen taskuliina. Taustalla ikkunoita. Länsirata nosti esiin ongelmia Kirkkonummen päätöksenteossa":
+            - /url: /fi/blog/50/lansirata-paatos-nosti-esiin-ongelmia-kirkkonummen-pitkajanteisessa-strategisessa-kehittamisessa/
+            - img "Lauri Lavanti nojaamassa korkeaan pöytään. Päällään hänellä on musta bleiseri ja sinivalkoinen kukkakuvioinen kauluspaita. Bleiserin taskussa on monivärinen taskuliina. Taustalla ikkunoita."
+            - heading "Länsirata nosti esiin ongelmia Kirkkonummen päätöksenteossa" [level=2]
+          - complementary "Kirjoituksen \"Länsirata nosti esiin ongelmia Kirkkonummen päätöksenteossa\" meta-tiedot":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Infra":
+                  - /url: /fi/category/infrastructure/
+              - listitem:
+                - link "Kirkkonummi":
+                  - /url: /fi/category/kirkkonummi/
+              - listitem:
+                - link "Länsirata":
+                  - /url: /fi/category/west-railway/
+              - listitem:
+                - link "Talous":
+                  - /url: /fi/category/economy/
+          - paragraph: Länsirata-päätöstä tehdessä mitattiin päättäjien kykyä tehdä koko kunnalle strategisesti tärkeitä, tulevaisuuteen katsovia ratkaisuja.
+      - listitem:
+        - article "Sivistyksen talo Lyyra – mahdollisuuksia Kirkkonummelle":
+          - link "Kuva Kirkkonummen uudesta lukiokampuksesta, sivistyksen talo Lyyrasta, keskeneräisenä Sivistyksen talo Lyyra – mahdollisuuksia Kirkkonummelle":
+            - /url: /fi/blog/49/sivistyksen-talo-lyyra-avaa-uusia-mahdollisuuksia-ja-nayttaa-suuntaa/
+            - img "Kuva Kirkkonummen uudesta lukiokampuksesta, sivistyksen talo Lyyrasta, keskeneräisenä"
+            - heading "Sivistyksen talo Lyyra – mahdollisuuksia Kirkkonummelle" [level=2]
+          - complementary "Kirjoituksen \"Sivistyksen talo Lyyra – mahdollisuuksia Kirkkonummelle\" meta-tiedot":
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
                 - link "Kirkkonummi":
                   - /url: /fi/category/kirkkonummi/
               - listitem:
-                - link "Luonto":
-                  - /url: /fi/category/nature/
-          - paragraph: Kirkkonummi osti Lähteelän rannikkokohteen. Se on yksi harvoista paikoista, jonne pääsee myös ilman omaa venettä — nyt se on pysyvästi kaikkien saavutettavissa.
+                - link "Sivistys":
+                  - /url: /fi/category/culture-and-education/
+          - paragraph: Kirkkonummen keskustan remontti rakentaa Fyyrin, Lyyran ja Rovastinpuiston sivistyksen keskittymän. Se luo edellytyksiä kasvulle vuosikymmeniksi.
     - link "Kaikki kirjoitukset aiheesta Kirkkonummi →":
       - /url: /fi/category/kirkkonummi/
     - link "Kaikki kirjoitukset →":

--- a/tests/e2e/blogSwePage.spec.ts-snapshots/Blog-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
+++ b/tests/e2e/blogSwePage.spec.ts-snapshots/Blog-Page-på-svenska-should-match-aria-snapshot-1.aria.yml
@@ -224,65 +224,62 @@
     - paragraph: Att trygga friheten i AI-eran kräver ärlighet om avvägningarna. Massövervakning, utvidgad användning av biometriska identifierare och automatisk meddelandekontroll är inte neutrala verktyg som väntar på att användas klokt. De omformar förhållandet mellan medborgare och stat. Riksdagens uppgift är att sätta gränserna innan verktygen byggs — inte debattera dem i efterhand.
     - list:
       - listitem:
-        - 'article "Chat control: parlamentet handlade rätt"':
-          - 'link "Bild på en japansk skärm bakom vilken ett rum skymtar suddigt. Chat control: parlamentet handlade rätt"':
-            - /url: /sv/blog/54/chat-control-parlamentet-handlade-ratt/
-            - img "Bild på en japansk skärm bakom vilken ett rum skymtar suddigt."
-            - 'heading "Chat control: parlamentet handlade rätt" [level=2]'
-          - 'complementary "Metainformation för inlägget \"Chat control: parlamentet handlade rätt\""':
+        - article "Flaggan hissades. Vad gör Kyrkslätt nästa?":
+          - link /Regnbågsflaggan vajar vid Kyrkslätts kommunhus i juni \d+\. Flaggan hissades\. Vad gör Kyrkslätt nästa\?/:
+            - /url: /sv/blog/64/flaggan-hissades-vad-gor-kyrkslatt-nasta/
+            - img /Regnbågsflaggan vajar vid Kyrkslätts kommunhus i juni \d+\./
+            - heading "Flaggan hissades. Vad gör Kyrkslätt nästa?" [level=2]
+          - complementary "Metainformation för inlägget \"Flaggan hissades. Vad gör Kyrkslätt nästa?\"":
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "Integritetsskydd":
-                  - /url: /sv/category/privacy/
+                - link "Kyrkslätt":
+                  - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "Teknologi":
-                  - /url: /sv/category/technology/
-              - listitem:
-                - link "Digitalisering":
-                  - /url: /sv/category/digitalisation/
+                - link "Jämlikhet":
+                  - /url: /sv/category/equality-and-non-discrimination/
               - listitem:
                 - link "Frihet":
                   - /url: /sv/category/freedom/
-          - paragraph: Chat control-lagens förlängning röstades ned i Europaparlamentet. KRP:s siffror är verkliga, men parlamentet handlade ändå rätt — och här är skälet.
+          - paragraph: /Kyrkslätt hissade regnbågsflaggan första gången \d+\.\d+\.\d+\. Flaggningen är viktig, men jämlikhet kräver också konkreta åtgärder i höstens budget\./
       - listitem:
-        - article "Användningen av biometriska identifierare i pass får inte utvidgas":
-          - link "Ett foto av Atte Harjanne och Lauri Lavanti. Båda bär svart jacka och skjorta. Användningen av biometriska identifierare i pass får inte utvidgas":
-            - /url: /sv/blog/48/anvandningen-av-biometriska-identifierare-i-pass-far-inte-utvidgas/
-            - img "Ett foto av Atte Harjanne och Lauri Lavanti. Båda bär svart jacka och skjorta."
-            - heading "Användningen av biometriska identifierare i pass får inte utvidgas" [level=2]
-          - complementary "Metainformation för inlägget \"Användningen av biometriska identifierare i pass får inte utvidgas\"":
+        - article "Lähteelä — en gem vid Kyrksländets kust":
+          - link "Lauri Lavanti och Miisa Jeremejew, kommunfullmäktigeledamöter (gröna), Kyrksländ Lähteelä — en gem vid Kyrksländets kust":
+            - /url: /sv/blog/56/lahteela-en-gemma-vid-kyrkslaendets-kust/
+            - img "Lauri Lavanti och Miisa Jeremejew, kommunfullmäktigeledamöter (gröna), Kyrksländ"
+            - heading "Lähteelä — en gem vid Kyrksländets kust" [level=2]
+          - complementary "Metainformation för inlägget \"Lähteelä — en gem vid Kyrksländets kust\"":
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "Teknologi":
-                  - /url: /sv/category/technology/
+                - link "Kyrkslätt":
+                  - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "Integritetsskydd":
-                  - /url: /sv/category/privacy/
+                - link "Natur":
+                  - /url: /sv/category/nature/
               - listitem:
                 - link "Frihet":
                   - /url: /sv/category/freedom/
-          - paragraph: När fingeravtryck infördes i pass skapades ett nationellt biometriskt register i Finland. Nu vill regeringen öppna det för polisens bruk.
+          - paragraph: Kyrksländ köpte Lähteelä som kustanläggning. En av få platser vid kusten dit man kan ta sig utan egen båt — nu permanent tillgängligt för alla invånare.
       - listitem:
-        - article "Grundläggande rättigheter får inte rivas utan grund":
-          - link "En bild av lamporna på taket av en polisbil. Grundläggande rättigheter får inte rivas utan grund":
-            - /url: /sv/blog/45/grundlaggande-rattigheter-far-inte-rivas-utan-grund/
-            - img "En bild av lamporna på taket av en polisbil."
-            - heading "Grundläggande rättigheter får inte rivas utan grund" [level=2]
-          - complementary "Metainformation för inlägget \"Grundläggande rättigheter får inte rivas utan grund\"":
+        - 'article "Kyrkslätt till alla: du hör hemma här"':
+          - 'link "Kyrkslätt Kirsikkapuisto en solig sommardag. Nästan bara gräsmatta i blickfånget, i bakgrunden flervåningshus och i förgrunden lite lekplatsutrustning Kyrkslätt till alla: du hör hemma här"':
+            - /url: /sv/blog/55/kyrkslatt-till-alla-du-hor-hemma-har/
+            - img "Kyrkslätt Kirsikkapuisto en solig sommardag. Nästan bara gräsmatta i blickfånget, i bakgrunden flervåningshus och i förgrunden lite lekplatsutrustning"
+            - 'heading "Kyrkslätt till alla: du hör hemma här" [level=2]'
+          - 'complementary "Metainformation för inlägget \"Kyrkslätt till alla: du hör hemma här\""':
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
-                - link "Teknologi":
-                  - /url: /sv/category/technology/
+                - link "Jämlikhet":
+                  - /url: /sv/category/equality-and-non-discrimination/
               - listitem:
-                - link "Integritetsskydd":
-                  - /url: /sv/category/privacy/
+                - link "Kyrkslätt":
+                  - /url: /sv/category/kirkkonummi/
               - listitem:
                 - link "Frihet":
                   - /url: /sv/category/freedom/
-          - paragraph: Regeringen planerar att utvidga underrättelselagstiftningens metoder mot brottslighet utan individuell misstanke — ett allvarligt hot mot grundrättigheter.
+          - paragraph: /Mobbning av regnbågsungdomar ökar\. Kyrkslätt röstade \d+–\d+ för flaggning — en liten gest med mätbara effekter på ungas välmående\./
     - link "Alla inlägg om Frihet →":
       - /url: /sv/category/freedom/
     - heading "Digital självständighet" [level=2]
@@ -349,22 +346,6 @@
     - paragraph: "Kyrkslätt är en tvåspråkig kustkommun som växer snabbt i kanten av Helsingforsregionen. Den har verkliga tillgångar — strandlinje, natur, en blandad gemenskap — och verkliga påfrestningar: en intäktsbas som har svårt att hålla jämna steg med behoven och ett järnvägskorridor som spelar stor roll för hur hela regionen utvecklas. Lokalpolitiken här är inte småpolitik."
     - list:
       - listitem:
-        - article "Flaggan hissades. Vad gör Kyrkslätt nästa?":
-          - link /Regnbågsflaggan vajar vid Kyrkslätts kommunhus i juni \d+\. Flaggan hissades\. Vad gör Kyrkslätt nästa\?/:
-            - /url: /sv/blog/64/flaggan-hissades-vad-gor-kyrkslatt-nasta/
-            - img /Regnbågsflaggan vajar vid Kyrkslätts kommunhus i juni \d+\./
-            - heading "Flaggan hissades. Vad gör Kyrkslätt nästa?" [level=2]
-          - complementary "Metainformation för inlägget \"Flaggan hissades. Vad gör Kyrkslätt nästa?\"":
-            - time: /\d+\.\d+\.\d+/
-            - list:
-              - listitem:
-                - link "Kyrkslätt":
-                  - /url: /sv/category/kirkkonummi/
-              - listitem:
-                - link "Jämlikhet":
-                  - /url: /sv/category/equality-and-non-discrimination/
-          - paragraph: /Kyrkslätt hissade regnbågsflaggan första gången \d+\.\d+\.\d+\. Flaggningen är viktig, men jämlikhet kräver också konkreta åtgärder i höstens budget\./
-      - listitem:
         - article "Jag röstade mot Västra":
           - link "Tre myntstaplar i olika höjder på vit bakgrund. Bilden illustrerar kommunalt ekonomiskt beslutsfattande. Jag röstade mot Västra":
             - /url: /sv/blog/58/jag-rostade-mot-vastra/
@@ -384,21 +365,43 @@
                   - /url: /sv/category/western-uusimaa/
           - paragraph: Jag röstade mot Västra kustsamarbetet. Fullmäktige beslutade annorlunda. Pengarna hör till bildningsservicen, inte ett avtal man inte kan lämna.
       - listitem:
-        - article "Lähteelä — en gem vid Kyrksländets kust":
-          - link "Lauri Lavanti och Miisa Jeremejew, kommunfullmäktigeledamöter (gröna), Kyrksländ Lähteelä — en gem vid Kyrksländets kust":
-            - /url: /sv/blog/56/lahteela-en-gemma-vid-kyrkslaendets-kust/
-            - img "Lauri Lavanti och Miisa Jeremejew, kommunfullmäktigeledamöter (gröna), Kyrksländ"
-            - heading "Lähteelä — en gem vid Kyrksländets kust" [level=2]
-          - complementary "Metainformation för inlägget \"Lähteelä — en gem vid Kyrksländets kust\"":
+        - article "Västbanan avslöjade problem i Kyrkslätts beslutsfattande":
+          - link "Lauri Lavanti lutar sig mot ett högt bord. Han bär en svart blazer och en blåvit blommönstrad skjorta. I blazerns ficka sitter en flerfärgad näsduk. Fönster i bakgrunden. Västbanan avslöjade problem i Kyrkslätts beslutsfattande":
+            - /url: /sv/blog/50/vastbanan-beslutet-avslojat-problem-i-kyrkslatts-langsiktiga-strategiska-utveckling/
+            - img "Lauri Lavanti lutar sig mot ett högt bord. Han bär en svart blazer och en blåvit blommönstrad skjorta. I blazerns ficka sitter en flerfärgad näsduk. Fönster i bakgrunden."
+            - heading "Västbanan avslöjade problem i Kyrkslätts beslutsfattande" [level=2]
+          - complementary "Metainformation för inlägget \"Västbanan avslöjade problem i Kyrkslätts beslutsfattande\"":
+            - time: /\d+\.\d+\.\d+/
+            - list:
+              - listitem:
+                - link "Infrastruktur":
+                  - /url: /sv/category/infrastructure/
+              - listitem:
+                - link "Kyrkslätt":
+                  - /url: /sv/category/kirkkonummi/
+              - listitem:
+                - link "Västbanan":
+                  - /url: /sv/category/west-railway/
+              - listitem:
+                - link "Ekonomi":
+                  - /url: /sv/category/economy/
+          - paragraph: Vid fattandet av Västbanans beslut mättes beslutsfattarnas förmåga att fatta strategiskt viktiga, framåtblickande beslut för hela kommunen.
+      - listitem:
+        - article "Lyyra öppnar nya möjligheter för Kyrkslättsborna":
+          - link "En bild av Kyrkslätts nya gymnasiekampus, bildningens hus Lyyra, under konstruktion. Lyyra öppnar nya möjligheter för Kyrkslättsborna":
+            - /url: /sv/blog/49/lyyra-bildningens-hus-oppnar-nya-mojligheter-och-visar-vagen/
+            - img "En bild av Kyrkslätts nya gymnasiekampus, bildningens hus Lyyra, under konstruktion."
+            - heading "Lyyra öppnar nya möjligheter för Kyrkslättsborna" [level=2]
+          - complementary "Metainformation för inlägget \"Lyyra öppnar nya möjligheter för Kyrkslättsborna\"":
             - time: /\d+\.\d+\.\d+/
             - list:
               - listitem:
                 - link "Kyrkslätt":
                   - /url: /sv/category/kirkkonummi/
               - listitem:
-                - link "Natur":
-                  - /url: /sv/category/nature/
-          - paragraph: Kyrksländ köpte Lähteelä som kustanläggning. En av få platser vid kusten dit man kan ta sig utan egen båt — nu permanent tillgängligt för alla invånare.
+                - link "Bildning":
+                  - /url: /sv/category/culture-and-education/
+          - paragraph: Renoveringen av Kyrkslätts centrum skapar ett bildningskluster av Fyyri, Lyyra och Provstparken. Det ger förutsättningar för tillväxt i decennier.
     - link "Alla inlägg om Kyrkslätt →":
       - /url: /sv/category/kirkkonummi/
     - link "Alla inlägg →":


### PR DESCRIPTION
> This PR containes AI-generated code. The author has reviewed and is responsible for all AI-generated content.

## Summary

- Adds `economy` or `freedom` pillar tag to the 6 posts (#43–#64) that were missing one (all three locales: fi/sv/en)
- Enforces the rule in `scripts/checks/content.sh` — posts with `id ≥ 43` without a pillar tag now block commit
- Updates the `/write` and `/review-content` skills to document the requirement

## Pillar tag mapping

| Finnish | Slug |
|---------|------|
| tekoäly | `artificial-intelligence` |
| digitaalinen itsenäisyys | `digital-independence` |
| talous | `economy` |
| sivistys | `culture-and-education` |
| vapaus | `freedom` |

## Posts changed

| # | Tag added |
|---|-----------|
| 46 | `economy` |
| 50 | `economy` |
| 52 | `freedom` |
| 55 | `freedom` |
| 56 | `freedom` |
| 64 | `freedom` |

## Test plan

- [ ] `npm run lint` passes on all 18 changed MDX files
- [ ] Create test post ≥43 without a pillar tag — confirm pre-commit blocks it
- [ ] `npm run test` passes
- [ ] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)